### PR TITLE
Replacing links on home page with buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,18 +38,18 @@ nocomments: true
 
 <div class="row-fluid">
   <div align="center" class="span6">
-    <a class="label swc-blue-bg" href="./sponsors.html">Sponsors</a>
+    <a class="label swc-blue-bg" title="Meet our sponsors" href="./sponsors.html">Sponsors</a>
     &nbsp;&nbsp;
-    <a class="label swc-blue-bg" href="./team.html">Team</a>
+    <a class="label swc-blue-bg" title="Meet our team" href="./team.html">Team</a>
     &nbsp;&nbsp;
-    <a class="label swc-blue-bg" href="./faq.html">FAQ</a>
+    <a class="label swc-blue-bg" title="Frequently Asked Questions" href="./faq.html">FAQ</a>
   </div>
   <div align="center" class="span6">
-    <a class="label swc-blue-bg" href="./contrib/training.html">Teach</a>
+    <a class="label swc-blue-bg" title="Learn how to become an instructor" href="./contrib/training.html">Teach</a>
     &nbsp;&nbsp;
-    <a class="label swc-blue-bg" href="./contrib/discuss.html">Discuss</a>
+    <a class="label swc-blue-bg" title="Chat about Software Carpentry" href="./contrib/discuss.html">Discuss</a>
     &nbsp;&nbsp;
-    <a class="label swc-blue-bg" href="./contrib/create.html">Make</a>
+    <a class="label swc-blue-bg" title="Help us create (and fix) things" href="./contrib/create.html">Make</a>
   </div>
 </div>
 


### PR DESCRIPTION
Turning the links below the explanatory paragraphs on the home page into white-on-blue buttons.
![screen shot 2013-09-13 at 8 44 08 pm](https://f.cloud.github.com/assets/911566/1142550/9aa5669a-1cd6-11e3-8b09-db5b2c2c634c.png)
