### PR TITLE
Handling missing latlng in bootcamp entries

### DIFF
--- a/bin/get_bootcamp_info.py
+++ b/bin/get_bootcamp_info.py
@@ -54,7 +54,7 @@ def setup(args):
                       default=False, action='store_true')
     parser.add_option('-v', '--verbose', dest='verbose', help='report progress',
                       default=False, action='store_true')
-    options, args = parser.parse_args()
+    options, args = parser.parse_args(args)
 
     reader, writer = sys.stdin, sys.stdout
     if options.input != '-':
@@ -122,7 +122,7 @@ def check_info(url, info):
 def cleanup(entries):
     '''Sanitize entries (e.g., convert 'TBD' to none).'''
     for e in entries:
-        for k in CLEANUP.keys():
+        for k in CLEANUP:
             if k in e:
                 e[k] = CLEANUP[k](e[k])
 

--- a/bin/make_calendar.py
+++ b/bin/make_calendar.py
@@ -84,7 +84,7 @@ class ICalendarWriter(object):
             'URL:{0}'.format(url),
             'LOCATION:{0}'.format(self.escape(info['venue'])),
         ]
-        if info.get('latlng', None):
+        if info.get('latlng'):
             latlng = re.sub(r'\s+', '', info['latlng']).replace(',', ';')
             lines.append('GEO:{0}'.format(latlng))
         lines.append('END:VEVENT')


### PR DESCRIPTION
This pull request:
1. Checks that the 'latlng' entries in bootcamp index.html page metadata contains comma-separated pairs of numbers.
2. Replaces those that don't with nulls.
3. Only places pins for bootcamps with non-null latlng entries.
