### PR TITLE
Add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Building
 Building the website requires: 
   - [Jekyll](http://jekyllrb.com/), used to compile templated HTML pages
   - [Python](http://python.org/), used for pre- and post-processing
-  - Python packages [pyyaml](https://pypi.python.org/pypi/PyYAML) and
-    [requests](https://pypi.python.org/pypi/requests), which can be installed
-    via ```pip install pyyaml requests``` 
+  - Some Python packages that can be installed using
+
+```
+$ pip -r requirements.txt
+```
 
 We use Jekyll because it's what [GitHub](http://github.com/) uses;
 we use Python because most of our volunteers speak it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML==3.10
+requests==2.0.1


### PR DESCRIPTION
This cover issue #218 since:
- `requirements.txt` are more findable,
- store the version of the packages that work properly and
- make easy to install the packages.
