### PR TITLE
Fixing links at top of sprint FAQ post

### DIFF
--- a/blog/2014/07/sprint-faq.html
+++ b/blog/2014/07/sprint-faq.html
@@ -11,8 +11,8 @@ etherpad: https://etherpad.mozilla.org/swc-sprint-2014
 <!-- start excerpt -->
 <p>
   The Mozilla Science Lab's first-ever
-  <a href="{{page.root}}/blog/2014/05/multisite-sprint-in-july.html">two</a>-<a href="blog/2014/06/planning-our-summer-sprint.html">day</a>
-  <a href="blog/2014/06/update-on-sprint-plans.html">sprint</a>
+  <a href="{{page.root}}/blog/2014/05/multisite-sprint-in-july.html">two</a>-<a href="{{page.root}}/blog/2014/06/planning-our-summer-sprint.html">day</a>
+  <a href="{{page.root}}/blog/2014/06/update-on-sprint-plans.html">sprint</a>
   is less than three weeks away,
   so here's a short FAQ to tell you who can take part and how.
 </p>


### PR DESCRIPTION
Did this directly on github, didn't build site.
