### PR TITLE
Adding topic maintainers' names to lesson page.

### DIFF
--- a/_includes/people/silva.raniere.html
+++ b/_includes/people/silva.raniere.html
@@ -7,6 +7,6 @@
     development of robust, reproducible, and scalable software tools
     for computational science and open science/access.
     <br/>
-    <span class="maintainer"Raniere is a maintainer for our website tools.</span>
+    <span class="maintainer">Raniere is a maintainer for our website tools.</span>
   </div>
 </div>

--- a/_includes/people/srinath.ashwin.html
+++ b/_includes/people/srinath.ashwin.html
@@ -8,6 +8,6 @@
     works with Python as much as possible, but can be persuaded to
     code in C, C++ or Fortran.
     <br/>
-    <span class="maintainer">Srinath is a topic maintainer for MATLAB.</span>
+    <span class="maintainer">Ashwin is a topic maintainer for MATLAB.</span>
   </div>
 </div>

--- a/lessons.html
+++ b/lessons.html
@@ -5,27 +5,25 @@ title: Lessons
 ---
 <div class="row-fluid">
   <div class="span6">
-    <div>
-      <h2>Version 5</h2>
-      <p>
-        This material is what we currently use in workshops.
-        <br/>
-        <a href="http://github.com/swcarpentry/bc">View source on GitHub</a>
-      </p>
-      <ul>
-        <li><a href="v5/intro.html">Introduction</a></li>
-        <li><a href="v5/novice/shell/index.html">The Unix Shell</a></li>
-        <li><a href="v5/novice/git/index.html">Version Control with Git</a></li>
-        <li><a href="v5/novice/python/index.html">Programming with Python</a></li>
-        <li><a href="v5/novice/sql/index.html">Using Databases and SQL</a></li>
-        <li><a href="v5/novice/extras/index.html">A Few Extras</a></li>
-        <li><a href="v5/novice/teaching/index.html">Instructor's Guide</a></li>
-        <li><a href="v5/setup.html">Setup Instructions</a></li>
-        <li><a href="v5/bib.html">Recommended Reading</a></li>
-        <li><a href="v5/gloss.html">Glossary</a></li>
-        <li><a href="v5/team.html">Our Team</a></li>
-      </ul>
-    </div>
+    <h2>Version 5</h2>
+    <p>
+      This material is what we currently use in workshops.
+      <br/>
+      <a href="http://github.com/swcarpentry/bc">View source on GitHub</a>
+    </p>
+    <ul>
+      <li><a href="v5/intro.html">Introduction</a></li>
+      <li><a href="v5/novice/shell/index.html">The Unix Shell</a></li>
+      <li><a href="v5/novice/git/index.html">Version Control with Git</a></li>
+      <li><a href="v5/novice/python/index.html">Programming with Python</a></li>
+      <li><a href="v5/novice/sql/index.html">Using Databases and SQL</a></li>
+      <li><a href="v5/novice/extras/index.html">A Few Extras</a></li>
+      <li><a href="v5/novice/teaching/index.html">Instructor's Guide</a></li>
+      <li><a href="v5/setup.html">Setup Instructions</a></li>
+      <li><a href="v5/bib.html">Recommended Reading</a></li>
+      <li><a href="v5/gloss.html">Glossary</a></li>
+      <li><a href="v5/team.html">Our Team</a></li>
+    </ul>
   </div>
   <div class="span6">
     <h2>Version 4</h2>
@@ -66,6 +64,57 @@ title: Lessons
     </div>
   </div>
 </div>
+
+<h2>Maintainers</h2>
+
+<p>
+  The topic maintainers listed below are responsible for
+  keeping issues and pull requests moving by reviewing,
+  managing discussion,
+  etc.,
+  and are also responsible for deciding what is and isn't included in our lessons.
+</p>
+
+<table class="table table-striped">
+  <tr>
+    <td>Git</td>
+    <td><a href="{{page.root}}/pages/team.html#davis.m">Matt Davis</a> and <a href="{{page.root}}/pages/team.html#hamrick.jessica">Jessica Hamrick</a></td>
+  </tr>
+  <tr>
+    <td>MATLAB</td>
+    <td><a href="{{page.root}}/pages/team.html#kiral-kornek.isabell">Isabell Kiral-Kornek</a> and <a href="{{page.root}}/pages/team.html#srinath.ashwin">Ashwin Srinath </a></td>
+  </tr>
+  <tr>
+    <td>Mercurial</td>
+    <td><a href="{{page.root}}/pages/team.html#latornell.d">Doug Latornell</a></td>
+  </tr>
+  <tr>
+    <td>Python</td>
+    <td><a href="{{page.root}}/pages/team.html#bekolay.trevor">Trevor Bekolay</a> and <a href="{{page.root}}/pages/team.html#bostroem.a">Azalee Bostroem</a></td>
+  </tr>
+  <tr>
+    <td>R</td>
+    <td><a href="{{page.root}}/pages/team.html#blischak.j">John Blischak</a> and <a href="{{page.root}}/pages/team.html#haine.denis">Denis Haine</a></td>
+  </tr>
+  <tr>
+    <td>SQL</td>
+    <td><a href="{{page.root}}/pages/team.html#cabunoc.abigail">Abigail Cabunoc</a> and <a href="{{page.root}}/pages/team.html#mckay.sheldon">Shelton McKay</a></td>
+  </tr>
+  <tr>
+    <td>Unix shell</td>
+    <td><a href="{{page.root}}/pages/team.html#devenyi.gabriel">Gabriel Devenyi</a> and <a href="{{page.root}}/pages/team.html#koch.christina">Christina Koch</a></td>
+  </tr>
+  <tr>
+    <td>setup instructions</td>
+    <td>Fran&ccedil;ois Michonneau</td>
+  </tr>
+  <tr>
+    <td>tools</td>
+    <td><a href="{{page.root}}/pages/team.html#emonet.remi">R&eacute;mi Emonet</a> and <a href="{{page.root}}/pages/team.html#silva.raniere">Raniere Silva</a></td>
+  </tr>
+</table>
+
+<h2>Older Material</h2>
 
 <p>
   The Version 3 material (circa 2007)


### PR DESCRIPTION
1. Adding names of topic maintainers to website.
2. Fixing two glitches in maintainers' `_include` snippets.
