### PR TITLE
Remove `gem install redcarpet` from README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ quick recipe to get started using HomeBrew.
 ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
 brew install ruby
 gem install jekyll
-gem install redcarpet 
+gem install RedCloth
 ~~~
 
 Design Notes


### PR DESCRIPTION
The redcarpet gem is a dependency of jekyll, making this command
superfluous. See http://rubygems.org/gems/jekyll for details.
