### PR TITLE
code of conduct linked to file in current directory, not the site root

### DIFF
--- a/bootcamps/index.html
+++ b/bootcamps/index.html
@@ -28,7 +28,7 @@ title: Boot Camps
 
   <p>
     <em>
-      All boot camp participants are required to abide by our <a href="conduct.html">code of conduct</a>
+      All boot camp participants are required to abide by our <a href="{{page.root}}/conduct.html">code of conduct</a>
       to ensure that all attendees to have an enjoyable and fulfilling experience.
   </em>
   </p>


### PR DESCRIPTION
The "code of conduct" link on the bootcamp page 404`d as it linked to a file in the current directory, not the site root. The patch fixes this using what I think is the correct markup
