### PR TITLE
Fixing Mozilla Science Lab logo in "About Us"

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -100,7 +100,7 @@ title: About Us
 
 <div class="row-fluid pagination-centered">
   <div class="span12">
-    <p><a href="http://mozillascience.org"><img src="{{page.root}}/img/mozilla-science-lab.svg" alt="Mozilla Science Lab logo" width="350px" /></a></p>
+    <p><a href="{{site.msl_url}}"><img src="{{page.root}}/img/mozilla-science-lab.png" alt="Mozilla Science Lab logo" width="350px" /></a></p>
     <p>Software Carpentry is a project of the <a href="http://mozillascience.org">Mozilla Science Lab</a></p>
   </div>
 </div>


### PR DESCRIPTION
The svg logo of Mozilla Science Lab use some special font that can
be unavailable in some machines and for that reason we should use
a png version of it.

Similar problem had been report in #250 and fix in #254 for home
page and now we fix it to "About Us".
