### PR TITLE
Script for certificate generation.

### DIFF
--- a/bin/certificates.py
+++ b/bin/certificates.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+from __future__ import print_function
+
+import argparse
+import tempfile
+import subprocess
+import unicodedata
+import glob
+import os
+import shutil
+
+parser = argparse.ArgumentParser(description='Generate certificates.')
+parser.add_argument('--svg', required=True,
+                    help='Path to certificate SVG.')
+parser.add_argument('--csv',
+                    help='CSV file containing participant info.')
+
+args = parser.parse_args()
+
+if not args.csv:
+    certificate_data = [{'name': 'Joe Doe', 'date': 'September 2013'},
+                        {'name': 'Sarah Rowland', 'date': 'June 2012'},
+                        {'name': 'Stéfan', 'date': '--'}]
+
+basedir = os.path.join(os.path.dirname(__file__), './')
+svg = open(args.svg).read()
+
+tmp_dir = os.path.dirname(tempfile.NamedTemporaryFile().name)
+for badge in glob.glob(basedir + '../img/badges/*.png'):
+    shutil.copy(badge, tmp_dir)
+
+for n, certificate in enumerate(certificate_data):
+    this_svg = svg
+    for key, value in certificate.items():
+        this_svg = this_svg.replace('{{ %s }}' % key, value)
+
+    tmp = tempfile.NamedTemporaryFile(suffix='.svg')
+    tmp.write(this_svg)
+    tmp.flush()
+
+    filename = ('%03d_' % n) + certificate['name'].decode('utf-8') + '.pdf'
+    filename = unicodedata.normalize('NFKD', filename).encode('ascii', 'ignore')
+    filename = filename.replace(' ', '_')
+
+    RED = '\033[1;37m'
+    CLEAR = '\033[0m'
+    print(RED + 'Exporting certificate', filename, CLEAR)
+
+    subprocess.call(['inkscape',
+                     '--export-pdf', filename,
+                     tmp.name,
+                     '--export-dpi', '600'])
+

--- a/img/badges/certificate.svg
+++ b/img/badges/certificate.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="990"
+   height="765"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="New document 1">
+  <defs
+     id="defs4">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lend"
+       style="overflow:visible;">
+      <path
+         id="path3995"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1.0pt;"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7"
+     inkscape:cx="515.93746"
+     inkscape:cy="296.53633"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1600"
+     inkscape:window-height="845"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-287.36218)">
+    <text
+       xml:space="preserve"
+       style="font-size:55.60087585px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:TeX Gyre Chorus;-inkscape-font-specification:TeX Gyre Chorus Medium"
+       x="63.322842"
+       y="392.00638"
+       id="text2985"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan2987"
+         x="63.322842"
+         y="392.00638"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Source Code Pro;-inkscape-font-specification:Source Code Pro">Certificate of Achievement</tspan></text>
+    <image
+       y="439.14972"
+       x="361.26355"
+       id="image3211"
+       xlink:href="helper.png"
+       height="271.28287"
+       width="271.28287" />
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sawasdee;-inkscape-font-specification:Sawasdee"
+       x="582.65503"
+       y="477.64487"
+       id="text3214"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3216"
+         x="582.65503"
+         y="477.64487">needs high res version</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 777.02267,524.64413 c -7.42564,36.6793 -41.15675,75.92508 -120.20815,100.00511"
+       id="path3218"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:TeX Gyre Chorus;-inkscape-font-specification:TeX Gyre Chorus Medium"
+       x="115.71429"
+       y="556.42859"
+       id="text4432"
+       sodipodi:linespacing="125%"
+       transform="translate(0,287.36218)"><tspan
+         sodipodi:role="line"
+         id="tspan4434"
+         x="115.71429"
+         y="556.42859" /></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:droid sans;-inkscape-font-specification:droid sans"
+       x="81.428574"
+       y="746.64789"
+       id="text4436"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4438"
+         x="81.428574"
+         y="746.64789"
+         style="font-family:Source Code Pro;-inkscape-font-specification:Source Code Pro">This certificate has been awarded to </tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:droid sans;-inkscape-font-specification:droid sans"
+       x="513.99707"
+       y="802.36218"
+       id="text4440"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4442"
+         x="513.99707"
+         y="802.36218">{{ name }}</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:droid sans;-inkscape-font-specification:droid sans"
+       x="318.83234"
+       y="869.50507"
+       id="text4444"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4446"
+         x="318.83234"
+         y="869.50507"
+         style="font-family:source code pro;-inkscape-font-specification:source code pro">for so such and such</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;text-align:end;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:end;fill:#000000;fill-opacity:1;stroke:none;font-family:droid sans;-inkscape-font-specification:droid sans"
+       x="961.17883"
+       y="986.64789"
+       id="text4448"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4450"
+         x="961.17883"
+         y="986.64789">Date: {{ date }}</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
Simple proof of concept for certificate genereation.  Takes an SVG file, substitutes some values (name, date, etc.) then uses Inkscape to compile to PDF.

This PR does not load data from CSV, and the certificate looks like it was drawn by an untalented three-year-old.
