### PR TITLE
Fixing end dates for bootcamps

### DIFF
--- a/bin/make_calendar.py
+++ b/bin/make_calendar.py
@@ -71,7 +71,7 @@ class ICalendarWriter(object):
             end = info['enddate']
         else:  # one day boot camp?
             end = info['startdate']
-        end + datetime.timedelta(1)  # non-inclusive end date
+        end += datetime.timedelta(1)  # non-inclusive end date
         lines = [
             u'BEGIN:VEVENT',
             u'UID:{0}'.format(uid),


### PR DESCRIPTION
This PR turns a simple `+` into a `+=` so that end dates for bootcamps are actually incremented by one day - according to the standard, end dates are non-inclusive, so two-day events are showing up as one-day events.
