### PR TITLE
Add two workshops in Leeds, UK

### DIFF
--- a/config/workshop_urls.yml
+++ b/config/workshop_urls.yml
@@ -11,5 +11,7 @@
 - https://github.com/karthik/2014-10-31-nw
 - https://github.com/dhaine/2014-11-06-fmv
 - https://github.com/swcarpentry/2014-11-12-embl
+- https://github.com/andreww/2014-11-24-leeds
 - https://github.com/jduckles/2014-11-27-uct
 - https://github.com/hpcarcher/2014-12-03-edinburgh
+- https://github.com/andreww/2015-01-14-leeds


### PR DESCRIPTION
These are both currently restricted but to a wide
group of people (all environmental scientists funded
by NERC - a major UK research funder - who are paying).
