### PR TITLE
Adding Soton bootcamp url

### DIFF
--- a/config/bootcamp_urls.yml
+++ b/config/bootcamp_urls.yml
@@ -34,6 +34,7 @@
 - https://github.com/swcarpentry/2014-04-28-training
 - https://github.com/elixirno/2014-04-23-uib
 - https://github.com/jrherr/2014-04-29-gwu
+- https://github.com/DevasenaInupakutika/2014-05-08-soton
 - https://github.com/wltrimbl/2014-05-12-cshl
 - https://github.com/r-gaia-cs/2014-05-12-furg
 - https://github.com/swcarpentry/2014-05-12-oicr-toronto


### PR DESCRIPTION
Due to misunderstanding this wasn't added to bootcamp_urls. Apologies.
