### PR TITLE
Improving Software Carpentry Google Map

### DIFF
--- a/_layouts/bootcamp_index.html
+++ b/_layouts/bootcamp_index.html
@@ -19,6 +19,15 @@
         return pin;
       }
 
+      function MarkerPinCluster(url,sizeX,sizeY) {
+      	var pin = new google.maps.MarkerImage(
+      	url,
+      	new google.maps.Size(sizeX,sizeY),
+      	new google.maps.Point(0,0),
+      	new google.maps.Point(10,34));
+      	return pin;
+      }
+
       function set_info_window(map, marker, info_window, content) {
         google.maps.event.addListener(marker, 'click', function () {
           info_window.setContent(content);
@@ -51,11 +60,11 @@
           mapTypeId: google.maps.MapTypeId.ROADMAP
         };
 
-        var pastPin = MarkerPin("{{site.colors.past}}");
         var openPin = MarkerPin("{{site.colors.open}}");
         var fullPin = MarkerPin("{{site.colors.full}}");
         var restrictedPin = MarkerPin("{{site.colors.restricted}}");
-        var instructorPin = MarkerPin("{{site.colors.instructor}}");
+        var instructorPin = MarkerPinCluster("http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/people35.png",34,34);
+        var pastPin = MarkerPinCluster("http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/m1.png",52,53);
 
         var pinShadow = new google.maps.MarkerImage(
             "http://chart.apis.google.com/chart?chst=d_map_pin_shadow",
@@ -130,19 +139,25 @@
         {% endfor %}
 
 		// Groups instructor_markers and past_markers into clusters
-		var instructor_mcOptions = {styles: [{
-url:'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/people35.png',
+		var instructor_mcOptions = {zoomOnClick: false, gridSize: 15, minimumClusterSize: 1, styles: [{
+		url: 'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/people35.png',
         height: 35,
         width: 35,
         anchor: [16, 0],
         textColor: '#ff00ff',
-        textSize: 10
+        textSize: 10,
       }]}
 
+      	var past_mcOptions = {zoomOnClick: false, maxZoom: 6, gridSize: 15, minimumClusterSize: 1, styles: [{
+      	url: 'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/m1.png',
+      	height: 52,
+      	width: 53,
+      	textColor: '#ffffff',
+      	textSize: 10,
+      	}]}
+
 		var instructor_markersCluster = new MarkerClusterer(null, instructor_markers,instructor_mcOptions);
-		instructor_markersCluster.setMaxZoom(6);
-		var past_markersCluster = new MarkerClusterer(null, past_markers);
-		past_markersCluster.setMaxZoom(6);
+		var past_markersCluster = new MarkerClusterer(null, past_markers,past_mcOptions);
 
         // This bit adds a button to the map that toggles the
         // visibility of past boot camps.


### PR DESCRIPTION
Greg raises several good points in the previous PR: https://github.com/swcarpentry/site/pull/166.
I thought I'd address them with a new PR.

**Currently Unresolved**
(i) How do I change the marker symbols on the bottom of the map? In <div id="map_canvas"...> the img src for past markers should be "http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/m1.png", for instructors "http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/images/people35.png"
In the screenshots below this is changed in _site/bootcamp/index.html only.
_The symbols on the bottom of the map are different in the screenshots_ (what they are supposed to be, but I need help on how to change them.)

**Resolved by this PR**
(ii) Individual instructor pins are all the "person" symbol now, even if there is only one.

**Resolved by this PR**
(iii) To do the great spread of instructors justice, I decreased the parameter gridSize to 15. This makes it also more impressive, yet organized.
![instructors_only](https://f.cloud.github.com/assets/2601674/1335610/98eb1bbc-35bb-11e3-8c5e-84e5d157922f.png)

**Resolved by this PR**
(iv) The default is that larger clusters get a different color, hence the orange circles. That was confusing, it has nothing to do with restricted boot camps. Past bootcamp markers are now always the blue circle.
![past_only](https://f.cloud.github.com/assets/2601674/1335637/e0abb02e-35bb-11e3-9bea-f7c82024058d.png)

**Resolved by this PR**
(v) To remain the clickability of past boot camps the clusters stop at maxZoom: 6. At this zoom the numbers disappear, but the symbol remains the blue circle.
![withclick](https://f.cloud.github.com/assets/2601674/1335644/0eb6d192-35bc-11e3-8151-a90714c37d1d.png)

If you're happy with (ii)-(v) and can help me with (i), I will update the PR. I suggest to not merge this before (i) was solved.
