### PR TITLE
Adding a page vm.html as a stable target for our virtual machine image

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,28 @@
+---
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    {% include header.html %}
+    <title>Software Carpentry: {{page.title}}</title>
+    <meta http-equiv="refresh" content="0; url={{site.vm_url}}" />
+  </head>
+  <body>
+    <header class="header">
+      {% include navbar.html %}
+    </header>
+    <section id="title" class="content">
+        <div class="container">
+          <h1>{{page.title}}</h1>
+        </div>
+    </section>
+    <section class="content">
+      <div class="container">
+        {{content}}
+      </div>
+    </section>
+    {% include footer.html %}
+    {% include javascript.html %}
+    {% include google-analytics.html %}
+  </body>
+</html>

--- a/config/standard_config.yml
+++ b/config/standard_config.yml
@@ -9,6 +9,7 @@ twitter_url     : "https://twitter.com/swcarpentry"
 irc_url         : "irc://freenode/swcarpentry"
 msl_url         : "http://mozillascience.org"
 store_url       : "http://www.cafepress.com/swcarpentry"
+vm_url          : "https://docs.google.com/uc?id=0B4Kr6DYkzkQtd05FekRId05DLXM&amp;export=download"
 recent_length   : 5
 upcoming_length : 10
 blog_title      : "Software Carpentry"

--- a/vm.html
+++ b/vm.html
@@ -1,0 +1,8 @@
+---
+layout: redirect
+root: .
+title: Virtual Machine Image
+---
+<p>
+  Redirecting to {{site.vm_url}}.
+</p>


### PR DESCRIPTION
This new page redirects to wherever the VM is actually located.

Note: I originally tried to create a generic page `_layouts/redirect.html`
that would redirect to `{{page.redirect}}`, and then set the key `redirect`
in the page `vm.html` like this:

```
redirect: {{site.vm_url}}
```

This doesn't work: Jekyll doesn't appear to expand variables in key/value
settings in the header of one page to pass into another.
