### PR TITLE
Fix unicode in bootcamp name

### DIFF
--- a/bin/get_bootcamp_info.py
+++ b/bin/get_bootcamp_info.py
@@ -64,7 +64,7 @@ def main(args):
 
     if (not faulty) or tolerate:
         cleanup(results)
-        yaml.dump(results, writer, allow_unicode=True)
+        yaml.dump(results, writer, encoding='utf-8', allow_unicode=True)
 
     writer.close()
 
@@ -167,9 +167,10 @@ def archive(all_urls, results, reader, archiver):
             upcoming_urls.append(all_urls[i])
 
     yaml.dump(upcoming_urls, reader, default_flow_style=False,
-              allow_unicode=True)
+              encoding='utf-8', allow_unicode=True)
     if archive_info:
-        yaml.dump(archive_info, archiver, allow_unicode=True)
+        yaml.dump(archive_info, archiver, encoding='utf-8',
+                allow_unicode=True)
 
 def should_be_archived(record):
     if 'enddate' in record:

--- a/bin/preprocess.py
+++ b/bin/preprocess.py
@@ -122,7 +122,7 @@ def main():
 
     # Save.
     with open(CONFIG_YML, 'w') as writer:
-        yaml.dump(config, writer)
+        yaml.dump(config, writer, encoding='utf-8', allow_unicode=True)
 
 #----------------------------------------
 


### PR DESCRIPTION
This should fix #503 since instead of

```
$ git rev-parse HEAD
d9b1d44a6ed0747b3a7dd2589bb3dbff595fd5bf
$ make clean site
...
$ grep Centro _config.yml 
  venue: "Centro de Compet\xEAncia em Software Livre"
  venue: "Centro de Compet\xEAncia em Software Livre"
```

with this PR we have

```
$ git rev-parse HEAD       
485b100f504c4f40e80cff2fefb3f3ccd8b29b67
$ make clean site
...
$ grep Centro _config.yml
  venue: Centro de Competência em Software Livre
  venue: Centro de Competência em Software Livre
```

@gvwilson Could you review this?
