### PR TITLE
If the name of a venue contains a single quote, such as "St. Mary's

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -67,8 +67,9 @@ SWC.maps = (function() {
           //icon: openPin,
           visible: true,
         });
+        // Use double-quoted string for the part containing 'venue' to avoid having to escape single quotes in bootcamp.venue.
         var info_string = '<div class="info-window">' +
-          '<h5><a href="{% if bootcamp.url %}{{bootcamp.url}}{% else %}{{page.root}}/{{bootcamp.path}}{% endif %}">{{bootcamp.venue|replace: '\'','\\\''}}</a></h5>' +
+          "<h5><a href=\"{% if bootcamp.url %}{{bootcamp.url}}{% else %}{{page.root}}/{{bootcamp.path}}{% endif %}\">{{bootcamp.venue}}</a></h5>" +
           '<h6><a href="{{page.root}}/{{bootcamp.path}}">{{bootcamp.humandate}}</a></h6>' +
           '</div>';
             set_info_window(map, marker, info_window, info_string);


### PR DESCRIPTION
University", the map on the bootcamp index page wasn't rendering
properly because the string containing it `js/maps.js` was in single
quotes.  We did have a `replace` in our template, but it wasn't
working.  This PR switches to a double-quoted string with explicit
escapes for the quotes around the `href` value - not 100% safe, but
good enough for everything we're doing.
