### PR TITLE
Fix internal links in operations page

### DIFF
--- a/bootcamps/operations.html
+++ b/bootcamps/operations.html
@@ -456,7 +456,7 @@ title: How to Run a Bootcamp
     <h3>Gather your gear</h3>
   
     <p>
-      Collect the equipment listed in the <a href="#checklist">checklist</a>
+      Collect the equipment listed in the <a href="#checklists">checklist</a>
       at least a day before the start of the bootcamp.
     </p>
   
@@ -1304,7 +1304,7 @@ title: How to Run a Bootcamp
   
 </div>
 
-<div>
+<div id="faq">
   <h2>FAQ</h2>
 
   <dl class="faq">


### PR DESCRIPTION
Should be #checklists not #checklist in the
in the host instructions. The FAQs need an id=faq.
