### PR TITLE
Add Ruby dependency information via Gemfiles.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+# List of gems should always be consistent with those in README.md
+gem 'jekyll'
+gem 'RedCloth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RedCloth (4.2.9)
+    blankslate (2.1.2.4)
+    classifier (1.3.4)
+      fast-stemmer (>= 1.0.0)
+    colorator (0.1)
+    commander (4.1.5)
+      highline (~> 1.6.11)
+    fast-stemmer (1.0.2)
+    ffi (1.9.3)
+    highline (1.6.20)
+    jekyll (1.4.3)
+      classifier (~> 1.3)
+      colorator (~> 0.1)
+      commander (~> 4.1.3)
+      liquid (~> 2.5.5)
+      listen (~> 1.3)
+      maruku (~> 0.7.0)
+      pygments.rb (~> 0.5.0)
+      redcarpet (~> 2.3.0)
+      safe_yaml (~> 0.9.7)
+      toml (~> 0.1.0)
+    liquid (2.5.5)
+    listen (1.3.1)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      rb-kqueue (>= 0.2)
+    maruku (0.7.1)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
+    posix-spawn (0.3.8)
+    pygments.rb (0.5.4)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.3)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.0)
+      ffi (>= 0.5.0)
+    redcarpet (2.3.0)
+    safe_yaml (0.9.7)
+    toml (0.1.0)
+      parslet (~> 1.5.0)
+    yajl-ruby (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  RedCloth
+  jekyll


### PR DESCRIPTION
Add Gemfile and Gemfile.lock, both of which are used by Bundler (a
Ruby gem) to encode Ruby dependencies for projects.
- Gemfile.lock is machine-generated (but human-readable) and encodes
  the most specific Ruby dependency information.
- Gemfile is human-written, and typically encodes less specific Ruby
  dependency information. It is used by Bundler if Gemfile.lock does
  not exist. Rubyists recommend committing both files.

Addresses issue #322.
