### PR TITLE
Puts marker clusters behind bootcamp markers. Also: New bootcamp & instructor icons

### DIFF
--- a/_layouts/bootcamp_previous.html
+++ b/_layouts/bootcamp_previous.html
@@ -31,6 +31,9 @@
     </section>
         <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&amp;sensor=false"></script>
     <script type="text/javascript" src="http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/src/markerclusterer.js"></script>
+        <script type="text/javascript"
+        	src="http://jawj.github.io/OverlappingMarkerSpiderfier/bin/oms.min.js">
+    	</script>
     <script type="text/javascript" src="{{page.root}}/js/maps.js"></script>
     {% include footer.html %}
     {% include javascript.html %}

--- a/js/maps.js
+++ b/js/maps.js
@@ -67,12 +67,10 @@ SWC.maps = (function() {
           //icon: openPin,
           visible: true,
         });
-
         var info_string = '<div class="info-window">' +
           '<h5><a href="{% if bootcamp.url %}{{bootcamp.url}}{% else %}{{page.root}}/{{bootcamp.path}}{% endif %}">{{bootcamp.venue|replace: '\'','\\\''}}</a></h5>' +
           '<h6><a href="{{page.root}}/{{bootcamp.path}}">{{bootcamp.humandate}}</a></h6>' +
           '</div>';
-
             set_info_window(map, marker, info_window, info_string);
       {% endif %}
     {% endfor %}
@@ -86,8 +84,24 @@ SWC.maps = (function() {
     },
     info_window   = new google.maps.InfoWindow({}),
     map           = new google.maps.Map(document.getElementById('map_canvas'), mapOptions);
+    var markers = [];
+    var mcOptions = {
+          zoomOnClick: false,
+          maxZoom: 5,
+          gridSize: 25,
+          minimumClusterSize: 1
+        }
+    var oms = new OverlappingMarkerSpiderfier(map,{markersWontMove: true, markersWontHide: true, keepSpiderfied: true});
+	var iw = new google.maps.InfoWindow();
+	oms.addListener('click', function(marker, event) {
+		iw.setContent(marker.desc);
+		iw.open(map, marker);
+	});
+	oms.addListener('spiderfy', function(markers) {
+		iw.close();
+	});
 
-    // Go over all the upcoming camps and create pins in the map
+    // Go over all the previous camps and create pins in the map
     {% for bootcamp in site.bootcamps %}
       {% if bootcamp.latlng and bootcamp.startdate < site.today %}
         var marker = new google.maps.Marker({
@@ -97,15 +111,16 @@ SWC.maps = (function() {
           //icon: openPin,
           visible: true,
         });
-
         var info_string = '<div class="info-window">' +
           '<h5><a href="{% if bootcamp.url %}{{bootcamp.url}}{% else %}{{page.root}}/{{bootcamp.path}}{% endif %}">{{bootcamp.venue|replace: '\'','\\\''}}</a></h5>' +
           '<h6><a href="{{page.root}}/{{bootcamp.path}}">{{bootcamp.humandate}}</a></h6>' +
           '</div>';
-
-            set_info_window(map, marker, info_window, info_string);
+        set_info_window(map, marker, info_window, info_string);
+        markers.push(marker); // For clustering
+        oms.addMarker(marker); // For spiderfying
       {% endif %}
     {% endfor %}
+    var mc = new MarkerClusterer(map,markers,mcOptions);
   }
 
   return maps;


### PR DESCRIPTION
This is a follow-up on PR #170 and fixes two issues:

1) The symbols for past bootcamps and instructors are replaced by nicer ones.
2) It was raised that the markers (pins) of upcoming bootcamps are hidden by the added clusters.

![selection_013](https://f.cloud.github.com/assets/2601674/1376202/8c30edbe-3a90-11e3-85dc-3f1cf1f57fb7.png)

1) Now uses links to https://raw.github.com/gvwilson/site/change-icon-for-instructor-clusters/assets/icons/bootcamp.png and https://raw.github.com/gvwilson/site/change-icon-for-instructor-clusters/assets/icons/instructor.png
Maybe it would be better to move them to this repo.

2) To change this, I swapped two google maps layers so that the layer holding the clusters is below the layer holding the markers (see https://developers.google.com/maps/documentation/javascript/reference#MapPanes and https://developers.google.com/maps/documentation/javascript/examples/overlay-simple).
Unfortunately, as a downside this makes the Info Window not clickable (the layer of the Info Window is not high enough). In particular, info windows can not be closed by clicking on the "x". As a workaround I made it such that clicking on another marker opens the new info window, click on the same marker again closes the corresponding info window.
Another downside of swapping the overlay is that the markers are now no longer hidden by the info window. The clusters are, but not the markers:

![selection_012](https://f.cloud.github.com/assets/2601674/1376193/6e69d66a-3a90-11e3-926e-4958518921f0.png)

Please let me know about 1) and if the benefits of 2) outweigh its downsides.
