### PR TITLE
Link to Version 5 teaching materials.

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -13,7 +13,7 @@
             <a href="{{page.root}}/bootcamps/index.html">Bootcamps</a>
           </li>
           <li id="nav-lessons">
-            <a href="{{page.root}}/v4/index.html">Lessons</a>
+            <a href="{{page.root}}/lessons.html">Lessons</a>
           </li>
           <li id="nav-blog">
             <a href="{{page.root}}/blog/index.html">Blog</a>

--- a/lessons.html
+++ b/lessons.html
@@ -1,0 +1,67 @@
+---
+layout: base
+root: .
+title: Lessons
+---
+<p>
+  All of our materials are made available under the
+  <a href="{{page.root}}/license.html#cc-by">Creative Commons - Attribution License</a>.
+  You are free to use and remix them,
+  provided that you cite Software Carpentry as the original source.
+</p>
+<div class="row-fluid">
+  <div class="span6">
+    <h2>Version 5</h2>
+    <p>
+      This material is what we currently use in bootcamps,
+      and is being actively developed.
+    </p>
+  </div>
+  <div class="span6">
+    <h2>Version 4</h2>
+    <p>
+      This material was created in 2010-11,
+      and is now in maintenance mode.
+    </p>
+  </div>
+</div>
+<div class="row-fluid">
+  <div class="span6">
+    <ul>
+      <li><a href="v5/intro.html">Introduction</a></li>
+      <li><a href="v5/novice/shell/index.html">The Unix Shell</a></li>
+      <li><a href="v5/novice/git/index.html">Version Control with Git</a></li>
+      <li><a href="v5/novice/python/index.html">Programming with Python</a></li>
+      <li><a href="v5/novice/sql/index.html">Using Databases and SQL</a></li>
+      <li><a href="v5/novice/extras/index.html">A Few Extras</a></li>
+      <li><a href="v5/novice/teaching/index.html">Instructor's Guide</a></li>
+      <li><a href="v5/setup.html">Setup Instructions</a></li>
+      <li><a href="v5/bib.html">Recommended Reading</a></li>
+      <li><a href="v5/gloss.html">Glossary</a></li>
+      <li><a href="v5/team.html">Our Team</a></li>
+    </ul>
+  </div>
+  <div class="span6">
+    <ul>
+      <li><a href="v4/vc/index.html">Version Control with Subversion</a></li>
+      <li><a href="v4/shell/index.html">The Unix Shell</a></li>
+      <li><a href="v4/python/index.html">Programming in Python</a></li>
+      <li><a href="v4/test/index.html">Testing</a></li>
+      <li><a href="v4/setdict/index.html">Sets and Dictionaries</a></li>
+      <li><a href="v4/regexp/index.html">Regular Expressions</a></li>
+      <li><a href="v4/databases/index.html">Databases</a></li>
+      <li><a href="v4/access/index.html">Using Access</a></li>
+      <li><a href="v4/data/index.html">Data Management</a></li>
+      <li><a href="v4/oop/index.html">Object-Oriented Programming</a></li>
+      <li><a href="v4/invperc/index.html">Program Design</a></li>
+      <li><a href="v4/make/index.html">Make</a></li>
+      <li><a href="v4/sysprog/index.html">Systems Programming</a></li>
+      <li><a href="v4/spreadsheets/index.html">Spreadsheets</a></li>
+      <li><a href="v4/matrix/index.html">Matrix Programming with NumPy</a></li>
+      <li><a href="v4/matlab/index.html">MATLAB</a></li>
+      <li><a href="v4/media/index.html">Multimedia Programming</a></li>
+      <li><a href="v4/softeng/index.html">Software Engineering</a></li>
+      <li><a href="v4/essays/index.html">Essays</a></li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
1. Change navbar to point to new `./lessons.html` page.
2. Create `./lessons.html` with links to `v4` and `v5`.

Note that `v5` isn't in this repo - we'll submodule it (or whatever) once it settles down.
