### PR TITLE
Emergency fix for badly-formatted dates.

### DIFF
--- a/bin/preprocess.py
+++ b/bin/preprocess.py
@@ -104,8 +104,15 @@ def main():
     # Get information from legacy boot camp pages and merge with cached info.
     config['bootcamps'] = harvest_bootcamps(options.site, cached_bootcamp_info)
 
-    # Select those that'll be displayed on the home page.
-    upcoming = [bc for bc in config['bootcamps'] if bc['startdate'] >= config['today']]
+    # Select those that'll be displayed on the home page.  Use a loop instead of
+    # a list comprehension to get better error reporting.
+    upcoming = []
+    for bc in config['bootcamps']:
+        try:
+            if bc['startdate'] >= config['today']:
+                upcoming.append(bc)
+        except TypeError, e:
+            print >> sys.stderr, 'Unable to process start date "{0}"'.format(bc['startdate'])
     config['bootcamps_upcoming'] = upcoming[:upcoming_length]
     config['bootcamps_num_upcoming'] = len(upcoming)
 

--- a/config/bootcamp_urls.yml
+++ b/config/bootcamp_urls.yml
@@ -1,4 +1,3 @@
-- https://github.com/geocarpentry/2014-01-21-erdc
 - https://github.com/arokem/2014-01-27-Stanford
 - https://github.com/jennybc/2014-01-27-miami
 - https://github.com/uiuc-cse/2014-01-30-cse

--- a/config/bootcamps_saved.yml
+++ b/config/bootcamps_saved.yml
@@ -1568,7 +1568,7 @@
   layout: bootcamp
   registration: open
   slug: 2013-11-14-whoi
-  startdate: 2013-11-14,
+  startdate: 2013-11-14
   url: http://swcarpentry.github.io/2013-11-14-whoi/
   user: swcarpentry
   venue: Woods Hole Scientific Community
@@ -2361,3 +2361,19 @@
   url: http://gvwilson.github.io/2014-01-20-montreal/
   user: gvwilson
   venue: CRIM (Montreal)
+- address: 3909 Halls Ferry Rd Vicksburg, MS 39180
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-01-22
+  humandate: January 21-22, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Randal Olson]
+  latlng: 32.301199,-90.871617
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-21-erdc
+  startdate: 2014-01-21
+  url: http://geocarpentry.github.io/2014-01-21-erdc/
+  user: geocarpentry
+  venue: US Army Engineer Research and Development Center


### PR DESCRIPTION
1.  Fixing badly-formatted date in bootcamp info.
2.  Turning list comprehension into explicit loop in pre-processor in order to get better error reporting.
