### PR TITLE
Fix lat/lon for Dundee bootcamp

### DIFF
--- a/config/bootcamps_saved.yml
+++ b/config/bootcamps_saved.yml
@@ -1796,7 +1796,7 @@
   humandate: December 16-17, 2013
   humantime: 9:00 am - 5.00 pm
   instructor: [David Martin, Martin Jones]
-  latlng: 50.735788,-3.535033
+  latlng: 56.464,-2.97
   layout: bootcamp
   registration: restricted
   root: .


### PR DESCRIPTION
The location of the Dundee bootcamp in the map on:
    http://software-carpentry.org/bootcamps/previous.html
was in Exeter (a long way from Dundee).
