### PR TITLE
Fix to UnicodeEncodeError at bin/make_bootcamp_rss_feed.py

### DIFF
--- a/bin/make_bootcamp_rss_feed.py
+++ b/bin/make_bootcamp_rss_feed.py
@@ -107,16 +107,12 @@ def get_description(bootcamp):
     '''
     address = ''
     if bootcamp.get('address'):
-        try:
-            address = 'at {0}'.format(bootcamp['address'])
-        except UnicodeEncodeError, e:
-            print >> sys.stderr, 'Unable to decode address for {0}'.format(bootcamp['slug'])
-            address = ''
-        instructors = ''
-        if bootcamp.get('instructor'):
-            instructors='led by {0}'.format(','.join(bootcamp['instructor'])) 
-        return 'A boot camp will be held on {0} {1} {2}'.format(
-            bootcamp['humandate'], address, instructors)
+        address = u'at {0}'.format(bootcamp['address'])
+    instructors = ''
+    if bootcamp.get('instructor'):
+        instructors = u'led by {0}'.format(u','.join(bootcamp['instructor']))
+    return u'A boot camp will be held on {0} {1} {2}'.format(
+        bootcamp['humandate'], address, instructors)
 
 #----------------------------------------
 


### PR DESCRIPTION
@gvwilson discovery a issue with non ASCII characters at YAML headers when generating the bootcamp RSS feed since [r-gaia-cs/2014-05-12-furg](http://r-gaia-cs.github.io/2014-05-12-furg) has a `á` at the address field. Similar same problem would happen when Rémi Emonet or Julián García be a instructor.

I hope this fix the issue.

```
$  python --version
Python 2.7.6
$ make clean cache site
cp ./config/bootcamps_saved.yml ./_bootcamp_cache.yml
make SITE=/home/raniere/documents/software_carpentry/site/_site OUT=/home/raniere/documents/software_carpentry/site/_site build
make[1]: Entering directory '/home/raniere/documents/software_carpentry/site'
python ./bin/preprocess.py -c ./config -o /home/raniere/documents/software_carpentry/site/_site -s /home/raniere/documents/software_carpentry/site/_site
jekyll build -d /home/raniere/documents/software_carpentry/site/_site
Configuration file: /home/raniere/documents/software_carpentry/site/_config.yml
            Source: /home/raniere/documents/software_carpentry/site
       Destination: /home/raniere/documents/software_carpentry/site/_site
      Generating... done.
python ./bin/make_calendar.py -o /home/raniere/documents/software_carpentry/site/_site -s /home/raniere/documents/software_carpentry/site/_site
python ./bin/make_rss_feed.py -o /home/raniere/documents/software_carpentry/site/_site -s /home/raniere/documents/software_carpentry/site/_site
python ./bin/make_bootcamp_rss_feed.py -o /home/raniere/documents/software_carpentry/site/_site -s /home/raniere/documents/software_carpentry/site/_site
cp _htaccess /home/raniere/documents/software_carpentry/site/_site/.htaccess
make[1]: Leaving directory '/home/raniere/documents/software_carpentry/site'
```
