### PR TITLE
Partial support for interactive construction of dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ cache :
 	@python bin/get_workshop_info.py -v -t \
 	    -i $(CONFIG_DIR)/workshop_urls.yml \
 	    -o ./_workshop_cache.yml
-	@python bin/make-dashboard.py ./git-token.txt ./_dashboard_cache.yml
+	@python bin/make-dashboard.py -t ./git-token.txt -o ./_dashboard_cache.yml
 
 ## biblio       : make HTML and PDF of bibliography.
 # Have to cd into 'bib' because bib2xhtml expects the .bst file in

--- a/bin/make-dashboard.py
+++ b/bin/make-dashboard.py
@@ -5,9 +5,9 @@
 import sys
 import yaml
 from github import Github
-from util import DASHBOARD_CACHE
+from optparse import OptionParser
 
-controls = (
+CONTROLS = (
     ('swcarpentry/shell-novice', 'Introduction to the Unix shell'),
     ('swcarpentry/git-novice', 'Introduction to Git'),
     ('swcarpentry/hg-novice', 'Introduction to Mercurial'),
@@ -23,21 +23,46 @@ controls = (
     ('swcarpentry/site', 'Software Carpentry website'),
 )
 
-assert len(sys.argv) == 3, 'Usage: make-dashboard.py token-file output-file'
-token_file = sys.argv[1]
-output_file = sys.argv[2]
+USAGE = '''Usage: make-dashboard.py -o outputfile [-t tokenfile | -u username -p password]
+If no credentials are supplied, user is prompted for username and password.
+To store credentials, create a file called git-token.txt that contains your GitHub API token
+and put it in the root directory of the 'site' project.'''
 
-with open(token_file, 'r') as reader:
-    token = reader.read().strip()
+# Command-line options.
+parser = OptionParser()
+parser.add_option('-o', '--output', dest='output', help='output directory')
+parser.add_option('-t', '--tokenfile', dest='tokenfile', help='GitHub token file')
+parser.add_option('-u', '--username', dest='username', help='GitHub username')
+parser.add_option('-p', '--password', dest='password', help='GitHub password')
+options, args = parser.parse_args()
 
-g = Github(token)
+assert not args, USAGE
+
+if options.tokenfile is not None:
+    assert options.username is None and options.password is None, USAGE
+    with open(token_file, 'r') as reader:
+        token = reader.read().strip()
+        g = Github(token)
+
+elif options.username is not None and options.password is not None:
+    g = Github(options.username, options.password)
+
+elif options.username is None and options.password is None:
+    username = raw_input('username: ')
+    password = raw_input('password: ')
+    g = Github(username, password)
+
+else:
+    assert False, USAGE
+    
+# Process data.
 all_records = []
 dashboard = {
     'records' : all_records,
     'num_repos' : 0,
     'num_issues' : 0
 }
-for (ident, description) in controls:
+for (ident, description) in CONTROLS:
     print '+', ident
     dashboard['num_repos'] += 1
     r = g.get_repo(ident)
@@ -54,5 +79,6 @@ for (ident, description) in controls:
         dashboard['num_issues'] += 1
     record['issues'].sort(lambda x, y: - cmp(x['updated'], y['updated']))
 
+# Output.
 with open(output_file, 'w') as writer:
     yaml.dump(dashboard, writer, encoding='utf-8', allow_unicode=True)

--- a/bin/make-dashboard.py
+++ b/bin/make-dashboard.py
@@ -30,7 +30,7 @@ and put it in the root directory of the 'site' project.'''
 
 # Command-line options.
 parser = OptionParser()
-parser.add_option('-o', '--output', dest='output', help='output directory')
+parser.add_option('-o', '--output', dest='outputfile', help='output directory')
 parser.add_option('-t', '--tokenfile', dest='tokenfile', help='GitHub token file')
 parser.add_option('-u', '--username', dest='username', help='GitHub username')
 parser.add_option('-p', '--password', dest='password', help='GitHub password')
@@ -38,9 +38,11 @@ options, args = parser.parse_args()
 
 assert not args, USAGE
 
+assert options.outputfile is not None, USAGE
+
 if options.tokenfile is not None:
     assert options.username is None and options.password is None, USAGE
-    with open(token_file, 'r') as reader:
+    with open(options.tokenfile, 'r') as reader:
         token = reader.read().strip()
         g = Github(token)
 
@@ -80,5 +82,5 @@ for (ident, description) in CONTROLS:
     record['issues'].sort(lambda x, y: - cmp(x['updated'], y['updated']))
 
 # Output.
-with open(output_file, 'w') as writer:
+with open(options.outputfile, 'w') as writer:
     yaml.dump(dashboard, writer, encoding='utf-8', allow_unicode=True)


### PR DESCRIPTION
We've added a GitHub project dashboard page to the site. In order to build it, we need to fetch data from GitHub, but GitHub throttles access for unauthenticated users.  The bin/make-dashboard.py script can now ask for credentials interactively, but this isn't launched from the Makefile when an API token file isn't found.  The Makefile and bin/make-dashboard.py should be modified so that:

1.  the Makefile passes a new '-i' (or '--interactive') flag to the script
2.  if '-t' is used to specify an API token file, the script looks for that and uses it...
3. ...and if '-i' is present, it prompts interactively if and only if the token file cannot be found.

This way, `make cache` will do the right thing most of the time (token file is present for frequent website rebuilder) but fall back on interactive when needed.

The alternative is to require everyone who wants to build the website to put their GitHub API token in a file, but that's yet another barrier for people to get over. I'm sure there's a better way...