### PR TITLE
Add blog post on the novice R materials and discuss future plans.

### DIFF
--- a/blog/2014/10/announcing-novice-r-lessons.html
+++ b/blog/2014/10/announcing-novice-r-lessons.html
@@ -3,13 +3,13 @@ layout: blog
 root: ../../..
 author: John Blischak
 title: "Presenting the novice R materials and future plans for the SWC R community"
-date: 2014-10-17
+date: 2014-10-20
 time: "10:00:00"
 category: ["Lessons", "R"]
 ---
 <!-- start excerpt -->
 <p>
-  Approximately six months after
+  Approximately seven months after
   our <a href="{{page.root}}/blog/2014/04/novice-r-discussion-summary.html">initial
   meeting</a>, the SWC R community has developed the first set of R lessons for use
   both in workshops and for self-directed learning from the SWC
@@ -22,11 +22,11 @@ category: ["Lessons", "R"]
 
 <p>
   Translating these lessons was a big effort. Many thanks are due to both
-  the large contributions made by
+  the major contributions made by
   <a href="https://github.com/sarahsupp">Sarah
   Supp</a>, <a href="https://github.com/dbarneche">Diego Barneche</a>,
   and <a href="https://github.com/gavinsimpson">Gavin Simpson</a>, as well as
-  the smaller contributions made by <a href="https://github.com/cboettig">Carl
+  the contributions made by <a href="https://github.com/cboettig">Carl
   Boettiger</a>, <a href="https://github.com/jainsley">Josh
   Ainsley</a>, <a href="https://github.com/chendaniely">Daniel
   Chen</a>, <a href="https://github.com/BernhardKonrad">Bernhard Konrad</a>, and
@@ -40,13 +40,19 @@ category: ["Lessons", "R"]
   The current set of novice R lessons fulfill the vision described in
   a <a href="https://gist.github.com/jkitzes/7478566">summary</a> of a meeting
   back in October 2012:
-  <blockquote> There is a general belief that SWC should be "language agnostic"
-  and primarily teach the computing skills that transcend individual programming
-  languages.  </blockquote>
-  <blockquote>In general, the R-based workshops should reuse as much material as
-  possible from the existing curriculum and contribute language-agnostic
-  improvements and new lessons back to the "main" Python-based lesson
-  set.</blockquote>
+  <blockquote>
+    <p>
+      There is a general belief that SWC should be "language agnostic"
+      and primarily teach the computing skills that transcend individual programming
+      languages.
+    </p>
+    <p>
+      In general, the R-based workshops should reuse as much material as
+      possible from the existing curriculum and contribute language-agnostic
+      improvements and new lessons back to the "main" Python-based lesson
+      set.
+    </p>
+  </blockquote>
   <a href="https://github.com/braithwaite">Dan Braithwaite</a> and I recently
   taught these lessons at
   a <a href="http://jdblischak.github.io/2014-09-18-chicago/">workshop for
@@ -89,23 +95,17 @@ category: ["Lessons", "R"]
 <h3>A call for proposals</h3>
 
 <p>
-  My
-  original <a href="http://lists.software-carpentry.org/pipermail/r-discuss_lists.software-carpentry.org/2014-September/000160.html">response</a>
-  to the complaints about the current set of novice R materials was to have
-  another R community meeting to discuss the future development of a new set of
-  lesson materials. However, upon further reflection, I no longer think this is
-  the best course of action. Six months ago my goal was to have a set of novice
-  R lessons that was developed, maintained, and taught by the R community as a
-  whole. The changes since then both in the SWC R community as well as the wider
-  SWC community indicate this sort of unified approach is not feasible.
+  We set out about seven months ago to create a set of lessons that would be
+  developed, maintained, and used by everyone in the Software Carpentry
+  community who is teaching R. Having built these lessons, I now question
+  whether that was the right goal.
 </p>
 
 <p>
   First, while it was an accomplishment to finally have novice R lessons on the
-  SWC website, overall this experiment was not overly successful. The work of
-  translating the materials ended up being done by only a few people, and only a
-  few instructors have actually taught these materials in their
-  workshops. Second, there is now another option for running R-based
+  SWC website, the work of translating the materials ended up being done by only
+  a few people, and only a few instructors have actually taught these materials
+  in their workshops. Second, there is now another option for running R-based
   workshops, <a href="http://datacarpentry.org/">Data Carpentry</a>. Thus, the
   common debate on how much we should focus on programming best practices versus
   data analysis skills has been somewhat solved: a Software Carpentry workshop
@@ -114,17 +114,16 @@ category: ["Lessons", "R"]
 </p>
 
 <p>
-  In the wider SWC community, we are currently in the process of overhauling
-  just about everything. The plan is
+  Third, in the wider SWC community, we are currently in the process of
+  overhauling just about everything. The plan is
   to <a href="{{page.root}}/blog/2014/09/splitting-the-repo.html">split up the
   bc repo</a>, which will result in a
   <a href="{{page.root}}/blog/2014/10/a-new-template-for-workshop-websites.html">new template
   for workshop websites</a> and a
-  <a href="{{page.root}}/blog/2014/10/a-new-template-for-lessons.html">new template
-  for lesson material</a>. One of the motivations for this effort is that the
-  unified lesson approach has not been working. Instructors want the flexibility
-  to add domain-specific data and introduce topics in an order that makes the
-  most sense to them.
+  <a href="{{page.root}}/blog/2014/10/a-new-template-for-lessons.html">new
+  template for lesson material</a>. One of the motivations for this effort is
+  that instructors want the flexibility to add domain-specific data and
+  introduce topics in an order that makes the most sense to them.
 </p>
 
 <p>


### PR DESCRIPTION
Sorry for the confusion. This PR replaces #641. I've copy-pasted my original message below:

This blog post has two primary purposes:
- Announce that the novice R materials have been translated and are now available on the SWC website.
- Provide some direction for future lesson development.

I'd appreciate all feedback. Especially from @eddelbuettel and @gavinsimpson, since I quote from your recent posts on r-discuss, @tracykteal, since I discuss Data Carpentry, @sritchie73, since I use your blog post as an example, and @dhaine. Thanks!
