### PR TITLE
Adding users group blog post

### DIFF
--- a/blog/2014/11/users-groups-for-ongoing-learning.html
+++ b/blog/2014/11/users-groups-for-ongoing-learning.html
@@ -1,0 +1,84 @@
+---
+layout: blog
+root: ../../..
+author: Noam Ross
+title: "Ongoing learning with user groups"
+date: 2014-11-07
+time: "15:30:00"
+category: ["Teaching", "Community"]
+---
+<!-- start excerpt -->
+<p>For the past two years I’ve run the <a href="http://www.noamross.net/davis-r-users-group.html">UC Davis R User’s Group</a> (D-RUG). 
+In this post, I’ll (1) outline the structure of D-RUG, and (2) summarize some lessons learned, and (3) discuss how such users’ groups could act to support and complement SWC’s workshops. 
+Per <a href="http://forum.mozillascience.org/t/new-member-introductions/30/22">Bill’s suggestion</a>, we could discuss the role of users group at a future <a href="http://mozillascience.org/instructor-hangouts-landing-this-friday/">instructor hangout</a></p>
+<!-- end excerpt -->
+
+<p>D-RUG was created with similar motivations as SWC - to help scientists learn computing skills. 
+Unlike SWC workshops, our model has been “everyone teaches everyone” rather than “instructor –&gt; learner”. 
+I saw that science graduate students at Davis increasingly needed to use R and similar tools in both their coursework and research, and there was a fair bit of knowledge dispersed among students and faculty in the university. 
+But there was little training on programming, and no forum to share our knowledge.</p>
+<p>Our users are primarily graduate students and postdocs from across the university, though they’re skewed towards ecology and related fields. 
+Most have no training in computer science or programming. 
+They take up R either for coursework or when a specific research task demands it. 
+So they are pretty much in the same place as most SWC Workshop students. 
+We try to maintain low barriers to entry for these students.</p>
+<p>Our basic operating principle is maintaining <em>low barriers to entry</em> for <em>users of all skill levels.</em> That means meeting students where they are in terms of their tools and needs, and making it as easy as possible for volunteers to pitch in.</p>
+<h2 id="basic-elements-of-the-users-group">Basic elements of the Users’ Group</h2>
+<ul>
+<li><p><strong>Work sessions</strong>: We have weekly, 2-hour co-work sessions where users come to work on their own projects and get help.</p></li>
+<li><p><strong>Talks and tutorials</strong>: About every other week, the first half of our work sessions is dedicated to a presentation. 
+These are mainly tutorials on tools in R. 
+Sometimes they are “show-and-tell” where a user presents an analysis for feedback. 
+Most speakers walk through a script on a large screen, and Q &amp; A takes up half of the time.</p></li>
+<li><p><strong>A Q &amp; A listserv</strong>: We use Google Groups to manage a listserv where people can ask questions, which is especially helpful for our many users who can’t attend the weekly sessions.</p>
+<p>Global fora, like the <a href="http://www.r-project.org/mail.html">R mailing lists</a> or <a href="http://stackoverflow.com/questions/tagged/r">Stack Overflow</a>, are great, but in order to scale they need pretty strict rules that are challenging for beginners. 
+Many beginners don’t yet know how to frame questions to get good answers. 
+Since our listserv is small-scale, new users can ask open-ended questions and expect responses more helpful than “RTFM.”</p></li>
+<li><p><strong>A website and blog</strong>: Our blog mostly serves as a way to post <a href="http://www.noamross.net/davis-r-users-group.html#d-rug-tutorials-from-our-meetings">materials from our talks</a>, usually <code>Rmd</code> scripts or slides. 
+More recently we have been broadcasting our tutorials with Google Hangouts on Air and posting those videos, as well.</p></li>
+</ul>
+<h2 id="some-lessons-learned">Some lessons learned</h2>
+<p>After 2 years, D-RUG has proved a successful. 
+A typical meeting brings 5-15 members, usually evenly split between regulars and those who come just when they have questions. 
+Attendance tends to be higher towards the beginning of the term and when we have speakers. 
+A fair number of on-campus (and LOTS of off-campus users) view the tutorials online.400 members have signed up for the listserv. 
+10-20% of these are active posters, and most questions get answered in a day or so.Most importantly, I’ve seen many users arrive with little or no experience, and go on be our most useful helpers and give some of our best tutorials.</p>
+<p>Here a few of the lessons I’ve learned in running D-RUG:</p>
+<ul>
+<li><p>One major challenge is keeping enough advanced users engaged so that they can be a resource for beginners. 
+Advanced users who attend work sessions can expect to spend about 50% of their time answering questions of others.</p>
+<p>The listserv is a low-commitment way for advanced users to help, and is even our advanced users ask questions on it sometimes. 
+Our <a href="http://www.revolutionanalytics.com/r-user-group-sponsorship-program">sponsors at Revolution Analytics</a> send us a box of schwag each year - I use these as prizes to recognize helpful volunteers.</p>
+<p>Users who started off as beginners but have learned a lot through D-RUG tend to be our most dedicated volunteers.</p></li>
+<li><p>There’s a trade-off between running D-RUG as a meeting where people regularly give talks, and a space where people come to work. 
+ I found a pretty good medium having weekly 2-hr work sessions, with talks every other week for half the session during the school year. 
+More people tend to come to those sessions with talks.</p></li>
+<li><p>It is constant work wrangling people to give talks, and one doesn’t want to burden advanced users already volunteering their time with too many requests to give tutorials. 
+ It’s good to encourage people who are learning a new topic to give talks on things they just learned. 
+ Also, encourage them to just walk through a script rather than make slides. 
+ It’s less work for the presenter, and the script is more useful to others afterwards than slides.</p></li>
+<li><p>Users are much more likely to be interested in <em>applications</em> rather than programming topics. 
+Talks on topics like “How to do AIC model comparison” and “How to prepare plots for publication” have been much more well attended (and heavily trafficked on the blog) than ones on topics like “speeding up code.” This is partially a function of our membership (mostly empirical ecologists, biologists, and social scientists).</p></li>
+<li><p>It takes time to build self-sustaining community. 
+For our first year, I had to monitor the listserv to make sure questions didn’t go unanswered, and I ran every work session and bugged power users to attend. 
+Now the listserv runs itself and we have enough regulars at our work sessions. 
+We would like to find some arrangements to help institutionalize the group more, though. 
+One possibility is having professors or TAs for courses using R to hold office hours at D-RUG.</p></li>
+<li><p>Food helps. 
+We have snacks paid for by our <a href="http://www.revolutionanalytics.com/r-user-group-sponsorship-program">sponsor</a>. 
+A lot of expert users and professors stop in for a mid-afternoon sugar infusion, and end up answering questions.</p></li>
+</ul>
+<h2 id="users-groups-as-a-complementary-tool-for-swc">Users’ Groups as a complementary tool for SWC</h2>
+<p>Users’ groups have the potential to be a complementary tool to SWC workshops. 
+We recruited a number of new members at the <a href="http://bernhardkonrad.github.io/2014-06-16-davis/">June SWC Workshop at Davis</a>, and they’ve been able to practice and build those skills at our work sessions. 
+Users’ groups also may be a good forum to stay connected to and follow up with learners.</p>
+<p>Beginners need a minimum amount of knowledge to take advantage of D-RUG, which can be provided by SWC workshops. 
+D-RUG doesn’t have the resources or structure to teach those beginners from scratch. 
+I sometimes point new users who show up with no experience to an appropriate online self-taught course, and encourage them do the work at our sessions where they can get support. 
+If these members attend a SWC workshop, they will know enough to get started, and to support each other.</p>
+<p>The D-RUG model is fairly easy to replicate. 
+Daniel Hocking at the University of New Hampshire has <a href="http://nhusers.com/">created a similar group</a>. 
+Anyone with the skill level of a typical SWC workshop helper can probably run a users’ group, though it does require a certain amount of time and skill at recruiting on-campus.</p>
+<p>I’d like to hear from others who have similar or alternative models. 
+How can these groups connect with SWC to build an ongoing community of learners?</p>
+


### PR DESCRIPTION
I've written a blog post about the users' group I've organized at Davis, and how it can be a complementary tool to SWC workshops.

I haven't rebuilt the site.  When I run `make cache` I'm getting the following error:

```
mentat : ~/Dropbox/code/site > make cache
cp ./config/workshops_saved.yml ./_workshop_cache.yml
Request for https://raw.github.com/gvwilson/2014-09-29-iDigBio/gh-pages/index.html returned status code 404
```

The URL returns 404 in my browser, as well.
