### PR TITLE
Fixed link to mailing list in MATLAB blog post

### DIFF
--- a/blog/2014/08/matlab-review.html
+++ b/blog/2014/08/matlab-review.html
@@ -63,17 +63,17 @@ category: ["MATLAB", "Bootcamps", "Opinion"]
     These challenges are very well documented (i.e. the relevant data files and answers 
     are all conveniently contained in an 
     <a href="https://github.com/resbaz/lessons/tree/master/matlab/intermediate/Exercises">Exercises</a> 
-    directory), however their completion requires that the participants to be familiar 
-    with <i>all</i> the content in the associated lesson. Since each of the lessons 
+    directory), however their completion requires the participants to be familiar 
+    with <i>all</i> the content in the associated lesson. Since each lesson 
     involves up to an hour of live coding/demonstration, the bootcamp involved very long 
     periods of demonstration followed by challenges that also took a very long time to 
     complete. This not only made it difficult for participants to maintain concentration, 
-    but it also meant that there were long periods where the helpers were not really 
+    but it also meant that there were long periods where the helpers weren't really 
     involved in the action.
     <ul>
 	  <li>
-	    There were shorter recommended activities scattered throughout the teaching notes, 
-	    but these often asked the participants to do something they'd never seen before 
+	    There are shorter recommended activities scattered throughout the teaching notes, 
+	    but these often ask the participants to do something they've never seen before 
 	    (e.g. one of the recommended activities asks the participants to define a 
 	    function, even though at that point the instructor hasn't even demonstrated the 
 	    associated syntax and typical use cases). Our instructors therefore used those 
@@ -119,7 +119,7 @@ category: ["MATLAB", "Bootcamps", "Opinion"]
   a slightly different approach to the re-write (i.e. comparing and combining their materials
   will result in a better final product), however to avoid such duplication of effort in the 
   future we've setup a Matlab
-  <a href="http://lists.software-carpentry.org/mailman/listinfo/matlab_lists.software-carpentry.org">mailing list</a>
+  <a href="{{site.mailing_lists}}/mailman/listinfo/matlab-discuss_lists.software-carpentry.org">mailing list</a>
   in order to keep the community updated with our progress.
 </p>  
 <p>


### PR DESCRIPTION
@gvwilson Thanks for creating that mailing list. The link I had to the list in the body of the post was broken (I had incorrectly assumed that the list would be called "matlab" as opposed to "matlab-discuss"), so I've fixed it in this PR.
