### PR TITLE
Need a clean(er) solution to Maruku/Redcarpet rendering problems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ we use Python because most of our volunteers speak it.
 *   Type `make check` to build everything in `_site` for testing.
     (Depending on your machine, this takes about 10-15 seconds.)
 
+We try to use the same MarkDown interpreters as GitHub does for
+consistency.  On OS X, we suggest you use a recent Ruby to get access
+to these.  If you don't have Homebrew or MacPorts installed, here's a
+quick recipe to get started using HomeBrew.
+
+```
+ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+brew install ruby
+gem install jekyll
+gem install redcarpet 
+```
+
 Blogging 
 --------
 


### PR DESCRIPTION
By default, GitHub uses Maruku for translating Markdown to HTML, but Maruku's error messages don't include line numbers, which makes it hard to track down rendering errors. We've switched to Redcarpet instead, but it doesn't work with the version of Ruby that's pre-installed on Mac OS X.  This means that Mac users must either go through a fairly involved process to get a newer version of Ruby, or skip previewing web site changes, blog posts, etc.  We need a solution that:
- Plays well out of the box with GitHub
- Doesn't require users to do horrific installs on Mac OS X (or Windows or Linux)
- Gives sensible error messages
