### PR TITLE
Adding prominent link on home page about running a bootcamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,12 @@ nocomments: true
 </div>
 
 <div class="row-fluid">
+  <div class="span12" align="center">
+    <h4><em>Please <u><a href="mailto:{{site.contact}}">mail us</a></u> about running a bootcamp where you are.</em></h4>
+  </div>
+</div>
+
+<div class="row-fluid">
   <div class="span6">
     <h4>Recent Blog Posts</h4>
     <table class="table table-striped">


### PR DESCRIPTION
Link is below the "who we are" and above the blog/bootcamp lists.
![screen shot 2013-09-14 at 2 31 22 pm](https://f.cloud.github.com/assets/911566/1144032/d2421522-1d6b-11e3-9e0f-4e996b977718.png)
