### PR TITLE
Change URL of MIT boot camp; add ERDC boot camp

### DIFF
--- a/config/bootcamp_urls.yml
+++ b/config/bootcamp_urls.yml
@@ -22,10 +22,11 @@
 - https://github.com/apawlik/2014-01-14-manchester
 - https://github.com/swcarpentry/2014-01-18-ucb
 - https://github.com/gvwilson/2014-01-20-montreal
+- https://github.com/geocarpentry/2014-01-21-erdc
 - https://github.com/arokem/2014-01-27-Stanford
 - https://github.com/jennybc/2014-01-27-miami
 - https://github.com/uiuc-cse/2014-01-30-cse
-- https://github.com/rhiever/2014-01-30-mit
+- https://github.com/geocarpentry/2014-01-30-mit
 - https://github.com/swcarpentry/2014-01-31-ucsb
 - https://github.com/apawlik/2014-02-03-TGAC
 - https://github.com/damienirving/2014-02-10-hobart


### PR DESCRIPTION
We're not hosting the MIT boot camp repo on my account any more.
