### PR TITLE
Removed URL for AZ bootcamp

### DIFF
--- a/config/bootcamp_urls.yml
+++ b/config/bootcamp_urls.yml
@@ -9,7 +9,6 @@
 - https://github.com/justincely/2013-10-25-columbia
 - https://github.com/chryswoods/2013-11-14-exeter
 - https://github.com/mikej888/2013-12-03-edinburgh
-- https://github.com/amyrbrown/2014-01-06-plantbreeding
 - https://github.com/adina/2014-01-08-iastate
 - https://github.com/arokem/2014-01-27-Stanford
 - https://github.com/damienirving/2013-11-25-unimelb


### PR DESCRIPTION
(because the bootcamp has been cancelled).
