### PR TITLE
Removing `.htaccess` rewrite rule for badges pages

### DIFF
--- a/_htaccess
+++ b/_htaccess
@@ -66,13 +66,6 @@ RewriteCond %{REQUEST_URI} !.html$
 RewriteCond %{SCRIPT_FILENAME} !-f 
 RewriteRule ^(.*?)/?$ $1.html [R,L]
 
-# Links to badge kind pages
-# Keep redirecting this for now, so as to not break old badges
-# but also in case we want to make individual badge criteria pages later on.
-RewriteCond %{REQUEST_URI} ^/badges/(.*).html
-RewriteCond %{REQUEST_URI} !^/badges/index.html
-RewriteRule ^.*/(.*).html /badges/index.html#$1-badge [NE,R,L]
-
 </IfModule>
 
 <Files "feed.xml">


### PR DESCRIPTION
Removed rule that sent requests for badges' sub-pag...es back to `badges/index.html`.  This should close #381.
