### PR TITLE
Update links to novice lessons in blog post.

### DIFF
--- a/blog/2014/10/announcing-novice-r-lessons.html
+++ b/blog/2014/10/announcing-novice-r-lessons.html
@@ -13,9 +13,9 @@ category: ["Lessons", "R"]
   our <a href="{{page.root}}/blog/2014/04/novice-r-discussion-summary.html">initial
   meeting</a>, the SWC R community has developed the first set of R lessons for use
   both in workshops and for self-directed learning from the SWC
-  website. These <a href="{{page.root}}/novice/r/index.html">novice R
+  website. These <a href="{{page.root}}/v5/novice/r/index.html">novice R
   lessons</a> are a translation of the
-  current <a href="{{page.root}}/novice/python/index.html">novice Python
+  current <a href="{{page.root}}/v5/novice/python/index.html">novice Python
   lessons</a>.
 </p>
 <!-- end excerpt -->


### PR DESCRIPTION
I forgot the `v5` in the link to the novice lessons.
