### PR TITLE
Enable allow_unicode when dumping bootcamp cache

### DIFF
--- a/bin/get_bootcamp_info.py
+++ b/bin/get_bootcamp_info.py
@@ -64,7 +64,7 @@ def main(args):
 
     if (not faulty) or tolerate:
         cleanup(results)
-        yaml.dump(results, writer)
+        yaml.dump(results, writer, allow_unicode=True)
 
     writer.close()
 
@@ -166,9 +166,10 @@ def archive(all_urls, results, reader, archiver):
         else:
             upcoming_urls.append(all_urls[i])
 
-    yaml.dump(upcoming_urls, reader, default_flow_style=False)
+    yaml.dump(upcoming_urls, reader, default_flow_style=False,
+              allow_unicode=True)
     if archive_info:
-        yaml.dump(archive_info, archiver)
+        yaml.dump(archive_info, archiver, allow_unicode=True)
 
 def should_be_archived(record):
     if 'enddate' in record:


### PR DESCRIPTION
I think this should fix #503.  It seems that by default PyYAML wants to output non-ASCII characters using escape sequences rather than writing a non-ASCII byte stream.  This will allow it to write the file out containing non-ASCII characters without escaping them (by default it writes UTF-8).

The escape sequences it was using previously are perfectly valid for YAML but it's possible that some tools elsewhere in the pipeline weren't recognizing it properly.  I think having just plain UTF-8 end-to-end should avoid the problem, I hope.
