### PR TITLE
Removing Facebook and Google+ buttons from the footer, but keeping links on contributing page.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,4 @@
 <div class="footer">
-  <a class="label swc-blue-bg" href="{{site.facebook_url}}">Facebook</a>
-  <a class="label swc-blue-bg" href="{{site.google_plus_url}}">Google+</a>
   <a class="label swc-blue-bg" href="{{site.twitter_url}}">Twitter</a>
   <a class="label swc-blue-bg" href="{{site.github_url}}">GitHub</a>
   <a class="label swc-blue-bg" href="{{site.rss_url}}">RSS</a>

--- a/contributing.html
+++ b/contributing.html
@@ -15,11 +15,23 @@ title: How to Contribute
   <h3 id="discuss">Discuss</h3>
 
   <p>
-    To stay up to date with us,
-    you can follow <a href="{{page.root}}/blog">our blog</a>
-    or sign up for our low-traffic announcement mailing list
-    (approximately 2-3 emails a month):
+    To stay up to date with what we're doing,
+    you can:
   </p>
+
+  <ul>
+    <li>
+      subsribe to <a href="{{page.root}}/blog">our blog</a>;
+    </li>
+    <li>
+      join us on <a href="{{facebook_url}}">Facebook</a>
+      or <a href="{{google_plus_url}}">Google+</a>;
+    </li>
+    <li>
+      or sign up for our low-traffic announcement mailing list
+      (approximately 2-3 emails a month):
+    </li>
+  </ul>
 
   <form class="form-inline" method="post" style="text-align:center" action="http://scripts.dreamhost.com/add_list.cgi">
     <fieldset>


### PR DESCRIPTION
Closes #70.
