### PR TITLE
Badges do not import into Open Badges

### DIFF
--- a/badges/index.html
+++ b/badges/index.html
@@ -59,11 +59,11 @@ title: Badges
       var link = $(this).attr('href');
 
       // configure dialog
-      var assertionURL = "{{page.root}}/badges/"+kind+"/"+user+".json";
+      var assertionURL = "{{site.site}}/badges/"+kind+"/"+user+".json";
       $('#assertion-modal iframe').attr('src', assertionURL);
       $('#assertion-modal button[name=add]').click(function(e) {
         OpenBadges.issue([assertionURL]);});
-      $('#modal-badge-img').attr("src", "{{page.root}}/img/badges/"+kind+".png");
+      $('#modal-badge-img').attr("src", "{{site.site}}/img/badges/"+kind+".png");
       $('#assertion-modal div.modal-footer a').attr("href", link);
       $('#assertion-modal').modal('show');
       return false;


### PR DESCRIPTION
When you click on a name on the Badges page it opens an Badge Details screen that states that:

```
If this is your badge, you may add it to your Mozilla Backpack. 
```

If you click on the `Add badge to my Backpack` button and then the `Hooray` button an error message is returned:

```
We have encountered the following problem: malformed assertion, must be a url or signature
```
