### PR TITLE
Add link to instructor post assessment

### DIFF
--- a/bootcamps/checklists/instructors.html
+++ b/bootcamps/checklists/instructors.html
@@ -95,7 +95,7 @@ title: Bootcamp Checklist &mdash; Instructors
       Debrief with Greg.
     </li>
     <li>
-      Complete the instructors' <a href = "http://software-carpentry.org/bootcamps/assess/post-instructor.html">post-bootcamp questionnaire</a>.
+      Complete the instructors' <a href = "{{page.root}}/bootcamps/assess/post-instructor.html">post-bootcamp questionnaire</a>.
     </li>
     <li>
       Send any other feedback you have

--- a/bootcamps/checklists/lead_instructor.html
+++ b/bootcamps/checklists/lead_instructor.html
@@ -191,7 +191,7 @@ title: Bootcamp Checklist &mdash; Lead Instructor
     </li>
     <li>
       Fill in the
-      <a href = "http://software-carpentry.org/bootcamps/assess/post-instructor.html">workshop summary questionnaire</a>
+      <a href = "{{page.root}}/bootcamps/assess/post-instructor.html">workshop summary questionnaire</a>
       to let the Software Carpentry admin know
       what was actually taught and how it went.
     </li>


### PR DESCRIPTION
I've added a link in the instructor's checklist and the lead instructor's checklist pointing to the instructor's post-assessment. I am currently pointing to the html in the site/bootcamps/assess directory (is there a google form?). There may also be a few places where my editor striped the white space from the end of a line.
