### PR TITLE
Adding summary of recent Disqus comments to home page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ nocomments: 1
           <tr><td>
             <a class="pull-right" href="workshops/index.html#future">...see all</a><br />
             <div align="center">
-              <p><em><a href="{{page.root}}/workshops/request.html">Request a workshop!</a></em></p>
+              <h4><a href="{{page.root}}/workshops/request.html">Request a Workshop</a></h4>
               <p><em><a href="{{page.root}}/workshops/previous.html">See where we've been!</a></em></p>
             </div>
           </td></tr>
@@ -106,9 +106,11 @@ nocomments: 1
         <a class="twitter-timeline" href="https://twitter.com/swcarpentry" data-widget-id="410241789077909504">Tweets by @swcarpentry</a>
         <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 
-        <h4><a href="{{page.root}}/workshops/request.html">Request a Workshop</a></h4>
-        <p><a href="{{page.root}}/workshops/request.html">Let us know</a> if you would like a software carpentry workshop in your area</p>
-
+        <h4>Recent Comments</h4>
+        <div id="recentcomments" class="dsq-widget"><script
+          type="text/javascript"
+          src="http://software-carpentry.disqus.com/recent_comments_widget.js?num_items=5&hide_avatars=1&excerpt_length=200"></script>
+	</div>
       </div>
     </div>
 


### PR DESCRIPTION
This closes #528.

Bug: The excerpts have `<p>` tags displayed as text.
