### PR TITLE
Simplifying build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,4 @@
 *.pyc
 .DS_Store
 _site
-_config.yml
-_dashboard_cache.yml
-_workshop_cache.yml
-_includes/recent_blog_posts.html
 git-token.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "v4"]
-	path = v4
-	url = https://github.com/swcarpentry/v4.git

--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,6 @@ commands : Makefile
 site :
 	make SITE=$(PWD)/_site OUT=$(PWD)/_site build
 
-## dev          : build into development directory on server.
-dev :
-	make SITE=$(DEV_URL) OUT=$(DEV_DIR) build
-
-## install      : build into installation directory on server.
-install :
-	make SITE=$(INSTALL_URL) OUT=$(INSTALL_DIR) build
-
 ## check        : check consistency of various things.
 check :
 	@python bin/check_workshop_info.py config/workshop_urls.yml config/workshops_saved.yml
@@ -146,6 +138,14 @@ cache :
 	    -i ./config/workshop_urls.yml \
 	    -o ./_workshop_cache.yml
 	@python bin/make-dashboard.py ./git-token.txt ./_dashboard_cache.yml
+
+## dev          : build into development directory on server.
+dev :
+	make SITE=$(DEV_URL) OUT=$(DEV_DIR) build
+
+## install      : build into installation directory on server.
+install :
+	make SITE=$(INSTALL_URL) OUT=$(INSTALL_DIR) build
 
 ## links        : check links.
 #  Depends on linklint, an HTML link-checking module from http://www.linklint.org/,

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Software Carpentry Web Site
 
 This repository holds the source for
 the [Software Carpentry](http://software-carpentry.org) web site.
-Home pages for workshops are not stored in this repository:
-if you want to create one,
-please see the instructions in the [`bc` repository](https://github.com/swcarpentry/bc).
+Lessons are not stored in this repository:
+please see [the lessons page](http://software-carpentry.org/lessons.html)
+for links to their repositories.
 
 Contributing
 ------------
@@ -16,53 +16,26 @@ By contributing,
 you are agreeing that Software Carpentry may redistribute your work
 under [these licenses](http://software-carpentry.org/license.html).
 
-Software Carpentry uses a development workflow similar to that of [AstroPy](http://astropy.org)
-and many other open source projects.
-The AstroPy docs have excellent sections on:
+Setting Up
+----------
 
-*   [Getting started with Git](http://astropy.readthedocs.org/en/latest/development/workflow/index.html#getting-started-with-git)
-*   [Developer workflow](http://astropy.readthedocs.org/en/latest/development/workflow/development_workflow.html)
-
-Cloning
--------
-
-To build this web site,
-you will need to clone `git@github.com:swcarpentry/site.git`,
-and then clone the submodule `https://github.com/swcarpentry/v4.git`.
-
-Note: this repository takes up roughly 360 MBytes
-(including what's in `.git`),
-and the Version 4 lesson materials add another 300 MBytes.
-
-Building
---------
-
-Building the web site requires:
+Rebuilding the web site locally to check changes requires:
 
 *   [Jekyll](http://jekyllrb.com/), used to compile templated HTML pages
 *   [Python](http://python.org/), used for pre- and post-processing
 
-Python packages can be installed using:
+We use Jekyll because it's what [GitHub](http://github.com/) uses;
+we use Python because most of our volunteers speak it.
+The Python packages we depend on can be installed using:
 
 ~~~
 $ pip install -r requirements.txt
 ~~~
 
-We use Jekyll because it's what [GitHub](http://github.com/) uses;
-we use Python because most of our volunteers speak it.
-
-*   Type `make` to see a list of all available commands.
-*   Type `make cache` to fetch information about upcoming workshops.
-    This must be done before building the web site.
-*   Type `make site` to build everything in `_site` for testing.
-    (Depending on your machine, this takes about 10-15 seconds.)
-*   Type `make clean` before re-doing `make site`,
-    to prepare the environment to build again.
-
-We try to use the same MarkDown interpreters as GitHub does for
-consistency.  On OS X, we suggest you use a recent Ruby to get access
-to these.  If you don't have Homebrew or MacPorts installed, here's a
-quick recipe to get started using HomeBrew.
+We try to use the same MarkDown interpreters as GitHub does for consistency.
+On OS X, we suggest you use a recent Ruby to get access to these.
+If you don't have Homebrew or MacPorts installed,
+here's a quick recipe to get started using HomeBrew:
 
 ~~~
 ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -71,29 +44,20 @@ gem install jekyll
 gem install RedCloth
 ~~~
 
-Design Notes
-------------
+Building
+--------
 
-*   We generate our own RSS feed (in `feed.xml`) and blog home page
-    because Jekyll insists on using `_posts/YYYY-MM-DD-name.html`,
-    and we don't want to have hundreds of files in one directory.
-*   Workshop pages for old workshops
-    are stored in the `workshops` directory of this repository,
-    since there's little point in creating repos for them.
-    New workshops should be created using the process described below.
+The commands used to rebuild the website are stored in `Makefile`.
 
-Adding Workshops
-----------------
-
-Old workshops' home pages are stored in `workshops/yyyy-mm-dd-site/index.html`.
-Newer workshops' home pages are stored in their own repositories on GitHub.
-The make target `make cache` runs the program `bin/get_workshop_info.py`
-which reads a list of GitHub repository URLs from the file `config/workshop_urls.yml`
-and (re-)creates the file `./_workshop_cache.yml`.
-That file is then used to build `./index.html`, `workshops/index.html`, and so on.
-To add another GitHub-hosted workshop to this web site,
-simply add a line to `config/workshop_urls.yml`.
-Please keep these ordered by date.
+*   Type `make` on its own to see a list of all available commands.
+*   Type `make clean` to get rid of generated files.
+*   Type `make site` to build everything in `_site` for testing.
+    (Depending on your machine, this takes about 10-15 seconds.)
+    You can then open `_site/index.html`
+    and other pages in `_site`
+    to see what your changes will look like.
+    Note that Disqus comments will *not* load properly,
+    since you'll be on your machine rather than our server.
 
 Blogging
 --------
@@ -122,55 +86,20 @@ To create a new blog post:
         as the excerpt to show in feed readers.
     *   If you need to refer to our email address, it is `{{page.contact}}`.
     *   If you need to another post, or something else on the site, use `{{page.root}}/path/to/file`.
-    *   We also provide `{{site.site}}` (the base URL for the site),
-        `{{site.twitter_name}}`,
-        `{{site.twitter_url}}`,
-        `{{site.facebook_url}}`,
-        `{{site.google_plus_url}}`,
-        and `{{site.rss_url}}`
-        (all of which should be self-explanatory),
-        and `{{site.msl_url}}` for the Mozilla Science Lab's web site.
 5.  Please add any images your blog post needs to the same blog/YYYY/MM directory as the post itself.
     Please use lower-case names without special characters for image files.
-6.  `make` in the root directory will list available commands;
-    `make site` will rebuild the web site in the `_site` directory.
-    Open `_site/index.html` to see your post on the blog's home page,
-    `_site/blog/index.html` to see it on the blog home page,
-    and `_site/YYYY/MM/post-name.html` to see the post itself.
-7.  When you're satisfied with your post,
+6.  When you're satisfied with your post,
     `git add path/to/post` and `git commit -m "Adding a blog post about something or other"`
     will commit it to your local copy (on your laptop).
-8.  `git push origin master` will push it to your clone on GitHub
+7.  `git push origin master` will push it to your clone on GitHub
     (assuming you've added your fork on GitHub as a remote called `origin`).
-9.  Go to GitHub and issue a pull request from your clone to `swcarpentry/website`,
-    then assign it to `@gvwilson` or `@amyrbrown` for proof-reading.
+8.  Go to GitHub and issue a pull request from your clone to `swcarpentry/website`,
+    then assign it to `@gvwilson` for proof-reading.
 
-Available Commands
-------------------
+For More Advanced Users
+-----------------------
 
-*   `archive_verb`: collect and archive workshop information from GitHub and
-    store in local cache (verbose).
-*   `archive`: collect and archive workshop information from GitHub and store in
-    local cache.
-*   `authors`: list all blog post authors.
-*   `biblio`: make HTML and PDF of bibliography.
-*   `cache_verb` : collect workshop information from GitHub and store in local cache (verbose).
-*   `cache`: collect workshop information from GitHub and store in local cache.
-*   `categories : list all blog category names.
-*   `check`: check consistency of workshop info, urls and other.
-*   `clean`: clean up.
-*   _`commands`_: show all commands (the default).
-*   `dev`: build into development directory on server.
-*   `install`: build into installation directory on server.
-*   `links`: check links.
-*   `sterile`: *really* clean up.
-*   `site`: build locally into _site directory for checking.
-*   `valid`: check validity of HTML.
-
-The Details
------------
-
-`make site`, `make dev`, and `make install` do the following:
+`make site` (and its partners `make dev` and `make install`) do the following:
 
 1.  Run `bin/preprocess.py` to create the `./_config.yml` file required by Jekyll
     and the `_includes/recent_blog_posts.html` file containing excerpts of recent blog posts.
@@ -180,6 +109,33 @@ The Details
 3.  Run `bin/make_rss_feed.py` to generate the RSS feed file `feed.xml`.
 4.  Run `bin/make_calendar.py` to generate the ICal calendar file `workshops.ics`.
 5.  Copy `./_htaccess` to create the `.htaccess` file for the web site.
+
+`bin/preprocess.py` needs two generated files to work properly:
+
+*   `_workshop_cache.yml`: stores information about recent and upcoming workshops.
+    This file is created by `bin/get_workshop_info.py`.
+*   `_dashboard_cache.yml`: stores information about Software Carpentry's GitHub projects.
+    This file is created by `bin/make-dashboard.py`.
+
+This information is stored in GitHub rather than being regenerated each time `make site` is run
+because harvesting the data can take 10-30 seconds
+depending on how busy GitHub is.
+In addition,
+the tool used to rebuild the dashboard cache requires credentials in order to run,
+since use of GitHub's API is throttled for unauthenticated users and programs.
+If you wish to regenerate these files:
+
+1.  Get a [GitHub API token](https://github.com/blog/1509-personal-api-tokens).
+2.  Save it in a file called `git-token.txt` in the root directory of this site.
+    (This file is ignored by Git, since tokens should not be shared between people.)
+
+After that,
+you can run `make cache` to re-create the two files.
+Please do *not* commit them unless you are sure you should;
+in particular,
+if you wish to add a new workshop to the list displayed on the main web site,
+please send us a pull request with a new URL in `config/workshop_urls.yml`,
+but do *not* send us the update to `_workshop_cache.yml`.
 
 Badges
 ------
@@ -191,21 +147,11 @@ To create badges, you must install [PyPNG](http://pythonhosted.org/pypng/index.h
 $ pip install pypng
 ~~~
 
-Use `bin/badge-create.py` to create a new badge:
+Use `bin/badge-create.py` to create a new badge, e.g.:
 
 ~~~
-$ python bin/badge-create.py --username abbrev.name --email name@site.com --kind instructor
+$ python bin/badge-create.py username email instructor
 ~~~
 
 The badges scripts in `bin` should be compatible with Python2 and Python3.
 To bake the badge we use `bin/badgebakery.py` which was provided by the Open Badge Team.
-
-To validate a badge:
-
-*   Build this repository.
-*   Setup a local copy of
-    [Open Badges Validator](https://github.com/mozilla/openbadges-validator-service.git).
-*   Setup a virtual server that responde to http://software-carpentry.org with the
-    content of `_site`.
-*   Add "127.0.1.1 software-carpentry.org localhost" to `/etc/hosts`.
-*   Open your local copy of Open Badges Validator with a web browser and follow the steps.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,20319 @@
+airports:
+- {airport: Auckland, count: 1, latlng: '-37.008056,174.791667'}
+- {airport: 'Atlanta, GA', count: 1, latlng: '33.640278,-84.426944'}
+- {airport: 'Austin, TX', count: 2, latlng: '30.194444,-97.669722'}
+- {airport: 'Hartford, CT', count: 2, latlng: '41.938889,-72.683056'}
+- {airport: Birmingham AL, count: 1, latlng: '33.562778,-86.753333'}
+- {airport: Birmingham, count: 1, latlng: '52.453611,-1.747778'}
+- {airport: Bangkok, count: 1, latlng: '13.6925,100.75'}
+- {airport: Bangalore, count: 1, latlng: '12.949722,77.668056'}
+- {airport: 'Nashville, TN', count: 1, latlng: '36.131312,-86.66945'}
+- {airport: Brisbane, count: 1, latlng: '-27.384167,153.1175'}
+- {airport: 'Boston, MA', count: 2, latlng: '42.364167,-71.005'}
+- {airport: Bristol, count: 1, latlng: '51.3825,-2.718889'}
+- {airport: 'Baltimore, MD', count: 3, latlng: '39.175278,-76.668333'}
+- {airport: Paris Charles de Gaulle, count: 1, latlng: '49.012778,2.55'}
+- {airport: 'Charlottesville, VA', count: 2, latlng: '38.139643,-78.452342'}
+- {airport: 'Charleston, SC', count: 1, latlng: '32.898611,-80.040278'}
+- {airport: 'Urbana-Champaign, IL', count: 1, latlng: '40.039167,-88.278056'}
+- {airport: Copenhagen Kastrup, count: 1, latlng: '55.617778,12.655833'}
+- {airport: Cape Town, count: 2, latlng: '-33.964722,18.601667'}
+- {airport: 'Ronald Reagan Washington, DC', count: 4, latlng: '38.851944,-77.0375'}
+- {airport: 'Denver, CO', count: 1, latlng: '39.858333,-104.666944'}
+- {airport: 'Dallas-Fort Worth, TX', count: 1, latlng: '32.896389,-97.0375'}
+- {airport: Dundee, count: 1, latlng: '56.4525,-3.025833'}
+- {airport: 'Des Moines, IA', count: 1, latlng: '41.533889,-93.6625'}
+- {airport: 'Detroit, MI', count: 3, latlng: '42.212222,-83.353333'}
+- {airport: Dublin, count: 1, latlng: '53.421111,-6.27'}
+- {airport: Edinburgh, count: 3, latlng: '55.95,-3.3725'}
+- {airport: 'Eugene, OR', count: 1, latlng: '38.175662,-85.736923'}
+- {airport: 'Newark, NJ', count: 1, latlng: '40.692222,-74.168611'}
+- {airport: Frankfurt, count: 2, latlng: '50.026389,8.543056'}
+- {airport: 'Spokane, WA', count: 1, latlng: '47.619722,-117.533611'}
+- {airport: 'Washington Dulles, DC', count: 1, latlng: '38.944444,-77.455556'}
+- {airport: 'Houston, TX', count: 3, latlng: '29.980278,-95.339722'}
+- {airport: 'Indianapolis, IN', count: 3, latlng: '39.717222,-86.294167'}
+- {airport: 'Ithaca, NY', count: 1, latlng: '42.491,-76.459'}
+- {airport: 'New York JFK, NY', count: 3, latlng: '40.639722,-73.778889'}
+- {airport: Krakow, count: 3, latlng: '50.0775,19.784722'}
+- {airport: 'Lansing, MI', count: 11, latlng: '42.778611,-84.587222'}
+- {airport: 'Los Angeles, CA', count: 1, latlng: '33.9415889,-118.40853'}
+- {airport: London City, count: 1, latlng: '51.505,0.054167'}
+- {airport: 'New York La Guardia, NY', count: 6, latlng: '40.777222,-73.8725'}
+- {airport: London Heathrow, count: 13, latlng: '51.4775,-0.461389'}
+- {airport: Lyon Saint Exupery, count: 1, latlng: '45.726111,5.090833'}
+- {airport: Madrid, count: 1, latlng: '40.472222,-3.560833'}
+- {airport: Manchester, count: 3, latlng: '53.353611,-2.274722'}
+- {airport: 'Kansas City, KS', count: 1, latlng: '39.2975,-94.713889'}
+- {airport: 'Harrisburg, PA', count: 1, latlng: '40.193333,-76.763333'}
+- {airport: 'Chicago Midway, IL', count: 3, latlng: '41.785833,-87.752222'}
+- {airport: Melbourne, count: 6, latlng: '-37.673333,144.843333'}
+- {airport: 'Manchester, New Hampshire', count: 1, latlng: '42.92786,-71.43844'}
+- {airport: 'Madison, WI', count: 4, latlng: '43.139722,-89.3375'}
+- {airport: 'Minneapolis St Paul, MN', count: 1, latlng: '44.880278,-93.216667'}
+- {airport: 'New Orleans, LA', count: 1, latlng: '29.993333,-90.257778'}
+- {airport: Munich, count: 1, latlng: '48.353611,11.785833'}
+- {airport: Newcastle, count: 1, latlng: '55.0375,-1.691667'}
+- {airport: Norwich, count: 1, latlng: '52.675833,1.282778'}
+- {airport: 'Oakland, CA', count: 9, latlng: '37.721111,-122.220556'}
+- {airport: Okinawa Naha, count: 1, latlng: '26.195556,127.645833'}
+- {airport: Oklahoma City, count: 1, latlng: '35.393056,-97.600556'}
+- {airport: Paris Orly, count: 2, latlng: '48.725278,2.359444'}
+- {airport: Oslo Gardermoen, count: 2, latlng: '60.193889,11.100278'}
+- {airport: 'Portland, OR', count: 1, latlng: '45.588611,-122.5975'}
+- {airport: 'Philadelphia, PA', count: 1, latlng: '39.871944,-75.241111'}
+- {airport: 'Pittsburgh, PA', count: 1, latlng: '40.491389,-80.232778'}
+- {airport: 'Providence, RI', count: 1, latlng: '41.723889,-71.428056'}
+- {airport: 'Raleigh Durham, NC', count: 4, latlng: '35.8775,-78.787222'}
+- {airport: 'Richmond, VA', count: 1, latlng: '37.505,-77.319444'}
+- {airport: 'San Diego, SC', count: 1, latlng: '32.733333,-117.189444'}
+- {airport: 'San Luis Obispo, CA', count: 1, latlng: '35.236944,-120.641944'}
+- {airport: 'State College, PA', count: 1, latlng: '40.855881,-77.843841'}
+- {airport: 'Louisville, KY', count: 1, latlng: '38.175662,-85.736923'}
+- {airport: 'Seattle, WA', count: 9, latlng: '47.448889,-122.309167'}
+- {airport: 'San Francisco, CA', count: 7, latlng: '37.618889,-122.374722'}
+- {airport: Singapore, count: 1, latlng: '1.355556,103.987222'}
+- {airport: 'San Jose, CA', count: 1, latlng: '37.361667,-121.928889'}
+- {airport: 'Salt Lake City, UT', count: 2, latlng: '40.788333,-111.9775'}
+- {airport: 'Sacramento, CA', count: 1, latlng: '38.695278,-121.590556'}
+- {airport: 'John Wayne (Orange County), CA', count: 1, latlng: '33.675556,-117.868056'}
+- {airport: Southampton, count: 2, latlng: '50.95,-1.356667'}
+- {airport: 'St. Louis, MO', count: 2, latlng: '38.7475,-90.359722'}
+- {airport: Sydney, count: 4, latlng: '-33.946111,151.177222'}
+- {airport: 'Syracuse, NY', count: 1, latlng: '38.175662,-85.736923'}
+- {airport: Tel Aviv, count: 1, latlng: '32.009444,34.876667'}
+- {airport: Trieste, count: 1, latlng: '45.827778,13.466389'}
+- {airport: 'Tucson, AZ', count: 1, latlng: '32.116111,-110.941389'}
+- {airport: 'Knoxville, TN', count: 1, latlng: '35.81,-84.0'}
+- {airport: Viracopos, count: 1, latlng: '-23.008056,-47.134444'}
+- {airport: Edmonton, count: 1, latlng: '53.309722,-113.579722'}
+- {airport: Halifax, count: 1, latlng: '44.880833,-63.508611'}
+- {airport: Montreal, count: 6, latlng: '45.468056,-73.741389'}
+- {airport: Vancouver, count: 9, latlng: '49.195,-123.181944'}
+- {airport: 'London, Ontario', count: 1, latlng: '43.035556,-81.153889'}
+- {airport: Victoria, count: 2, latlng: '48.646944,-123.425833'}
+- {airport: Toronto, count: 11, latlng: '43.677222,-79.630556'}
+- {airport: Zhongchuan, count: 1, latlng: '36.516667,103.621667'}
+badges:
+  creator:
+  - {name: John Blischak, user: blischak.j}
+  - {name: Jennifer Bryan, user: bryan.j}
+  - {name: Stephen Crouch, user: crouch.s}
+  - {name: Matt Davis, user: davis.m}
+  - {name: Tommy Guy, user: guy.t}
+  - {name: Michael Hansen, user: hansen.m}
+  - {name: Katy Huff, user: huff.k}
+  - {name: Mike Jackson, user: jackson.m}
+  - {name: Jason Montojo, user: montojo.j}
+  - {name: Jon Pipitone, user: pipitone.j}
+  - {name: Anthony Scopatz, user: scopatz.a}
+  - {name: Will Trimble, user: trimble.will}
+  - {name: Ethan White, user: white.e}
+  - {name: Greg Wilson, user: wilson.g}
+  instructor:
+  - {name: Joshua Adelman, user: adelman.joshua}
+  - {name: Aron Ahmadia, user: ahmadia.a}
+  - {name: Matthew Aiello-Lammens, user: aiello-lammens.matthew}
+  - {name: Joshua Ainsley, user: ainsley.joshua}
+  - {name: Russell Alleen-Willems, user: alleen-willems.russell}
+  - {name: James Allen, user: allen.james}
+  - {name: Pete Alonzi, user: alonzi.pete}
+  - {name: Carlos Anderson, user: anderson.c}
+  - {name: Catalina Anghel, user: anghel.catalina}
+  - {name: Mario Antonioletti, user: antonioletti.mario}
+  - {name: Dhavide Aruliah, user: aruliah.d}
+  - {name: Camille Avestruz, user: avestruz.camille}
+  - {name: Christie Bahlai, user: bahlai.christie}
+  - {name: Piotr Banaszkiewicz, user: banaszkiewicz.piotr}
+  - {name: Pauline Barmby, user: barmby.pauline}
+  - {name: Diego Barneche, user: barneche.diego}
+  - {name: Kathryn Barrett, user: barrett.kathryn}
+  - {name: Radovan Bast, user: bast.radovan}
+  - {name: Dana Bauer, user: bauer.dana}
+  - {name: Philipp Bayer, user: bayer.p}
+  - {name: Robert Beagrie, user: beagrie.robert}
+  - {name: Trevor Bekolay, user: bekolay.trevor}
+  - {name: Nichole Bennett, user: bennett.n}
+  - {name: Miguel Bernabeu, user: bernabeu.miguel}
+  - {name: Lukas Blakk, user: blakk.lukas}
+  - {name: John Blischak, user: blischak.j}
+  - {name: Carl Boettiger, user: boettiger.carl}
+  - {name: Jessica Bonnie, user: bonnie.jessica}
+  - {name: Darren Boss, user: boss.darren}
+  - {name: Azalee Bostroem, user: bostroem.a}
+  - {name: Erik Bray, user: bray.e}
+  - {name: C. Titus Brown, user: brown.ct}
+  - {name: Jennifer Bryan, user: bryan.j}
+  - {name: Scott Burns, user: burns.scott}
+  - {name: Abigail Cabunoc, user: cabunoc.abigail}
+  - {name: Jared Camins-Esakov, user: camins-esakov.jared}
+  - {name: Rosangela Canino-Koning, user: canino-koning.r}
+  - {name: Chris Cannam, user: cannam.c}
+  - {name: Greg Caporaso, user: caporaso.greg}
+  - {name: Timothy Cerino, user: cerino.t}
+  - {name: Scott Chamberlain, user: chamberlain.s}
+  - {name: Cliburn Chan, user: chan.cliburn}
+  - {name: Daniel Chen, user: chen.daniel}
+  - {name: Chelsea Chisholm, user: chisholm.chelsea}
+  - {name: Shreyas Cholia, user: cholia.s}
+  - {name: Adina Chuang Howe, user: chuang-howe.a}
+  - {name: Neil Chue Hong, user: chue-hong.n}
+  - {name: Luis Pedro Coelho, user: coelho.luis}
+  - {name: Ruth Collings, user: collings.ruth}
+  - {name: John Corless, user: corless.john}
+  - {name: Marianne Corvellec, user: corvellec.marianne}
+  - {name: Logan Cox, user: cox.logan}
+  - {name: Stefano Cozzini, user: cozzini.s}
+  - {name: Karen Cranston, user: cranston.k}
+  - {name: Stephen Crouch, user: crouch.s}
+  - {name: Michael Crusoe, user: crusoe.michael}
+  - {name: Maciej Czuchry, user: czuchry.maciej}
+  - {name: Emily Davenport, user: davenport.e}
+  - {name: Rob Davey, user: davey.rob}
+  - {name: Matt Davis, user: davis.m}
+  - {name: Neal Davis, user: davis.neal}
+  - {name: Balamurugan Desinghu, user: desinghu.balamurugan}
+  - {name: Gabriel A. Devenyi, user: devenyi.gabriel}
+  - {name: Ross Dickson, user: dickson.r}
+  - {name: Matthew Dimmock, user: dimmock.matt}
+  - {name: Jonah Duckles, user: duckles.jonah}
+  - {name: Martin Durant, user: durant.martin}
+  - {name: Jonathan Dursi, user: dursi.j}
+  - {name: Dureid El-Moghraby, user: el-moghraby.dureid}
+  - {name: Justin Ely, user: ely.j}
+  - {name: Remi Emonet, user: emonet.remi}
+  - {name: Richard Enbody, user: enbody.r}
+  - {name: Aaron Erlich, user: erlich.aaron}
+  - {name: Daniel Falster, user: falster.daniel}
+  - {name: Xu Fei, user: fei.xu}
+  - {name: Luis Figueira, user: figueira.l}
+  - {name: Jordan Fish, user: fish.jordan}
+  - {name: Rich FitzJohn, user: fitzjohn.rich}
+  - {name: Robert Flight, user: flight.r}
+  - {name: John Fonner, user: fonner.john}
+  - {name: Philip Fowler, user: fowler.p}
+  - {name: Philip Fowler, user: fowler.philip}
+  - {name: Jonathan Frederic, user: frederic.jonathan}
+  - {name: Chris Friedline, user: friedline.chris}
+  - {name: Zhuo Fu, user: fu.zhuo}
+  - {name: Emilia Gan, user: gan.emilia}
+  - {name: Leonor Garcia-Gutierrez, user: garcia-gutierrez.leonor}
+  - {name: Julian Garcia, user: garcia.julian}
+  - {name: Aaron Garoutte, user: garoutte.aaron}
+  - {name: Chris Gates, user: gates.chris}
+  - {name: Laurent Gatto, user: gatto.laurent}
+  - {name: Molly Gibson, user: gibson.molly}
+  - {name: Ivan Gonzalez, user: gonzalez.ivan}
+  - {name: Gerard Gorman, user: gorman.gerard}
+  - {name: John Gosset, user: gosset.john}
+  - {name: Alistair Grant, user: grant.alistair}
+  - {name: Jonathan Gross, user: gross.jonathan}
+  - {name: Thomas Guignard, user: guignard.thomas}
+  - {name: Jiarong Guo, user: guo.jiarong}
+  - {name: Julia Gustavsen, user: gustavsen.j}
+  - {name: Tommy Guy, user: guy.t}
+  - {name: Jonathan Guyer, user: guyer.jonathan}
+  - {name: Steve Haddock, user: haddock.s}
+  - {name: Denis Haine, user: haine.denis}
+  - {name: Jessica Hamrick, user: hamrick.jessica}
+  - {name: Michael Hansen, user: hansen.m}
+  - {name: Anthony Harrison, user: harrison.anthony}
+  - {name: Ted Hart, user: hart.t}
+  - {name: Ian Hawke, user: hawke.ian}
+  - {name: Ian Henry, user: henry.ian}
+  - {name: Joshua Herr, user: herr.joshua}
+  - {name: Kate Hertweck, user: hertweck.kate}
+  - {name: James Hetherington, user: hetherington.james}
+  - {name: James Hiebert, user: hiebert.james}
+  - {name: Cody Hinchliff, user: hinchliff.cody}
+  - {name: Konrad Hinsen, user: hinsen.k}
+  - {name: Daniel Hocking, user: hocking.daniel}
+  - {name: Chris Holdgraf, user: holdgraf.c}
+  - {name: Jeff Hollister, user: hollister.jeff}
+  - {name: Daisie Huang, user: huang.daisie}
+  - {name: Katy Huff, user: huff.k}
+  - {name: Devasena Inupakutika, user: inupakutika.devasena}
+  - {name: Luiz Irber, user: irber.luiz}
+  - {name: Damien Irving, user: irving.d}
+  - {name: Paul Ivanov, user: ivanov.p}
+  - {name: Mike Jackson, user: jackson.m}
+  - {name: Christian Jacobs, user: jacobs.christian}
+  - {name: Zbigniew Jedrzejewski-Szmek, user: jedrzejewski-szmek.zbigniew}
+  - {name: David Jones, user: jones.d}
+  - {name: David Jones, user: jones.dm}
+  - {name: Jessica Kerr, user: kerr.j}
+  - {name: Jan Kim, user: kim.jan}
+  - {name: W. Trevor King, user: king.wt}
+  - {name: Ted Kirkpatrick, user: kirkpatrick.ted}
+  - {name: Justin Kitzes, user: kitzes.j}
+  - {name: Christina Koch, user: koch.christina}
+  - {name: Steven Koenig, user: koenig.steven}
+  - {name: Alexander Koeppel, user: koeppel.alexander}
+  - {name: Bernhard Konrad, user: konrad.b}
+  - {name: Igor Kozlov, user: kozlov.igor}
+  - {name: Paulina Lach, user: lach.paulina}
+  - {name: Olivier Lafleur, user: lafleur.olivier}
+  - {name: Isabelle Laforest-Lapointe, user: laforest-lapointe.isabelle}
+  - {name: Karin Lagesen, user: lagesen.k}
+  - {name: Sherry Lake, user: lake.sherry}
+  - {name: Ian Langmore, user: langmore.i}
+  - {name: Jeremiah Lant, user: lant.jeremiah}
+  - {name: Chris Lasher, user: lasher.c}
+  - {name: Doug Latornell, user: latornell.d}
+  - {name: David LeBauer, user: lebauer.david}
+  - {name: Kate Lee, user: lee.kate}
+  - {name: Luke Lee, user: lee.luke}
+  - {name: Jacob Levernier, user: levernier.jacob}
+  - {name: JC Leyder, user: leyder.jean-christophe}
+  - {name: Matthew Lightman, user: lightman.matthew}
+  - {name: Johnny Lin, user: lin.johnny}
+  - {name: Elijah Lowe, user: lowe.elijah}
+  - {name: Yuxi Luo, user: luo.yuxi}
+  - {name: Cam Macdonell, user: macdonell.cam}
+  - {name: Gary Macindoe, user: macindoe.gary}
+  - {name: Dan MacLean, user: maclean.dan}
+  - {name: Steve McGough, user: mcgough.s}
+  - {name: Catherine McGoveran, user: mcgoveran.catherine}
+  - {name: Sheldon McKay, user: mckay.sheldon}
+  - {name: Jessica McKellar, user: mckellar.j}
+  - {name: Maria McKinley, user: mckinley.maria}
+  - {name: Emily Jane McTavish, user: mctavish.ej}
+  - {name: Lauren Michael, user: michael.lauren}
+  - {name: Simon Michnowicz, user: michnowicz.s}
+  - {name: Francois Michonneau, user: michonneau.francois}
+  - {name: Brian Miles, user: miles.brian}
+  - {name: Bill Mills, user: mills.b}
+  - {name: Ian Mitchell, user: mitchell.i}
+  - {name: Ben Morris, user: morris.b}
+  - {name: Erika Mudrak, user: mudrak.erika}
+  - {name: Ian Munoz, user: munoz.ian}
+  - {name: R. David Murray, user: murray.david}
+  - {name: Lex Nederbragt, user: nederbragt.l}
+  - {name: Aleksandra Nenadic, user: nenadic.aleksandra}
+  - {name: Jens Hedegaard Nielsen, user: nielsen.jens}
+  - {name: Klemens Noga, user: noga.klemens}
+  - {name: Brenna O'Brien, user: obrien.brenna}
+  - {name: Alan O'Cais, user: ocais.alan}
+  - {name: Aaron O'Leary, user: oleary.aaron}
+  - {name: Randy Olson, user: olson.r}
+  - {name: Jeramia Ory, user: ory.j}
+  - {name: Geoff Oxberry, user: oxberry.g}
+  - {name: Kirill Palamartchouk, user: palamartchouk.k}
+  - {name: Aleksandra Pawlik, user: pawlik.a}
+  - {name: John Pearson, user: pearson.john}
+  - {name: Jason Pell, user: pell.j}
+  - {name: David Perez-Suarez, user: perez-suarez.david}
+  - {name: Fernando Perez, user: perez.f}
+  - {name: Mariela Perignon, user: perignon.mariela}
+  - {name: Stefan Pfenninger, user: pfenninger.s}
+  - {name: Timothee Poisot, user: poisot.t}
+  - {name: Tom Pollard, user: pollard.tom}
+  - {name: Likit Preeyanon, user: preeyanon.likit}
+  - {name: Francoise Provencher, user: provencher.francoise}
+  - {name: Karthik Ram, user: ram.k}
+  - {name: Saravanan Ramalingam, user: ramalingam.saravanan}
+  - {name: Janet Riley, user: riley.janet}
+  - {name: David Rio, user: rio.david}
+  - {name: Scott Ritchie, user: ritchie.scott}
+  - {name: James Robinson, user: robinson.james}
+  - {name: Natalie Robinson, user: robinson.natalie}
+  - {name: Rosario Robinson, user: robinson.rosario}
+  - {name: Ariel Rokem, user: rokem.a}
+  - {name: Billy Rowell, user: rowell.bill}
+  - {name: Dale Russell, user: russell.dale}
+  - {name: Maneesha Sane, user: sane.maneesha}
+  - {name: Martin Schilling, user: schilling.martin}
+  - {name: Jorden Schossau, user: schossau.j}
+  - {name: Anthony Scopatz, user: scopatz.a}
+  - {name: Michael Selik, user: selik.m}
+  - {name: Neem Serra, user: serra.neem}
+  - {name: Brent Shambaugh, user: shambaugh.brent}
+  - {name: Jeffrey Shelton, user: shelton.j}
+  - {name: Jennifer Shelton, user: shelton.jennifer}
+  - {name: Leigh Sheneman, user: sheneman.leigh}
+  - {name: Yu-Ching Shih, user: shih.yu-ching}
+  - {name: Raniere Silva, user: silva.raniere}
+  - {name: Sarah Simpkin, user: simpkin.sarah}
+  - {name: Rachel Slaybaugh, user: slaybaugh.rachel}
+  - {name: Clare Sloggett, user: sloggett.clare}
+  - {name: Daniel Smith, user: smith.daniel}
+  - {name: Joshua Smith, user: smith.j}
+  - {name: Mike Smorul, user: smorul.mike}
+  - {name: Ashwin Trikuta Srinath, user: srinath.ashwin}
+  - {name: Margaret Staton, user: staton.margaret}
+  - {name: Peter Steinbach, user: steinbach.peter}
+  - {name: Mark Stillwell, user: stillwell.mark}
+  - {name: Jonathan Strootman, user: strootman.jonathan}
+  - {name: Shoaib Sufi, user: sufi.s}
+  - {name: Sarah Supp, user: supp.s}
+  - {name: 'Svaksha ', user: svaksha}
+  - {name: Gayathri Swaminathan, user: swaminathan.gayathri}
+  - {name: Bradley Taber-Thomas, user: taber-thomas.bradley}
+  - {name: Scott Talafuse, user: talafuse.scott}
+  - {name: Leszek Tarkowski, user: tarkowski.leszek}
+  - {name: Tracy Teal, user: teal.t}
+  - {name: Matt Terry, user: terry.m}
+  - {name: Andrew Teucher, user: teucher.andrew}
+  - {name: Robert Till, user: till.robert}
+  - {name: Will Trimble, user: trimble.will}
+  - {name: Stephen Turner, user: turner.s}
+  - {name: Olav Vahtras, user: vahtras.olav}
+  - {name: Roman Valls Guimera, user: valls-guimera.roman}
+  - {name: Vicky Varga, user: varga.vicky}
+  - {name: Nelle Varoquaux, user: varoquaux.n}
+  - {name: Bogdan Vera, user: vera.b}
+  - {name: Alex Viana, user: viana.a}
+  - {name: Jens von der Linden, user: vonderlinden.jens}
+  - {name: Andrew Walker, user: walker.andrew}
+  - {name: Dan Warren, user: warren.dan}
+  - {name: Leah Wasser, user: wasser.leah}
+  - {name: Ben Waugh, user: waugh.b}
+  - {name: Ethan White, user: white.e}
+  - {name: Easton White, user: white.easton}
+  - {name: Amanda Whitlock, user: whitlock.a}
+  - {name: Asela Wijeratne, user: wijeratne.asela}
+  - {name: Mark Wilber, user: wilber.mark}
+  - {name: Chandler Wilkerson, user: wilkerson.chandler}
+  - {name: Jason Williams, user: williams.jason}
+  - {name: Lynne Williams, user: williams.l}
+  - {name: Ryan Williams, user: williams.ryan}
+  - {name: Greg Wilson, user: wilson.g}
+  - {name: Kara Woo, user: woo.kara}
+  - {name: Christopher Woods, user: woods.c}
+  - {name: April Wright, user: wright.april}
+  - {name: Thomas Wright, user: wright.thomas}
+  - {name: Fan Yang, user: yang.fan}
+  - {name: Qingpeng Zhang, user: zhang.qp}
+  - {name: Naupaka Zimmerman, user: zimmerman.naupaka}
+  - {name: Tiziano Zito, user: zito.t}
+  - {name: Andrea Zonca, user: zonca.andrea}
+  organizer:
+  - {name: Jorge Aranda, user: aranda.j}
+  - {name: Clair Barrass, user: barrass.clair}
+  - {name: Casey Bergman, user: bergman.c}
+  - {name: Bruce Berriman, user: berriman.b}
+  - {name: Azalee Bostroem, user: bostroem.a}
+  - {name: Onno Broekmans, user: broekmans.o}
+  - {name: Amy Brown, user: brown.amy}
+  - {name: C. Titus Brown, user: brown.ct}
+  - {name: Simon Burbidge, user: burbidge.simon}
+  - {name: Alex Chartier, user: chartier.a}
+  - {name: Shreyas Cholia, user: cholia.s}
+  - {name: Stefano Cozzini, user: cozzini.s}
+  - {name: Matt Davis, user: davis.m}
+  - {name: Ross Dickson, user: dickson.r}
+  - {name: Jonah Duckles, user: duckles.jonah}
+  - {name: Dan Ellis, user: ellis.dan}
+  - {name: Valerie Evans, user: evans.valerie}
+  - {name: Philip Fowler, user: fowler.p}
+  - {name: Elise Glen, user: glen.e}
+  - {name: Carole Goble, user: goble.c}
+  - {name: Chris Gray, user: gray.c}
+  - {name: Norman Gray, user: gray.n}
+  - {name: David Henty, user: henty.d}
+  - {name: James Hetherington, user: hetherington.james}
+  - {name: Bill Howe, user: howe.b}
+  - {name: Katy Huff, user: huff.k}
+  - {name: Catherine Inglis, user: inglis.catherine}
+  - {name: Mike Jackson, user: jackson.m}
+  - {name: Bernhard Konrad, user: konrad.b}
+  - {name: Nic Kooyers, user: kooyers.n}
+  - {name: Ian Langmore, user: langmore.i}
+  - {name: Paul Lu, user: lu.p}
+  - {name: Andrew Lumsdaine, user: lumsdaine.a}
+  - {name: Joshua Madin, user: madin.j}
+  - {name: Avril Manners, user: manners.avril}
+  - {name: Damian Marchewka, user: marchewka.damian}
+  - {name: Ian Mitchell, user: mitchell.i}
+  - {name: Jason Montojo, user: montojo.j}
+  - {name: Lex Nederbragt, user: nederbragt.l}
+  - {name: Miguel Oliveira, user: oliveira.miguel}
+  - {name: Randy Olson, user: olson.r}
+  - {name: Chris Paciorek, user: paciorek.c}
+  - {name: Konrad Paszkiewicz, user: paszkiewicz.konrad}
+  - {name: Marian Petre, user: petre.m}
+  - {name: Jon Pipitone, user: pipitone.j}
+  - {name: Mark Plumbley, user: plumbley.m}
+  - {name: Michael Rezny, user: rezny.m}
+  - {name: Ariel Rokem, user: rokem.a}
+  - {name: Jorden Schossau, user: schossau.j}
+  - {name: Rachel Schutt, user: schutt.r}
+  - {name: Anthony Scopatz, user: scopatz.a}
+  - {name: Jeffrey Shelton, user: shelton.j}
+  - {name: Andrew Su, user: su.a}
+  - {name: Tracy Teal, user: teal.t}
+  - {name: Luke Tweddle, user: tweddle.l}
+  - {name: Todd Vision, user: vision.t}
+  - {name: Andrew Walker, user: walker.a}
+  - {name: Ben Waugh, user: waugh.b}
+  - {name: Ethan White, user: white.e}
+  - {name: Greg Wilson, user: wilson.g}
+  - {name: Paul Wilson, user: wilson.p}
+  - {name: Robin Wilson, user: wilson.r}
+  - {name: David Wolever, user: wolever.d}
+blog:
+- &id023
+  author: Greg Wilson
+  category: [Python Software Foundation]
+  date: 2004-12-30
+  favorite: null
+  folder: blog/2004/12
+  layout: blog
+  path: blog/2004/12/python-software-foundation-grant.html
+  time: 09:00:00
+  title: Python Software Foundation Grant
+- &id024
+  author: Greg Wilson
+  category: [Content]
+  date: 2005-07-08
+  favorite: null
+  folder: blog/2005/07
+  layout: blog
+  path: blog/2005/07/software-carpentry-notes-are-up.html
+  time: 09:00:00
+  title: Software Carpentry notes are up
+- &id025
+  author: Greg Wilson
+  category: [Community]
+  date: 2005-07-29
+  favorite: null
+  folder: blog/2005/07
+  layout: blog
+  path: blog/2005/07/software-carpentry-course-in-nature.html
+  time: 09:00:00
+  title: Software Carpentry course in Nature
+- &id026
+  author: Greg Wilson
+  category: [Indiana University]
+  date: 2005-08-22
+  favorite: null
+  folder: blog/2005/08
+  layout: blog
+  path: blog/2005/08/software-carpentry-at-indiana-university.html
+  time: 09:00:00
+  title: Software Carpentry at Indiana University
+- &id027
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2005-09-14
+  favorite: null
+  folder: blog/2005/09
+  layout: blog
+  path: blog/2005/09/software-carpentry-first-meeting.html
+  time: 09:00:00
+  title: 'Software Carpentry: First Meeting'
+- &id028
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2005-09-20
+  favorite: null
+  folder: blog/2005/09
+  layout: blog
+  path: blog/2005/09/day-9.html
+  time: 09:00:00
+  title: Day 9
+- &id029
+  author: Greg Wilson
+  category: [Community, Community, EBI Cambridge]
+  date: 2005-09-21
+  favorite: null
+  folder: blog/2005/09
+  layout: blog
+  path: blog/2005/09/software-carpentry-at-the-aaas.html
+  time: 09:00:00
+  title: Software Carpentry at the AAAS
+- &id030
+  author: Greg Wilson
+  category: [Community]
+  date: 2005-11-04
+  favorite: null
+  folder: blog/2005/11
+  layout: blog
+  path: blog/2005/11/workshop-at-aaas-06.html
+  time: 09:00:00
+  title: Workshop at AAAS '06
+- &id031
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2005-12-08
+  favorite: null
+  folder: blog/2005/12
+  layout: blog
+  path: blog/2005/12/executive-version-of-software-carpentry-course.html
+  time: 09:00:00
+  title: Executive Version of Software Carpentry Course
+- &id032
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2005-12-09
+  favorite: null
+  folder: blog/2005/12
+  layout: blog
+  path: blog/2005/12/american-scientist-article-on-software-carpentry.html
+  time: 09:00:00
+  title: American Scientist article on Software Carpentry
+- &id033
+  author: Greg Wilson
+  category: [Content]
+  date: 2005-12-11
+  favorite: null
+  folder: blog/2005/12
+  layout: blog
+  path: blog/2005/12/maintaining-correctness.html
+  time: 09:00:00
+  title: Maintaining Correctness
+- &id034
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2005-12-23
+  favorite: null
+  folder: blog/2005/12
+  layout: blog
+  path: blog/2005/12/procrastination-one-of-the-few-things-in-life-nicer-than-toast.html
+  time: 09:00:00
+  title: 'Procrastination: One of the Few Things in Life Nicer Than Toast'
+- &id035
+  author: Greg Wilson
+  category: [Content]
+  date: 2005-12-27
+  favorite: null
+  folder: blog/2005/12
+  layout: blog
+  path: blog/2005/12/new-years-schedule-for-software-carpentry.html
+  time: 09:00:00
+  title: New Year's Schedule for Software Carpentry
+- &id036
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2005-12-28
+  favorite: null
+  folder: blog/2005/12
+  layout: blog
+  path: blog/2005/12/67-million-a-year.html
+  time: 09:00:00
+  title: $67 million a year
+- &id037
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-02
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/software-carpentry-introduction-revised-and-on-the-web.html
+  time: 09:00:00
+  title: Software Carpentry Introduction revised and on the web
+- &id038
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-04
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/first-shell-lecture-for-software-carpentry-is-up.html
+  time: 09:00:00
+  title: First Shell Lecture for Software Carpentry is Up
+- &id039
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-09
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/two-more-revised-software-carpentry-lectures.html
+  time: 09:00:00
+  title: Two More Revised Software Carpentry Lectures
+- &id040
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-11
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/build-lecture-is-up.html
+  time: 09:00:00
+  title: Build Lecture Is Up
+- &id041
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-15
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/intro-python-lecture-available.html
+  time: 09:00:00
+  title: Intro Python Lecture Available
+- &id042
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-18
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/second-python-lecture-now-on-the-web.html
+  time: 09:00:00
+  title: Second Python Lecture Now on the Web
+- &id043
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-23
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/third-software-carpentry-python-lecture-on-the-web.html
+  time: 36000
+  title: Third Software Carpentry Python Lecture on the Web
+- &id044
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-23
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/programming-style-lecture-has-been-revised.html
+  time: 09:00:00
+  title: Programming Style Lecture Has Been Revised
+- &id045
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-24
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/quality-assurance-lecture-now-available.html
+  time: 09:00:00
+  title: Quality Assurance Lecture Now Available
+- &id046
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-01-29
+  favorite: null
+  folder: blog/2006/01
+  layout: blog
+  path: blog/2006/01/fourth-python-lecture-for-software-carpentry.html
+  time: 09:00:00
+  title: Fourth Python Lecture for Software Carpentry
+- &id047
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-02
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/debugging-lecture.html
+  time: 09:00:00
+  title: Debugging Lecture
+- &id048
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-06
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/first-lecture-on-object-oriented-programming-is-up.html
+  time: 09:00:00
+  title: First Lecture on Object-Oriented Programming Is Up
+- &id049
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-10
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/software-carpentry-design-lecture.html
+  time: 09:00:00
+  title: Software Carpentry Design Lecture
+- &id050
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-12
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/regular-expressions-lecture-is-up.html
+  time: 09:00:00
+  title: Regular Expressions Lecture is Up
+- &id051
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-14
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/lecture-on-binary-data.html
+  time: 36000
+  title: Lecture on Binary Data
+- &id052
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-14
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/data-lineage.html
+  time: 09:00:00
+  title: Data Lineage
+- &id053
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-02-20
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/aaas-annual-meeting-2006.html
+  time: 09:00:00
+  title: AAAS Annual Meeting 2006
+- &id054
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-21
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/what-else-for-software-carpentry.html
+  time: 36000
+  title: What Else for Software Carpentry?
+- &id055
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-21
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/second-lecture-on-object-oriented-programming.html
+  time: 09:00:00
+  title: Second Lecture on Object-Oriented Programming
+- &id056
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-22
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/second-lecture-on-testing-now-online.html
+  time: 09:00:00
+  title: Second Lecture on Testing Now Online
+- &id057
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-02-23
+  favorite: null
+  folder: blog/2006/02
+  layout: blog
+  path: blog/2006/02/database-lecture-is-up.html
+  time: 09:00:00
+  title: Database Lecture is Up
+- &id058
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-03-02
+  favorite: null
+  folder: blog/2006/03
+  layout: blog
+  path: blog/2006/03/last-two-lectures-are-up.html
+  time: 09:00:00
+  title: Last Two Lectures Are Up
+- &id059
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-03-03
+  favorite: null
+  folder: blog/2006/03
+  layout: blog
+  path: blog/2006/03/client-side-web-programming-lecture.html
+  time: 09:00:00
+  title: Client-Side Web Programming Lecture
+- &id060
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-03-06
+  favorite: null
+  folder: blog/2006/03
+  layout: blog
+  path: blog/2006/03/web-server-programming-lecture-is-up.html
+  time: 09:00:00
+  title: Web Server Programming Lecture Is Up
+- &id061
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2006-03-26
+  favorite: null
+  folder: blog/2006/03
+  layout: blog
+  path: blog/2006/03/2020-hype.html
+  time: 09:00:00
+  title: 2020 Hype
+- &id062
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-04-04
+  favorite: null
+  folder: blog/2006/04
+  layout: blog
+  path: blog/2006/04/integration-and-xml-lectures.html
+  time: 09:00:00
+  title: Integration and XML Lectures
+- &id063
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-04-05
+  favorite: null
+  folder: blog/2006/04
+  layout: blog
+  path: blog/2006/04/new-security-lecture-up.html
+  time: 09:00:00
+  title: New Security Lecture Up
+- &id064
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-04-09
+  favorite: null
+  folder: blog/2006/04
+  layout: blog
+  path: blog/2006/04/341-words.html
+  time: 09:00:00
+  title: 341 Words
+- &id065
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-04-17
+  favorite: null
+  folder: blog/2006/04
+  layout: blog
+  path: blog/2006/04/zipfs-law-of-feedback.html
+  time: 09:00:00
+  title: Zipf's Law of Feedback
+- &id066
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-04-28
+  favorite: null
+  folder: blog/2006/04
+  layout: blog
+  path: blog/2006/04/corrections-done.html
+  time: 09:00:00
+  title: Corrections Done
+- &id067
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-05-03
+  favorite: null
+  folder: blog/2006/05
+  layout: blog
+  path: blog/2006/05/software-carpentry-1111.html
+  time: 09:00:00
+  title: Software Carpentry 1111
+- &id068
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-05-05
+  favorite: null
+  folder: blog/2006/05
+  layout: blog
+  path: blog/2006/05/revised-lecture-on-teamware.html
+  time: 09:00:00
+  title: Revised Lecture on Teamware
+- &id069
+  author: Greg Wilson
+  category: [Enthought]
+  date: 2006-06-25
+  favorite: null
+  folder: blog/2006/06
+  layout: blog
+  path: blog/2006/06/software-carpentrys-new-home.html
+  time: 09:00:00
+  title: Software Carpentry's new home
+- &id070
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-07-14
+  favorite: null
+  folder: blog/2006/07
+  layout: blog
+  path: blog/2006/07/software-carpentry-20.html
+  time: 09:00:00
+  title: Software Carpentry 3.0
+- &id071
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-07-20
+  favorite: null
+  folder: blog/2006/07
+  layout: blog
+  path: blog/2006/07/the-parallel-tools-platform.html
+  time: 09:00:00
+  title: The Parallel Tools Platform
+- &id072
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-07-30
+  favorite: null
+  folder: blog/2006/07
+  layout: blog
+  path: blog/2006/07/design-patterns-in-scientific-software.html
+  time: 09:00:00
+  title: Design Patterns in Scientific Software
+- &id073
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-08-04
+  favorite: null
+  folder: blog/2006/08
+  layout: blog
+  path: blog/2006/08/hpcwire-interview-on-software-carpentry.html
+  time: 09:00:00
+  title: HPCWire Interview on Software Carpentry
+- &id074
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-08-16
+  favorite: null
+  folder: blog/2006/08
+  layout: blog
+  path: blog/2006/08/scipy-and-software-carpentry.html
+  time: 09:00:00
+  title: SciPy and Software Carpentry
+- &id075
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-08-17
+  favorite: null
+  folder: blog/2006/08
+  layout: blog
+  path: blog/2006/08/scipy06-first-morning.html
+  time: 36000
+  title: 'SciPy''06: First Morning'
+- &id076
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-08-17
+  favorite: null
+  folder: blog/2006/08
+  layout: blog
+  path: blog/2006/08/oh-my-god-its-django.html
+  time: 09:00:00
+  title: Oh My God It's Django!
+- &id077
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-10-26
+  favorite: null
+  folder: blog/2006/10
+  layout: blog
+  path: blog/2006/10/german-version-of-bottleneck.html
+  time: 09:00:00
+  title: German Version of 'Bottleneck'
+- &id078
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-10-31
+  favorite: null
+  folder: blog/2006/10
+  layout: blog
+  path: blog/2006/10/computational-result-retracted.html
+  time: 09:00:00
+  title: Computational Result Retracted
+- &id079
+  author: Greg Wilson
+  category: [Community, Enthought]
+  date: 2006-11-02
+  favorite: null
+  folder: blog/2006/11
+  layout: blog
+  path: blog/2006/11/software-carpentry-continues-to-grow.html
+  time: 09:00:00
+  title: Software Carpentry continues to grow
+- &id080
+  author: Greg Wilson
+  category: [Community]
+  date: 2006-11-28
+  favorite: null
+  folder: blog/2006/11
+  layout: blog
+  path: blog/2006/11/software-carpentry-article-in-cise.html
+  root: ../../..
+  time: 09:00:00
+  title: Software Carpentry article in CiSE
+- &id081
+  author: Greg Wilson
+  category: [Content]
+  date: 2006-12-05
+  favorite: null
+  folder: blog/2006/12
+  layout: blog
+  path: blog/2006/12/youtube-for-data.html
+  time: 09:00:00
+  title: YouTube for Data
+- &id082
+  author: Greg Wilson
+  category: [Community, Enthought]
+  date: 2007-01-18
+  favorite: null
+  folder: blog/2007/01
+  layout: blog
+  path: blog/2007/01/software-carpentry-usage-in-december.html
+  time: 09:00:00
+  title: Software Carpentry Usage in December
+- &id083
+  author: Greg Wilson
+  category: [Content]
+  date: 2007-02-07
+  favorite: null
+  folder: blog/2007/02
+  layout: blog
+  path: blog/2007/02/software-carpentry-screencasts.html
+  time: 09:00:00
+  title: Software Carpentry Screencasts
+- &id084
+  author: Greg Wilson
+  category: [Content]
+  date: 2007-03-10
+  favorite: null
+  folder: blog/2007/03
+  layout: blog
+  path: blog/2007/03/reproducibility-of-computational.html
+  time: 09:00:00
+  title: Reproducibility of Computational Results
+- &id085
+  author: Greg Wilson
+  category: [Community]
+  date: 2007-03-11
+  favorite: null
+  folder: blog/2007/03
+  layout: blog
+  path: blog/2007/03/scipy07-dates-announced.html
+  time: 09:00:00
+  title: SciPy'07 Dates Announced
+- &id086
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2007-03-19
+  favorite: null
+  folder: blog/2007/03
+  layout: blog
+  path: blog/2007/03/sign-error-five-papers-retracted.html
+  time: 09:00:00
+  title: 'Sign Error: Five Papers Retracted'
+- &id087
+  author: Greg Wilson
+  category: [Lawrence Livermore National Laboratory]
+  date: 2007-04-02
+  favorite: null
+  folder: blog/2007/04
+  layout: blog
+  path: blog/2007/04/titus-brown-teaching-software-carpentry.html
+  time: 09:00:00
+  title: Titus Brown Teaching Software Carpentry
+- &id088
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2007-05-05
+  favorite: null
+  folder: blog/2007/05
+  layout: blog
+  path: blog/2007/05/computational-scientists-still-dont-get-it.html
+  time: 09:00:00
+  title: Computational Scientists Still Don't Get It
+- &id089
+  author: Greg Wilson
+  category: [Content]
+  date: 2007-06-11
+  favorite: null
+  folder: blog/2007/06
+  layout: blog
+  path: blog/2007/06/praising-the-good.html
+  time: 09:00:00
+  title: Praising the Good
+- &id090
+  author: Greg Wilson
+  category: [Noticed, Research]
+  date: 2007-06-18
+  favorite: null
+  folder: blog/2007/06
+  layout: blog
+  path: blog/2007/06/nature-precedings.html
+  time: 09:00:00
+  title: Nature Precedings
+- &id091
+  author: Greg Wilson
+  category: [Content]
+  date: 2007-06-20
+  favorite: null
+  folder: blog/2007/06
+  layout: blog
+  path: blog/2007/06/software-carpentry-screencasts-by-chris-lasher.html
+  time: 36000
+  title: Software Carpentry Screencasts by Chris Lasher
+- &id092
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2007-06-20
+  favorite: null
+  folder: blog/2007/06
+  layout: blog
+  path: blog/2007/06/inspirational-videos.html
+  time: 09:00:00
+  title: Inspirational Videos
+- &id093
+  author: Greg Wilson
+  category: [Lawrence Livermore National Laboratory]
+  date: 2007-06-26
+  favorite: null
+  folder: blog/2007/06
+  layout: blog
+  path: blog/2007/06/software-carpentry-at-llnl.html
+  time: 09:00:00
+  title: Software Carpentry at LLNL
+- &id094
+  author: Greg Wilson
+  category: [Content, Research]
+  date: 2007-06-27
+  favorite: null
+  folder: blog/2007/06
+  layout: blog
+  path: blog/2007/06/two-studies-of-asci-and-no-thats-not-a-typo.html
+  time: 09:00:00
+  title: Two Studies of ASCI (and no, that's not a typo)
+- &id095
+  author: Greg Wilson
+  category: [University of California - San Diego]
+  date: 2007-07-04
+  favorite: null
+  folder: blog/2007/07
+  layout: blog
+  path: blog/2007/07/another-sighting-of-software-carpentry.html
+  time: 09:00:00
+  title: Another Sighting of Software Carpentry
+- &id096
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2007-07-05
+  favorite: null
+  folder: blog/2007/07
+  layout: blog
+  path: blog/2007/07/win-a-trip-to-reno.html
+  time: 09:00:00
+  title: Win a Trip to Reno!
+- &id097
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2007-07-18
+  favorite: null
+  folder: blog/2007/07
+  layout: blog
+  path: blog/2007/07/computational-education-for-scientists.html
+  time: 09:00:00
+  title: Computational Education for Scientists
+- &id098
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2007-07-31
+  favorite: null
+  folder: blog/2007/07
+  layout: blog
+  path: blog/2007/07/how-not-to-collaborate.html
+  time: 09:00:00
+  title: How Not to Collaborate
+- &id099
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2007-08-07
+  favorite: null
+  folder: blog/2007/08
+  layout: blog
+  path: blog/2007/08/how-im-doing.html
+  time: 09:00:00
+  title: How I'm Doing
+- &id100
+  author: Greg Wilson
+  category: [Community, Noticed, Research]
+  date: 2007-08-31
+  favorite: null
+  folder: blog/2007/08
+  layout: blog
+  path: blog/2007/08/random-survey-about-hpc.html
+  time: 09:00:00
+  title: Random Survey about HPC
+- &id101
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2007-09-05
+  favorite: null
+  folder: blog/2007/09
+  layout: blog
+  path: blog/2007/09/openness-and-the-promise-of-xml.html
+  time: 09:00:00
+  title: Openness and (the promise of) XML
+- &id102
+  author: Greg Wilson
+  category: [Bernstein Center - Berlin]
+  date: 2007-09-25
+  favorite: null
+  folder: blog/2007/09
+  layout: blog
+  path: blog/2007/09/another-sighting-of-software-carpentry-2.html
+  time: 09:00:00
+  title: Another Sighting of Software Carpentry
+- &id103
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2007-10-02
+  favorite: null
+  folder: blog/2007/10
+  layout: blog
+  path: blog/2007/10/doomed-to-repeat-it.html
+  time: 09:00:00
+  title: Doomed to Repeat It
+- &id104
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2007-10-26
+  favorite: null
+  folder: blog/2007/10
+  layout: blog
+  path: blog/2007/10/the-burning-man-of-hpc.html
+  time: 09:00:00
+  title: The Burning Man of HPC
+- &id105
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2007-12-09
+  favorite: null
+  folder: blog/2007/12
+  layout: blog
+  path: blog/2007/12/python-supercomputing-statistics.html
+  time: 09:00:00
+  title: Python Supercomputing Statistics
+- &id106
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2008-02-02
+  favorite: null
+  folder: blog/2008/02
+  layout: blog
+  path: blog/2008/02/scibarcamp-in-toronto-march-15-16.html
+  time: 09:00:00
+  title: SciBarCamp in Toronto March 15-16
+- &id107
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2008-02-14
+  favorite: null
+  folder: blog/2008/02
+  layout: blog
+  path: blog/2008/02/grumpy-minds-think-alike.html
+  time: 09:00:00
+  title: Grumpy Minds Think Alike
+- &id108
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-02-20
+  favorite: null
+  folder: blog/2008/02
+  layout: blog
+  path: blog/2008/02/oreilly-creating-a-web-version-of-mathematica.html
+  time: 09:00:00
+  title: O'Reilly Creating a Web Version of Mathematica
+- &id109
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2008-02-26
+  favorite: null
+  folder: blog/2008/02
+  layout: blog
+  path: blog/2008/02/scientific-groupware-revisited.html
+  time: 09:00:00
+  title: Scientific Groupware Revisited
+- &id110
+  author: Greg Wilson
+  category: [LearnHub]
+  date: 2008-03-06
+  favorite: null
+  folder: blog/2008/03
+  layout: blog
+  path: blog/2008/03/learnhub-launches-with-software-carpentry-front-and-center.html
+  time: 09:00:00
+  title: LearnHub Launches with Software Carpentry Front and Center
+- &id111
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2008-03-07
+  favorite: null
+  folder: blog/2008/03
+  layout: blog
+  path: blog/2008/03/survey-silent-errors-in-scientific-code.html
+  time: 09:00:00
+  title: 'Survey: Silent Errors in Scientific Code'
+- &id112
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2008-03-26
+  favorite: null
+  folder: blog/2008/03
+  layout: blog
+  path: blog/2008/03/nice-quote.html
+  time: 09:00:00
+  title: Nice Quote
+- &id113
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2008-03-31
+  favorite: null
+  folder: blog/2008/03
+  layout: blog
+  path: blog/2008/03/meet-the-new-flaw.html
+  time: 09:00:00
+  title: Meet the New Flaw
+- &id114
+  author: Greg Wilson
+  category: [Community, Content, Noticed]
+  date: 2008-04-02
+  favorite: null
+  folder: blog/2008/04
+  layout: blog
+  path: blog/2008/04/the-retractions-just-keep-coming-in.html
+  time: 36000
+  title: The Retractions Just Keep Coming In
+- &id115
+  author: Greg Wilson
+  category: [Content]
+  date: 2008-04-02
+  favorite: null
+  folder: blog/2008/04
+  layout: blog
+  path: blog/2008/04/summer-plans-for-software-carpentry.html
+  time: 09:00:00
+  title: Summer Plans for Software Carpentry
+- &id116
+  author: Greg Wilson
+  category: [Community, Opinion, Research]
+  date: 2008-04-10
+  favorite: null
+  folder: blog/2008/04
+  layout: blog
+  path: blog/2008/04/three-studies-maybe-four.html
+  time: 09:00:00
+  title: Three Studies (Maybe Four)
+- &id117
+  author: Greg Wilson
+  category: [Community, Opinion]
+  date: 2008-04-14
+  favorite: null
+  folder: blog/2008/04
+  layout: blog
+  path: blog/2008/04/spoc.html
+  time: 09:00:00
+  title: SPOC
+- &id118
+  author: Greg Wilson
+  category: [Community]
+  date: 2008-05-05
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/those-who-will-not-learn-from-history.html
+  time: 09:00:00
+  title: Those Who Will Not Learn From History...
+- &id119
+  author: Greg Wilson
+  category: [Community, Content, Research]
+  date: 2008-05-15
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/se-cse-workshop.html
+  time: 09:00:00
+  title: SE-CSE Workshop
+- &id120
+  author: Greg Wilson
+  category: [Community, Enthought, Opinion]
+  date: 2008-05-16
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/but-i-was-gone-less-than-48-hours.html
+  time: 09:00:00
+  title: But I Was Gone Less than 48 Hours!
+- &id121
+  author: Greg Wilson
+  category: [Community, Opinion]
+  date: 2008-05-21
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/why-dont-we-do-this.html
+  time: 09:00:00
+  title: Why Don't We Do This?
+- &id122
+  author: Greg Wilson
+  category: [Community]
+  date: 2008-05-25
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/interviewed-by-jon-udell.html
+  time: 09:00:00
+  title: Interviewed by Jon Udell
+- &id123
+  author: Greg Wilson
+  category: [Content]
+  date: 2008-05-27
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/reminded-of-the-difference-once-again.html
+  time: 09:00:00
+  title: Reminded of the Difference Once Again
+- &id124
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2008-05-30
+  favorite: null
+  folder: blog/2008/05
+  layout: blog
+  path: blog/2008/05/programming-and-scientific-education-on-slashdot.html
+  time: 09:00:00
+  title: Programming and Scientific Education on Slashdot
+- &id125
+  author: Greg Wilson
+  category: [MathWorks]
+  date: 2008-06-03
+  favorite: null
+  folder: blog/2008/06
+  layout: blog
+  path: blog/2008/06/three-weeks-and-change.html
+  time: 09:00:00
+  title: Three Weeks and Change
+- &id126
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2008-06-06
+  favorite: null
+  folder: blog/2008/06
+  layout: blog
+  path: blog/2008/06/faking-results.html
+  time: 09:00:00
+  title: Faking Results
+- &id127
+  author: Greg Wilson
+  category: [MathWorks]
+  date: 2008-06-13
+  favorite: null
+  folder: blog/2008/06
+  layout: blog
+  path: blog/2008/06/what-a-proposal-looks-like.html
+  time: 09:00:00
+  title: What a Proposal Looks Like
+- &id128
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-07-01
+  favorite: null
+  folder: blog/2008/07
+  layout: blog
+  path: blog/2008/07/kevins-been-busy.html
+  time: 09:00:00
+  title: Kevin's Been Busy
+- &id129
+  author: Greg Wilson
+  category: [Community]
+  date: 2008-07-19
+  favorite: null
+  folder: blog/2008/07
+  layout: blog
+  path: blog/2008/07/badge-of-honor.html
+  time: 09:00:00
+  title: Badge of Honor?
+- &id130
+  author: Greg Wilson
+  category: [Content]
+  date: 2008-07-22
+  favorite: null
+  folder: blog/2008/07
+  layout: blog
+  path: blog/2008/07/reviving-the-software-carpentry-mailing-list.html
+  time: 09:00:00
+  title: Reviving the Software Carpentry Mailing List
+- &id131
+  author: Greg Wilson
+  category: [Content, Research]
+  date: 2008-07-23
+  favorite: null
+  folder: blog/2008/07
+  layout: blog
+  path: blog/2008/07/quick-quiz-to-measure-what-scientists-know.html
+  time: 36000
+  title: Quick Quiz to Measure What Scientists Know
+- &id132
+  author: Greg Wilson
+  category: [Community, Noticed, Opinion]
+  date: 2008-07-23
+  favorite: null
+  folder: blog/2008/07
+  layout: blog
+  path: blog/2008/07/badge-of-reproducibility.html
+  time: 09:00:00
+  title: Badge of Reproducibility
+- &id133
+  author: Greg Wilson
+  category: [Content]
+  date: 2008-07-28
+  favorite: null
+  folder: blog/2008/07
+  layout: blog
+  path: blog/2008/07/next-lecture.html
+  time: 09:00:00
+  title: Next Lecture?
+- &id134
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2008-08-01
+  favorite: null
+  folder: blog/2008/08
+  layout: blog
+  path: blog/2008/08/theyre-breeding-like-rabbits.html
+  time: 09:00:00
+  title: They're Breeding Like Rabbits
+- &id135
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-08-11
+  favorite: null
+  folder: blog/2008/08
+  layout: blog
+  path: blog/2008/08/scifoo-egy-and-splitting.html
+  time: 09:00:00
+  title: SciFoo, eGY, and Splitting
+- &id136
+  author: Greg Wilson
+  category: [Community, Content, Noticed]
+  date: 2008-08-13
+  favorite: null
+  folder: blog/2008/08
+  layout: blog
+  path: blog/2008/08/data-provenance-challenge.html
+  time: 09:00:00
+  title: Data Provenance Challenge
+- &id137
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-08-22
+  favorite: null
+  folder: blog/2008/08
+  layout: blog
+  path: blog/2008/08/bil-lewis-works-with-biologists.html
+  time: 09:00:00
+  title: Bil Lewis Works With Biologists...
+- &id138
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2008-09-04
+  favorite: null
+  folder: blog/2008/09
+  layout: blog
+  path: blog/2008/09/science-20-the-future-of-online-tools-for-scientists.html
+  time: 09:00:00
+  title: 'Science 2.0: the Future of Online Tools for Scientists'
+- &id139
+  author: Greg Wilson
+  category: [Community, Opinion]
+  date: 2008-09-11
+  favorite: null
+  folder: blog/2008/09
+  layout: blog
+  path: blog/2008/09/science-in-the-21st-century.html
+  time: 09:00:00
+  title: Science in the 21st Century
+- &id140
+  author: Greg Wilson
+  category: [Community, Content, Research]
+  date: 2008-10-15
+  favorite: null
+  folder: blog/2008/10
+  layout: blog
+  path: blog/2008/10/surveying-scientists-use-of-computers.html
+  time: 09:00:00
+  title: Surveying Scientists' Use of Computers
+- &id141
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-10-27
+  favorite: null
+  folder: blog/2008/10
+  layout: blog
+  path: blog/2008/10/finding-and-re-using-open-scientific-resources.html
+  time: 09:00:00
+  title: Finding and Re-using Open Scientific Resources
+- &id142
+  author: Greg Wilson
+  category: [Community, Content, Research]
+  date: 2008-11-02
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/1731-people.html
+  time: 09:00:00
+  title: 1731 People
+- &id143
+  author: Greg Wilson
+  category: [Community, Content, MathWorks, Research]
+  date: 2008-11-04
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/one-good-survey-deserves-another.html
+  time: 09:00:00
+  title: One Good Survey Deserves Another
+- &id144
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2008-11-16
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/what-sciences-are-there.html
+  time: 09:00:00
+  title: What Sciences Are There?
+- &id145
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-11-17
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/science-lessons-for-mps.html
+  time: 09:00:00
+  title: Science Lessons for MPs
+- &id146
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-11-20
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/getting-the-science-right-or-at-least-less-wrong.html
+  time: 09:00:00
+  title: Getting the Science Right-Or At Least, Less Wrong
+- &id147
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2008-11-21
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/secse09-call-for-papers.html
+  time: 09:00:00
+  title: SECSE'09 Call for Papers
+- &id148
+  author: Greg Wilson
+  category: [Content]
+  date: 2008-11-30
+  favorite: null
+  folder: blog/2008/11
+  layout: blog
+  path: blog/2008/11/igor-connect-the-electrodes.html
+  time: 09:00:00
+  title: Igor, Connect the Electrodes!
+- &id149
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-12-10
+  favorite: null
+  folder: blog/2008/12
+  layout: blog
+  path: blog/2008/12/three-reasons-to-distrust-microarray-results.html
+  time: 09:00:00
+  title: Three Reasons to Distrust Microarray Results
+- &id150
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2008-12-19
+  favorite: null
+  folder: blog/2008/12
+  layout: blog
+  path: blog/2008/12/the-national-academy-would-like-to-hear-from-you.html
+  time: 36000
+  title: The National Academy Would Like to Hear From You
+- &id151
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2008-12-19
+  favorite: null
+  folder: blog/2008/12
+  layout: blog
+  path: blog/2008/12/google-pulls-the-plug-on-scientific-data-sharing-project.html
+  time: 09:00:00
+  title: Google Pulls the Plug on Scientific Data Sharing Project
+- &id152
+  author: Greg Wilson
+  category: [Community, Noticed, Opinion]
+  date: 2008-12-24
+  favorite: null
+  folder: blog/2008/12
+  layout: blog
+  path: blog/2008/12/a-healthy-dose-of-scepticism.html
+  time: 09:00:00
+  title: A Healthy Dose of Scepticism
+- &id153
+  author: Greg Wilson
+  category: [Community]
+  date: 2008-12-26
+  favorite: null
+  folder: blog/2008/12
+  layout: blog
+  path: blog/2008/12/articles-id-like-to-write-in-the-next-489-days.html
+  time: 09:00:00
+  title: Things I'd Like To Finish In the Next 489 Days
+- &id154
+  author: Greg Wilson
+  category: [Content]
+  date: 2008-12-31
+  favorite: null
+  folder: blog/2008/12
+  layout: blog
+  path: blog/2008/12/time-to-freshen-it-up.html
+  time: 09:00:00
+  title: Time to Freshen It Up
+- &id155
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-01-10
+  favorite: null
+  folder: blog/2009/01
+  layout: blog
+  path: blog/2009/01/i-want-to-be-a-number.html
+  time: 09:00:00
+  title: I *Want* To Be A Number
+- &id156
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-01-23
+  favorite: null
+  folder: blog/2009/01
+  layout: blog
+  path: blog/2009/01/a-new-kind-of-big-science.html
+  time: 09:00:00
+  title: A New Kind of Big Science
+- &id157
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2009-01-27
+  favorite: null
+  folder: blog/2009/01
+  layout: blog
+  path: blog/2009/01/web-native-lab-notebooks.html
+  time: 09:00:00
+  title: Web Native Lab Notebooks
+- &id158
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-01-30
+  favorite: null
+  folder: blog/2009/01
+  layout: blog
+  path: blog/2009/01/communicate-first-standardize-second.html
+  time: 09:00:00
+  title: Communicate First, Standardize Second
+- &id159
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2009-02-04
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/cameron-neylon-says-interesting-things.html
+  time: 09:00:00
+  title: Cameron Neylon Says Interesting Things
+- &id160
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2009-02-06
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/sharing-data-isnt-that-easy.html
+  time: 09:00:00
+  title: Sharing Data Isn't That Easy
+- &id161
+  author: Greg Wilson
+  category: [Community, Content, MathWorks, Noticed]
+  date: 2009-02-11
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/mtest.html
+  time: 36000
+  title: MTEST
+- &id162
+  author: Greg Wilson
+  category: [Community, Content, Noticed]
+  date: 2009-02-11
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/python-textbooks-for-biotech.html
+  time: 39600
+  title: Python Textbooks for Biotech
+- &id163
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-02-11
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/carl-zimmers-readers-reading-list.html
+  time: 09:00:00
+  title: Carl Zimmer's Readers' Reading List
+- &id164
+  author: Greg Wilson
+  category: [Community, Content, Noticed]
+  date: 2009-02-16
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/enough-players-to-hand-out-medals.html
+  time: 09:00:00
+  title: Enough Players to Hand Out Medals
+- &id165
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-02-18
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/open-science-panel-at-columbia.html
+  time: 36000
+  title: Open Science Panel at Columbia
+- &id166
+  author: Greg Wilson
+  category: [Content, Opinion]
+  date: 2009-02-18
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/computer-supported-collaborative-science.html
+  time: 09:00:00
+  title: Computer Supported Collaborative Science
+- &id167
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2009-02-23
+  favorite: null
+  folder: blog/2009/02
+  layout: blog
+  path: blog/2009/02/das-kapital-computational-thinking-and-productivity.html
+  time: 09:00:00
+  title: Das Kapital, Computational Thinking, and Productivity
+- &id168
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2009-03-02
+  favorite: null
+  folder: blog/2009/03
+  layout: blog
+  path: blog/2009/03/open-science-and-autisms-false-prophets.html
+  time: 09:00:00
+  title: Open Science and Autism's False Prophets
+- &id169
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2009-03-17
+  favorite: null
+  folder: blog/2009/03
+  layout: blog
+  path: blog/2009/03/legal-frameworks-for-reproducible-research.html
+  time: 09:00:00
+  title: Legal Frameworks for Reproducible Research
+- &id170
+  author: Greg Wilson
+  category: [Community]
+  date: 2009-03-25
+  favorite: null
+  folder: blog/2009/03
+  layout: blog
+  path: blog/2009/03/open-notebook-science-badges.html
+  time: 36000
+  title: Open Notebook Science Badges
+- &id171
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-03-25
+  favorite: null
+  folder: blog/2009/03
+  layout: blog
+  path: blog/2009/03/inference-for-r.html
+  time: 09:00:00
+  title: Inference for R
+- &id172
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-03-30
+  favorite: null
+  folder: blog/2009/03
+  layout: blog
+  path: blog/2009/03/user-stories.html
+  time: 09:00:00
+  title: User Stories
+- &id173
+  author: Greg Wilson
+  category: [MITACS, University of Toronto]
+  date: 2009-04-01
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/software-carpentry-in-toronto-july-13-31-2008.html
+  time: 09:00:00
+  title: Software Carpentry in Toronto July 13-31 2009
+- &id174
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-04-03
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/cameron-neylon-on-the-three-opens.html
+  time: 09:00:00
+  title: Cameron Neylon on the Three Opens
+- &id175
+  author: Greg Wilson
+  category: [Content, University of Alberta, University of Toronto]
+  date: 2009-04-08
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/weve-started-a-faq.html
+  time: 36000
+  title: We've Started a FAQ
+- &id176
+  author: Greg Wilson
+  category: [Cybera, University of Alberta]
+  date: 2009-04-08
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/software-carpentry-in-alberta.html
+  time: 09:00:00
+  title: Software Carpentry in Alberta
+- &id177
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-04-23
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/what-supervisors-need-to-know.html
+  time: 09:00:00
+  title: What Supervisors Need To Know
+- &id178
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-04-27
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/madagascar-course-in-delft-june-12-13.html
+  time: 36000
+  title: Madagascar Course in Delft June 12-13
+- &id179
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-04-27
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/firming-up-course-goals.html
+  time: 09:00:00
+  title: Firming Up Course Goals
+- &id180
+  author: Greg Wilson
+  category: [Community, Content, Opinion, Research]
+  date: 2009-04-28
+  favorite: null
+  folder: blog/2009/04
+  layout: blog
+  path: blog/2009/04/empirical-software-engineering-and-scientific-computing.html
+  time: 09:00:00
+  title: Empirical Software Engineering and Scientific Computing
+- &id181
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-05-01
+  favorite: null
+  folder: blog/2009/05
+  layout: blog
+  path: blog/2009/05/what-if-scientists-didnt-compete.html
+  time: 09:00:00
+  title: What If Scientists Didn't Compete?
+- &id182
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-05-04
+  favorite: null
+  folder: blog/2009/05
+  layout: blog
+  path: blog/2009/05/entrance-requirements.html
+  time: 09:00:00
+  title: Entrance Requirements
+- &id183
+  author: Greg Wilson
+  category: [Content, University of Alberta, University of Toronto]
+  date: 2009-05-06
+  favorite: null
+  folder: blog/2009/05
+  layout: blog
+  path: blog/2009/05/topics-and-schedule-posted.html
+  time: 09:00:00
+  title: Topics and Schedule Posted
+- &id184
+  author: Greg Wilson
+  category: [Community, Content, Research]
+  date: 2009-05-09
+  favorite: null
+  folder: blog/2009/05
+  layout: blog
+  path: blog/2009/05/how-scientists-use-computers-survey-part-2.html
+  time: 09:00:00
+  title: 'How Scientists Use Computers: Survey Part 2'
+- &id185
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-05-11
+  favorite: null
+  folder: blog/2009/05
+  layout: blog
+  path: blog/2009/05/links-for-summer-interns.html
+  time: 09:00:00
+  title: Links for Summer Interns
+- &id186
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-05-12
+  favorite: null
+  folder: blog/2009/05
+  layout: blog
+  path: blog/2009/05/error-handling.html
+  time: 09:00:00
+  title: Error Handling
+- &id187
+  author: Greg Wilson
+  category: [Community, Content, Noticed, Research]
+  date: 2009-06-01
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/secse-workshop.html
+  time: 36000
+  title: SECSE Workshop
+- &id188
+  author: Greg Wilson
+  category: [Community, Noticed, Opinion]
+  date: 2009-06-01
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/big-code-vs-science-2-0.html
+  time: 09:00:00
+  title: Big Code vs. Science 2.0
+- &id189
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2009-06-02
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/two-spots-left-in-toronto.html
+  time: 36000
+  title: Two Spots Left in Toronto
+- &id190
+  author: Greg Wilson
+  category: [University of Alberta]
+  date: 2009-06-02
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/software-carpentry-in-edmonton-july-13-31.html
+  time: 09:00:00
+  title: Software Carpentry in Edmonton July 13-31
+- &id191
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-06-15
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/neylons-head-in-the-clouds.html
+  time: 36000
+  title: Neylon's Head in the Clouds
+- &id192
+  author: Greg Wilson
+  category: [University of Glasgow]
+  date: 2009-06-15
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/sightings.html
+  time: 39600
+  title: Sightings
+- &id193
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-06-15
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/and-speaking-of-sightings.html
+  time: 09:00:00
+  title: And Speaking of Sightings...
+- &id194
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-06-23
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/another-new-version-of-the-slides.html
+  time: 09:00:00
+  title: Another New Version of the Slides
+- &id195
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-06-24
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/topics-and-schedule.html
+  time: 09:00:00
+  title: Topics and Schedule
+- &id196
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-06-25
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/updating-the-license.html
+  time: 09:00:00
+  title: Updating the License
+- &id197
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-06-29
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/ready-for-proofreading.html
+  time: 36000
+  title: Ready for Proofreading
+- &id198
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-06-29
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/the-environmental-e-science-revolution.html
+  time: 39600
+  title: The Environmental e-Science Revolution
+- &id199
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2009-06-29
+  favorite: null
+  folder: blog/2009/06
+  layout: blog
+  path: blog/2009/06/quality-control-and-traceability.html
+  time: 09:00:00
+  title: Quality Control and Traceability
+- &id200
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-04
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/registration-for-july-29-talks-is-now-open.html
+  time: 09:00:00
+  title: Registration for July 29 Talks is Now Open
+- &id201
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-10
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/see-you-monday.html
+  time: 09:00:00
+  title: See You Monday!
+- &id202
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-13
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/aaaand-theyre-off.html
+  time: 09:00:00
+  title: Aaaand They're Off!
+- &id203
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-15
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-2.html
+  time: 09:00:00
+  title: Day 2
+- &id204
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-16
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-3.html
+  time: 09:00:00
+  title: Day 3
+- &id205
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-17
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-4.html
+  time: 09:00:00
+  title: Day 4
+- &id206
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-07-19
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/quantum-to-cosmos-october-15-25-in-waterloo.html
+  time: 36000
+  title: 'Quantum to Cosmos: October 15-25 in Waterloo'
+- &id207
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-19
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-5.html
+  time: 09:00:00
+  title: Day 5
+- &id208
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2009-07-21
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/elseviers-future-version-0-1.html
+  time: 36000
+  title: Elsevier's Future, Version 0.1
+- &id209
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-21
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-6-theory-and-practice.html
+  time: 09:00:00
+  title: 'Day 6: Theory and Practice'
+- &id210
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-22
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-8-getting-it-right.html
+  time: 36000
+  title: 'Day 8: Getting It Right'
+- &id211
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-22
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-7-lots-more-objects.html
+  time: 09:00:00
+  title: 'Day 7: Lots More Objects'
+- &id212
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-24
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-9-2.html
+  time: 36000
+  title: Day 9
+- &id213
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-24
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-10-done-and-with-it-week-2.html
+  time: 09:00:00
+  title: Day 10 Done - and With It, Week 2
+- &id214
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2009-07-26
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/martin-fenner-on-scibarcamp.html
+  time: 09:00:00
+  title: Martin Fenner on SciBarCamp
+- &id215
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-07-27
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/where-this-course-came-from.html
+  time: 09:00:00
+  title: Where This Course Came From
+- &id216
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-28
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-11-and-day-12.html
+  time: 09:00:00
+  title: Day 11 and Day 12
+- &id217
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-29
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/every-day-is-a-big-day.html
+  time: 09:00:00
+  title: Every Day Is a Big Day...
+- &id218
+  author: Greg Wilson
+  category: [University of Alberta, University of Toronto]
+  date: 2009-07-31
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/day-2-2.html
+  time: 36000
+  title: Day[-2]
+- &id219
+  author: Greg Wilson
+  category: [Content, Noticed, University of Alberta, University of Toronto]
+  date: 2009-07-31
+  favorite: null
+  folder: blog/2009/07
+  layout: blog
+  path: blog/2009/07/a-good-afternoon.html
+  time: 09:00:00
+  title: A Good Afternoon
+- &id220
+  author: Greg Wilson
+  category: [Content, University of Alberta, University of Toronto]
+  date: 2009-08-01
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/post-mortem.html
+  time: 09:00:00
+  title: Post-Mortem
+- &id221
+  author: Greg Wilson
+  category: [Content, Tooling]
+  date: 2009-08-02
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/next-steps.html
+  time: 09:00:00
+  title: Next Steps
+- &id222
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-08-03
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/what-is-open-science.html
+  time: 36000
+  title: What *Is* Open Science?
+- &id223
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-08-03
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/guest-speakers-slides-now-available.html
+  time: 09:00:00
+  title: Guest Speakers' Slides Now Available
+- &id224
+  author: Greg Wilson
+  category: [Community]
+  date: 2009-08-04
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/the-ice-cream-test.html
+  time: 09:00:00
+  title: The Ice Cream Test
+- &id225
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2009-08-06
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/american-scientist-article-on-how-scientists-use-computers.html
+  time: 09:00:00
+  title: American Scientist Article on How Scientists Use Computers
+- &id226
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-08-15
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/you-can-do-a-lot-without-programming.html
+  time: 36000
+  title: You Can Do a Lot Without Programming
+- &id227
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-08-15
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/its-like-not-wearing-your-cleats-in-the-house.html
+  time: 09:00:00
+  title: It's Like Not Wearing Your Cleats in the House
+- &id228
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-08-21
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/the-big-picture.html
+  time: 09:00:00
+  title: The Big Picture
+- &id229
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-08-23
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/the-delight-is-in-the-details-too.html
+  time: 09:00:00
+  title: The Delight Is In The Details, Too
+- &id230
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-08-24
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/playing-safe.html
+  time: 36000
+  title: Playing Safe
+- &id231
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-08-24
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/science-and-jove.html
+  time: 39600
+  title: Science and JoVE
+- &id232
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2009-08-24
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/who-owns-your-data.html
+  time: 43200
+  title: Who Owns Your Data?
+- &id233
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-08-24
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/bad-news-and-good-news.html
+  time: 09:00:00
+  title: Bad News and Good News
+- &id234
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-08-26
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/how-important-is-geospatial-data-to-you.html
+  time: 09:00:00
+  title: How Important is Geospatial Data to You?
+- &id235
+  author: Greg Wilson
+  category: [Content, Noticed, Opinion]
+  date: 2009-08-30
+  favorite: null
+  folder: blog/2009/08
+  layout: blog
+  path: blog/2009/08/is-the-future-waving-at-you.html
+  time: 09:00:00
+  title: Is The Future Waving At You?
+- &id236
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-09-05
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/r-for-programmers.html
+  time: 09:00:00
+  title: R for Programmers?
+- &id237
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-09-11
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/two-links.html
+  time: 36000
+  title: Two Links
+- &id238
+  author: Greg Wilson
+  category: [MITACS]
+  date: 2009-09-11
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/job-opening-mitacs-scientific-coordinator.html
+  time: 09:00:00
+  title: 'Job Opening: MITACS Scientific Coordinator'
+- &id239
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-09-15
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/partial-outline-of-new-version-of-course.html
+  time: 09:00:00
+  title: Partial Outline of New Version of Course
+- &id240
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-09-18
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/updated-outline-for-revised-course.html
+  time: 09:00:00
+  title: Updated Outline for Revised Course
+- &id241
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2009-09-21
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/another-reason-to-care-about-provenance.html
+  time: 09:00:00
+  title: Another Reason to Care About Provenance
+- &id242
+  author: Greg Wilson
+  category: [Support]
+  date: 2009-09-22
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/grant-proposal.html
+  time: 09:00:00
+  title: Grant Proposal
+- &id243
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2009-09-24
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/presentation-presentation-presentation.html
+  time: 09:00:00
+  title: Presentation, Presentation, Presentation
+- &id244
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2009-09-29
+  favorite: null
+  folder: blog/2009/09
+  layout: blog
+  path: blog/2009/09/a-strange-obsession.html
+  root: ../../..
+  time: 09:00:00
+  title: A Strange Obsession
+- &id245
+  author: Greg Wilson
+  category: [Community, University of Wisconsin - Madison]
+  date: 2009-10-05
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/the-hacker-within.html
+  time: 09:00:00
+  title: The Hacker Within
+- &id246
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-10-06
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/comments-on-course-reorganization.html
+  time: 09:00:00
+  title: Comments on Course Reorganization
+- &id247
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-10-08
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/videos-from-symposium-are-now-online.html
+  time: 09:00:00
+  title: Videos from Symposium Are Now Online
+- &id248
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-10-16
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/revised-plan.html
+  time: 09:00:00
+  title: Revised Plan
+- &id249
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-10-21
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/should-modeling-be-part-of-this-course.html
+  time: 36000
+  title: Should Modeling Be Part of This Course?
+- &id250
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2009-10-21
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/creating-new-niches.html
+  time: 09:00:00
+  title: Creating New Niches
+- &id251
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-10-23
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/cryptography-isnt-security.html
+  time: 09:00:00
+  title: Cryptography Isn't Security
+- &id252
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-10-30
+  favorite: null
+  folder: blog/2009/10
+  layout: blog
+  path: blog/2009/10/by-popular-request.html
+  time: 09:00:00
+  title: By Popular Request...
+- &id253
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2009-11-01
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/our-target-audience.html
+  time: 09:00:00
+  title: Our Target Audience
+- &id254
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-11-06
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/python-in-science.html
+  time: 09:00:00
+  title: Python in Science
+- &id255
+  author: Greg Wilson
+  category: [Content]
+  date: 2009-11-13
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/packaging.html
+  time: 09:00:00
+  title: Packaging
+- &id256
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2009-11-15
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/cloud-computing-for-beginners.html
+  time: 09:00:00
+  title: Cloud Computing for Beginners
+- &id257
+  author: Greg Wilson
+  category: [Community, Noticed, Research]
+  date: 2009-11-18
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/special-issue-of-computing-in-science-engineering.html
+  time: 09:00:00
+  title: Special Issue of Computing in Science and Engineering
+- &id258
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2009-11-22
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/serendipitous-and-unexpected.html
+  time: 09:00:00
+  title: Serendipitous and Unexpected
+- &id259
+  author: Greg Wilson
+  category: [MathWorks, MITACS, SciNet, University of Toronto]
+  date: 2009-11-24
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/tutorials-start-this-week.html
+  time: 09:00:00
+  title: Tutorials Start This Week
+- &id260
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2009-11-26
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/caesars-wife.html
+  time: 09:00:00
+  title: Caesar's Wife
+- &id261
+  author: Greg Wilson
+  category: [MathWorks, University of Toronto]
+  date: 2009-11-28
+  favorite: null
+  folder: blog/2009/11
+  layout: blog
+  path: blog/2009/11/thanks-jamie.html
+  time: 09:00:00
+  title: Thanks, Jamie
+- &id262
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2009-12-11
+  favorite: null
+  folder: blog/2009/12
+  layout: blog
+  path: blog/2009/12/why-opening-up-probably-wouldnt-help.html
+  time: 09:00:00
+  title: Why Opening Up (Probably) Wouldn't Help
+- &id263
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2009-12-18
+  favorite: null
+  folder: blog/2009/12
+  layout: blog
+  path: blog/2009/12/double-standards.html
+  time: 09:00:00
+  title: Double Standards
+- &id264
+  author: Greg Wilson
+  category: [Support]
+  date: 2009-12-19
+  favorite: null
+  folder: blog/2009/12
+  layout: blog
+  path: blog/2009/12/nsf-programs.html
+  time: 09:00:00
+  title: NSF Programs
+- &id265
+  author: Greg Wilson
+  category: [Content, Noticed, Opinion]
+  date: 2009-12-27
+  favorite: null
+  folder: blog/2009/12
+  layout: blog
+  path: blog/2009/12/dudley-and-butte-on-software-skills.html
+  time: 09:00:00
+  title: Dudley and Butte on Software Skills
+- &id266
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2009-12-30
+  favorite: null
+  folder: blog/2009/12
+  layout: blog
+  path: blog/2009/12/osmosis-is-just-a-fancy-name-for-failure.html
+  root: ../../..
+  time: 09:00:00
+  title: Osmosis is Just a Fancy Name for Failure
+- &id267
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2010-01-07
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/new-challenges.html
+  time: 09:00:00
+  title: New Challenges
+- &id268
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-01-10
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/how-we-got-here-and-where-we-are.html
+  time: 09:00:00
+  title: How We Got Here, and Where We Are
+- &id269
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2010-01-13
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/whatcha-gonna-do-when-they-come-for-you.html
+  time: 36000
+  title: Whatcha Gonna Do When They Come For You?
+- &id270
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-01-13
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/podcast-with-jon-udell.html
+  time: 09:00:00
+  title: Podcast with Jon Udell
+- &id271
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-01-18
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/was-designed-to-but-didnt.html
+  time: 09:00:00
+  title: Was Designed To, But Didn't
+- &id272
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2010-01-20
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/big-science-big-skills-gap.html
+  time: 09:00:00
+  title: Big Science == Big Skills Gap
+- &id273
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2010-01-24
+  favorite: null
+  folder: blog/2010/01
+  layout: blog
+  path: blog/2010/01/it-seems-that-everyone-cares.html
+  time: 09:00:00
+  title: It Seems That Everyone Cares
+- &id274
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-02-12
+  favorite: null
+  folder: blog/2010/02
+  layout: blog
+  path: blog/2010/02/two-views.html
+  time: 09:00:00
+  title: Two Views
+- &id275
+  author: Greg Wilson
+  category: [Michigan State University, Noticed]
+  date: 2010-02-22
+  favorite: null
+  folder: blog/2010/02
+  layout: blog
+  path: blog/2010/02/beacon-funded.html
+  time: 09:00:00
+  title: BEACON Funded!
+- &id276
+  author: Greg Wilson
+  category: [Support]
+  date: 2010-02-25
+  favorite: null
+  folder: blog/2010/02
+  layout: blog
+  path: blog/2010/02/eighty-per-cent.html
+  time: 09:00:00
+  title: Eighty Per Cent!
+- &id277
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-02-28
+  favorite: null
+  folder: blog/2010/02
+  layout: blog
+  path: blog/2010/02/panton-principles.html
+  time: 09:00:00
+  title: Panton Principles
+- &id278
+  author: Greg Wilson
+  category: [Content, Opinion]
+  date: 2010-03-11
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/how-much-of-this-should-scientists-understand.html
+  time: 09:00:00
+  title: How Much Of This Should Scientists Understand?
+- &id279
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-03-23
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/now-on-twitter.html
+  time: 09:00:00
+  title: Now on Twitter
+- &id280
+  author: Greg Wilson
+  category: [Michigan State University, Noticed]
+  date: 2010-03-25
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/summer-course-analyzing-next-generation-sequencing-data.html
+  time: 36000
+  title: 'Summer Course: Analyzing Next-Generation Sequencing Data'
+- &id281
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2010-03-25
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/software-carpentry-version-4-is-a-go.html
+  time: 09:00:00
+  title: Software Carpentry Version 4 is a Go!
+- &id282
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-03-26
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/online-delivery.html
+  time: 36000
+  title: Online Delivery
+- &id283
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-03-26
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/instructional-design.html
+  time: 09:00:00
+  title: Instructional Design
+- &id284
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-03-28
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/recommended-reading.html
+  time: 09:00:00
+  title: Recommended Reading
+- &id285
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2010-03-29
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/whats-not-on-the-reading-list.html
+  time: 09:00:00
+  title: What's Not on the Reading List
+- &id286
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-03-30
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/formats.html
+  time: 09:00:00
+  title: Formats
+- &id287
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-03-31
+  favorite: null
+  folder: blog/2010/03
+  layout: blog
+  path: blog/2010/03/periodic-table-of-science-bloggers.html
+  time: 09:00:00
+  title: Periodic Table of Science Bloggers
+- &id288
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-04-01
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/simon-singh-wins-and-so-does-science.html
+  time: 36000
+  title: Simon Singh Wins (and So Does Science)
+- &id289
+  author: Greg Wilson
+  category: [Noticed, Tooling]
+  date: 2010-04-01
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/models-to-imitate.html
+  time: 09:00:00
+  title: Models To Imitate
+- &id290
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2010-04-04
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/feedback-and-boundaries.html
+  time: 09:00:00
+  title: Feedback and Boundaries
+- &id291
+  author: Greg Wilson
+  category: [Universitaet Mannheim]
+  date: 2010-04-08
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/software-carpentry-for-economists-in-mannheim-this-autumn.html
+  time: 36000
+  title: Software Carpentry for Economists in Mannheim This Autumn
+- &id292
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-04-08
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/platforms.html
+  time: 09:00:00
+  title: Platforms
+- &id293
+  author: Greg Wilson
+  category: [Opinion, Research]
+  date: 2010-04-11
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/measuring-science.html
+  time: 09:00:00
+  title: Measuring Science
+- &id294
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2010-04-12
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/teaching-open-source.html
+  time: 36000
+  title: Teaching Open Source
+- &id295
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-04-12
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/more-on-instructional-design.html
+  time: 09:00:00
+  title: More on Instructional Design
+- &id296
+  author: Greg Wilson
+  category: [Scimatic]
+  date: 2010-04-15
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/scimatic-sponsorship.html
+  time: 09:00:00
+  title: Scimatic Sponsorship
+- &id297
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2010-04-16
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/file-sharing-for-scientists.html
+  time: 09:00:00
+  title: File Sharing for Scientists
+- &id298
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-04-19
+  favorite: null
+  folder: blog/2010/04
+  layout: blog
+  path: blog/2010/04/apologies-for-the-flurry-of-re-posts.html
+  time: 09:00:00
+  title: Apologies for the Flurry of Re-Posts
+- &id299
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-05-02
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/t-minus-one.html
+  time: 09:00:00
+  title: T Minus One
+- &id300
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-05-03
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/setting-up-a-new-windows-machine.html
+  time: 09:00:00
+  title: Setting Up a New Windows Machine
+- &id301
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-04
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-2-more-sticky-notes.html
+  time: 36000
+  title: 'Day 2: More Sticky Notes'
+- &id302
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-04
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-1-shuffling-sticky-notes-around.html
+  time: 09:00:00
+  title: 'Day 1: Shuffling Sticky Notes Around'
+- &id303
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2010-05-05
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/a-question-about-documentation.html
+  time: 09:00:00
+  title: A Question About Documentation
+- &id304
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-06
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/first-preliminary-alpha-test-etc-screencast.html
+  time: 09:00:00
+  title: 'Day 4: First Preliminary Alpha Test Etc. Screencast'
+- &id305
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-07
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-5-a-different-kind-of-screencast.html
+  time: 09:00:00
+  title: 'Day 5: A Different Kind of Screencast'
+- &id306
+  author: Greg Wilson
+  category: [Microsoft]
+  date: 2010-05-09
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/microsoft.html
+  time: 09:00:00
+  title: Microsoft
+- &id307
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-05-10
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/why-were-self-hosting.html
+  time: 36000
+  title: Why We're Self-Hosting
+- &id308
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-10
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-6-screencast-with-point-form-notes.html
+  time: 09:00:00
+  title: 'Day 6: Screencast With Point-Form Notes'
+- &id309
+  author: Jon Pipitone
+  category: [Content]
+  date: 2010-05-12
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-7-mini-screencasts.html
+  time: 09:00:00
+  title: 'Day 7: Mini-screencasts'
+- &id310
+  author: Jon Pipitone
+  category: [Content]
+  date: 2010-05-13
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-8-exercises-with-a-screencast.html
+  time: 36000
+  title: 'Day 8: Exercises (with a screencast)'
+- &id311
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-13
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-9-programming.html
+  time: 39600
+  title: 'Day 9: Programming'
+- &id312
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-05-13
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/a-word-or-three-from-our-sponsors.html
+  time: 09:00:00
+  title: A Word (Or Three) From Our Sponsors
+- &id313
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-05-14
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/why-most-scientists-dont-like-computers.html
+  time: 36000
+  title: Why Most Scientists Don't Like Computers
+- &id314
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-14
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-10-closed-captioning.html
+  time: 09:00:00
+  title: 'Day 10: Closed Captioning'
+- &id315
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-17
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/day-11-slides.html
+  time: 09:00:00
+  title: 'Day 11: Slides'
+- &id316
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-05-18
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/well-know-weve-succeeded-if.html
+  time: 09:00:00
+  title: We'll Know We've Succeeded If...
+- &id317
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-05-19
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/evaluating-methods-and-protocols.html
+  time: 09:00:00
+  title: Evaluating Methods and Protocols
+- &id318
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-05-25
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/archiving-experiments-to-raise-scientific-standards.html
+  time: 09:00:00
+  title: Archiving Experiments to Raise Scientific Standards
+- &id319
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-05-27
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/badges-and-stars.html
+  time: 09:00:00
+  title: Badges and Stars
+- &id320
+  author: Jon Pipitone
+  category: [Content]
+  date: 2010-05-28
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/teaching-by-example.html
+  time: 09:00:00
+  title: Teaching databases by example
+- &id321
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-05-29
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/jim-graham-on-reproducibility.html
+  time: 09:00:00
+  title: Jim Graham on Reproducibility
+- &id322
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-05-31
+  favorite: null
+  folder: blog/2010/05
+  layout: blog
+  path: blog/2010/05/program-design-the-first-third.html
+  time: 09:00:00
+  title: 'Program Design: the First Third'
+- &id323
+  author: Greg Wilson
+  category: [Noticed, Opinion, Research]
+  date: 2010-06-01
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/who-reports-on-the-other-97-per-cent.html
+  time: 36000
+  title: Who Reports On The Other 97 Per Cent?
+- &id324
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-01
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/program-design-the-second-instalment.html
+  time: 09:00:00
+  title: 'Program Design: the Second Instalment'
+- &id325
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-03
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/if-you-want-to-look-ahead.html
+  time: 36000
+  title: If You Want to Look Ahead...
+- &id326
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-03
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/assembling-a-program.html
+  time: 09:00:00
+  title: Assembling a Program
+- &id327
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-04
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/refactoring-invasion-percolation.html
+  time: 36000
+  title: Refactoring Invasion Percolation
+- &id328
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-04
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/concept-map.html
+  time: 09:00:00
+  title: Concept Map
+- &id329
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-07
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/the-big-picture-version-2.html
+  time: 36000
+  title: The Big Picture (version 2)
+- &id330
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-07
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/testing-invasion-percolation.html
+  time: 09:00:00
+  title: Testing Invasion Percolation
+- &id331
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-08
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/episode-11-making-it-fast.html
+  time: 09:00:00
+  title: 'Episode 11: Making It Fast'
+- &id332
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-09
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/reorganizing-content.html
+  time: 09:00:00
+  title: Reorganizing Content
+- &id333
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-10
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/our-lecture-on-databases-is-now-online.html
+  time: 36000
+  title: Our Lecture on Databases is Now Online
+- &id334
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-10
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/the-big-picture-version-3.html
+  time: 39600
+  title: The Big Picture (version 3)
+- &id335
+  author: Greg Wilson
+  category: [Interviews, Scimatic]
+  date: 2010-06-10
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/interview-scimatic.html
+  time: 09:00:00
+  title: 'Interview: Jim Graham of Scimatic'
+- &id336
+  author: Greg Wilson
+  category: [Interviews, SHARCNET]
+  date: 2010-06-11
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/interview-sharcnet.html
+  time: 36000
+  title: 'Interview: SHARCNET''s Hugh Couchman'
+- &id337
+  author: Greg Wilson
+  category: [Interviews, UK Met Office]
+  date: 2010-06-11
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/interview-uk-met-office.html
+  time: 39600
+  title: 'Interview: David Jackson at the UK Met Office'
+- &id338
+  author: Greg Wilson
+  category: [Education]
+  date: 2010-06-11
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/thought-for-the-day.html
+  time: 43200
+  title: Thought for the Day
+- &id339
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-11
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/counting-things.html
+  time: 09:00:00
+  title: Counting Things
+- &id340
+  author: Greg Wilson
+  category: [Opinion, Research]
+  date: 2010-06-12
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/the-cowichan-problems.html
+  time: 09:00:00
+  title: The Cowichan Problems
+- &id341
+  author: Greg Wilson
+  category: [Interviews, Queen Mary University London]
+  date: 2010-06-14
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/interview-queen-mary-university-of-london.html
+  time: 09:00:00
+  title: 'Interview: Mark Plumbley at Queen Mary University of London'
+- &id342
+  author: Greg Wilson
+  category: [Michigan State University]
+  date: 2010-06-15
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/next-gen-sequencing-course-at-msu-it-went-well.html
+  time: 36000
+  title: 'Next-Gen Sequencing Course at MSU: It Went Well'
+- &id343
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-15
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/glossary-and-license-online.html
+  time: 09:00:00
+  title: Glossary and License Online
+- &id344
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-16
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/is-live-coding-worth-it.html
+  time: 36000
+  title: Is Live Coding Worth It?
+- &id345
+  author: Greg Wilson
+  category: [Content, Noticed, Opinion]
+  date: 2010-06-16
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/a-voice-from-the-back-of-the-room.html
+  time: 09:00:00
+  title: A Voice from the Back of the Room
+- &id346
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-17
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/lets-try-that-again.html
+  time: 09:00:00
+  title: Let's Try That Again
+- &id347
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-06-18
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/for-world-cup-fans-and-everyone-else.html
+  time: 36000
+  title: For World Cup Fans (and Everyone Else)
+- &id348
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-18
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/our-first-few-exercises.html
+  time: 39600
+  title: Our First Few Exercises
+- &id349
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-06-18
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/people-you-dont-want-on-your-team.html
+  time: 43200
+  title: People You Don't Want On Your Team
+- &id350
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-18
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/first-half-of-spreadsheets-lecture-now-online.html
+  time: 09:00:00
+  title: First Half of Spreadsheets Lecture Now Online
+- &id351
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-19
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/second-lecture-on-regular-expressions.html
+  time: 09:00:00
+  title: Second Lecture on Regular Expressions
+- &id352
+  author: Greg Wilson
+  category: [Interviews, Microsoft]
+  date: 2010-06-21
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/interview-with-microsofts-david-rich.html
+  time: 36000
+  title: Interview with Microsoft's David Rich
+- &id353
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-21
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/a-little-bit-of-theory.html
+  time: 09:00:00
+  title: A Little Bit of Theory
+- &id354
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-22
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/episode-4-on-regular-expressions.html
+  time: 09:00:00
+  title: Episode 4 on Regular Expressions
+- &id355
+  author: Greg Wilson
+  category: [Jobs, Queen Mary University London]
+  date: 2010-06-23
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/software-developer-audio-and-digital-music.html
+  time: 36000
+  title: 'Software Developer: Audio and Digital Music'
+- &id356
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2010-06-23
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/software-carpentry-in-three-and-a-half-minutes.html
+  time: 09:00:00
+  title: Software Carpentry in Three and a Half Minutes
+- &id357
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-06-24
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/eric-lander-on-genomics.html
+  time: 36000
+  title: Eric Lander on Genomics
+- &id358
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-06-24
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/siam-news-article-about-software-carpentry.html
+  time: 39600
+  title: SIAM News Article About Software Carpentry
+- &id359
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-24
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/another-example-of-small-p-patterns.html
+  time: 09:00:00
+  title: Another Example of small-p Patterns
+- &id360
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-25
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/final-episode-of-regular-expressions-lecture-now-online.html
+  time: 09:00:00
+  title: Final Episode of Regular Expressions Lecture Now Online
+- &id361
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-27
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/four-down-what-next.html
+  time: 09:00:00
+  title: Four Down-What Next?
+- &id362
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-28
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/last-episode-on-sets-dictionaries-posted-first.html
+  time: 09:00:00
+  title: Last Episode on Sets and Dictionaries Posted First
+- &id363
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-06-29
+  favorite: null
+  folder: blog/2010/06
+  layout: blog
+  path: blog/2010/06/the-violas-of-programming.html
+  time: 09:00:00
+  title: The Violas of Programming
+- &id364
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-06
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/thats-uh-pretty-ambitious.html
+  time: 36000
+  title: That's, Uh, Pretty Ambitious
+- &id365
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-07-06
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/hubs-spokes-and-gonzo-programming-skills.html
+  time: 09:00:00
+  title: Hubs, Spokes, and Gonzo Programming Skills
+- &id366
+  author: Greg Wilson
+  category: [Education]
+  date: 2010-07-07
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/using-science-to-design-this-course.html
+  time: 09:00:00
+  title: Using Science to Design This Course
+- &id367
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-08
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/two-episodes-on-sets.html
+  time: 36000
+  title: Two Episodes on Sets
+- &id368
+  author: Greg Wilson
+  category: [Interviews, SciNet]
+  date: 2010-07-08
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/interview-scinet.html
+  time: 09:00:00
+  title: 'Interview: SciNet''s Daniel Gruner'
+- &id369
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-10
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/which-topics-are-most-important-to-you.html
+  time: 36000
+  title: Which Topics Are Most Important to You?
+- &id370
+  author: Greg Wilson
+  category: [Noticed, Opinion, Research]
+  date: 2010-07-10
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/hpc-and-programmability.html
+  time: 09:00:00
+  title: HPC and Programmability
+- &id371
+  author: Greg Wilson
+  category: [Interviews, Michigan State University]
+  date: 2010-07-11
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/interview-with-michigan-states-titus-brown.html
+  time: 09:00:00
+  title: Interview with Michigan State's Titus Brown
+- &id372
+  author: Greg Wilson
+  category: [Indiana University, Interviews]
+  date: 2010-07-13
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/interview-andrew-lumsdaine-of-indiana-university.html
+  time: 36000
+  title: 'Interview: Andrew Lumsdaine of Indiana University'
+- &id373
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-13
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/traffic.html
+  time: 39600
+  title: Traffic
+- &id374
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-13
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/a-shorter-version-of-the-sets-and-tuples-episode.html
+  time: 09:00:00
+  title: A Shorter Version of the Sets and Tuples Episode
+- &id375
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-14
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/two-new-episodes-on-dictionaries.html
+  time: 09:00:00
+  title: Two New Episodes on Dictionaries
+- &id376
+  author: Greg Wilson
+  category: [Community, Content, Research]
+  date: 2010-07-15
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/survey-results.html
+  time: 09:00:00
+  title: Survey Results
+- &id377
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-07-16
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/clip-art.html
+  time: 09:00:00
+  title: Clip Art
+- &id378
+  author: Greg Wilson
+  category: [Interviews]
+  date: 2010-07-18
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/an-interview-with-hans-petter-langtangen.html
+  time: 36000
+  title: An Interview with Hans Petter Langtangen
+- &id379
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2010-07-18
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/a-gentle-introduction.html
+  time: 09:00:00
+  title: A Gentle Introduction
+- &id380
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-19
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/script-for-introduction-to-version-control.html
+  time: 09:00:00
+  title: Script for Introduction to Version Control
+- &id381
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-20
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/five-five-five-scripts-in-one.html
+  time: 36000
+  title: Five... Five... Five Scripts in One!
+- &id382
+  author: Greg Wilson
+  category: [Interviews, Space Telescope Science Institute]
+  date: 2010-07-20
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/interview-with-stscis-perry-greenfield.html
+  time: 39600
+  title: Interview with STSci's Perry Greenfield
+- &id383
+  author: Greg Wilson
+  category: [Interviews, University of Wisconsin - Madison]
+  date: 2010-07-20
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/interview-with-the-hackers-within.html
+  time: 43200
+  title: Interview with The Hackers Within
+- &id384
+  author: Greg Wilson
+  category: [Opinion, Tooling]
+  date: 2010-07-20
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/a-note-on-tools.html
+  time: 09:00:00
+  title: A Note on Tools
+- &id385
+  author: Greg Wilson
+  category: [Content, Tooling]
+  date: 2010-07-21
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/popular-fast-or-usable-pick-one.html
+  time: 09:00:00
+  title: 'Popular, Fast, or Usable: Pick One'
+- &id386
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-22
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/first-episode-of-testing-lecture.html
+  time: 09:00:00
+  title: First Episode of Testing Lecture
+- &id387
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-23
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/strictly-speaking-this-isnt-part-of-testing.html
+  time: 09:00:00
+  title: Strictly Speaking, This Isn't Part of Testing
+- &id388
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-24
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/introduction-to-version-control.html
+  time: 09:00:00
+  title: Introduction to Version Control
+- &id389
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-26
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/second-lecture-on-version-control.html
+  time: 09:00:00
+  title: Second Lecture on Version Control
+- &id390
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2010-07-28
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/mark-guzdial-on-software-carpentry.html
+  time: 09:00:00
+  title: Mark Guzdial on Software Carpentry
+- &id391
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-07-29
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/two-more-episodes-on-version-control.html
+  time: 36000
+  title: Two More Episodes on Version Control
+- &id392
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2010-07-29
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/survey-update.html
+  time: 09:00:00
+  title: Survey Update
+- &id393
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-07-30
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/stats-for-july.html
+  time: 36000
+  title: Stats for July
+- &id394
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2010-07-30
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/a-little-bit-of-javascript.html
+  time: 09:00:00
+  title: A Little Bit of Javascript
+- &id395
+  author: Greg Wilson
+  category: [Interviews]
+  date: 2010-07-31
+  favorite: null
+  folder: blog/2010/07
+  layout: blog
+  path: blog/2010/07/interview-with-davor-cubranic.html
+  time: 09:00:00
+  title: Interview with Davor Cubranic
+- &id396
+  author: Greg Wilson
+  category: [Interviews]
+  date: 2010-08-02
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/interview-with-sergey-fomel.html
+  time: 09:00:00
+  title: Interview with Sergey Fomel
+- &id397
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-08-03
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/open-source-open-science-in-1999.html
+  time: 36000
+  title: Open Source, Open Science in 1999
+- &id398
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-08-03
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/a-question-about-nose.html
+  time: 09:00:00
+  title: A Question About Nose
+- &id399
+  author: Greg Wilson
+  category: [Queen Mary University London]
+  date: 2010-08-05
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/software-carpentry-for-audio-and-music-researchers.html
+  time: 36000
+  title: Software Carpentry for Audio and Music Researchers
+- &id400
+  author: Greg Wilson
+  category: [Community, Opinion]
+  date: 2010-08-05
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/an-answer-that-most-students-wont-understand.html
+  time: 09:00:00
+  title: An Answer That Most Students Won't Understand
+- &id401
+  author: Greg Wilson
+  category: [Interviews]
+  date: 2010-08-12
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/interview-with-cameron-neylon.html
+  time: 09:00:00
+  title: Interview with Cameron Neylon
+- &id402
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-08-16
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/43-independent.html
+  time: 09:00:00
+  title: 43% Independent
+- &id403
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-08-19
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/slides-and-scripts-for-the-next-two-episodes.html
+  time: 09:00:00
+  title: Slides and Scripts for the Next Two Episodes
+- &id404
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-08-23
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/what-dont-you-understand-that-youd-like-to.html
+  time: 09:00:00
+  title: What Don't You Understand That You'd Like To?
+- &id405
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-08-26
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/another-update-on-what-you-want.html
+  time: 09:00:00
+  title: Another Update on What You Want
+- &id406
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-08-27
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/four-more-screencasts-on-testing.html
+  time: 09:00:00
+  title: Four More Screencasts on Testing
+- &id407
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-08-31
+  favorite: null
+  folder: blog/2010/08
+  layout: blog
+  path: blog/2010/08/five-episodes-on-the-shell-and-three-to-come.html
+  time: 09:00:00
+  title: Five Episodes on the Shell (and Three to Come)
+- &id408
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-01
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/three-more-sets-of-slides.html
+  time: 09:00:00
+  title: Three More Sets of Slides
+- &id409
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-03
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/eight-episodes-on-the-unix-shell.html
+  time: 09:00:00
+  title: Eight Episodes on the Unix Shell
+- &id410
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-09-06
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/getting-the-source.html
+  time: 09:00:00
+  title: Getting the Source
+- &id411
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-08
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/slides-for-the-first-four-episodes-on-make.html
+  time: 09:00:00
+  title: Slides for the First Four Episodes on Make
+- &id412
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-09
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/and-for-my-next-trick.html
+  time: 09:00:00
+  title: And For My Next Trick...
+- &id413
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-09-13
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/will-americas-universities-go-the-way-of-its-car-companies.html
+  time: 09:00:00
+  title: Will America's Universities Go The Way Of Its Car Companies?
+- &id414
+  author: Greg Wilson
+  category: [Online]
+  date: 2010-09-14
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/software-carpentry-offered-online-in-fall-2010-for-ontario-students.html
+  time: 09:00:00
+  title: Software Carpentry Offered Online in Fall 2010 (for Ontario students)
+- &id415
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-09-15
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/testing-scientific-software.html
+  time: 36000
+  title: Testing Scientific Software
+- &id416
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-15
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/five-episodes-on-make.html
+  time: 09:00:00
+  title: Five Episodes on Make
+- &id417
+  author: Greg Wilson
+  category: [Research]
+  date: 2010-09-16
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/survey-help-needed.html
+  time: 09:00:00
+  title: 'Survey: Help Needed'
+- &id418
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-20
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/your-favorite-running-examples.html
+  time: 09:00:00
+  title: Your Favorite Running Examples?
+- &id419
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-21
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/im-no-graphic-artist.html
+  time: 09:00:00
+  title: I'm No Graphic Artist...
+- &id420
+  author: Greg Wilson
+  category: [Online]
+  date: 2010-09-22
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/response-has-been-overwhelming.html
+  time: 09:00:00
+  title: Response Has Been Overwhelming
+- &id421
+  author: Greg Wilson
+  category: [University of California - San Francisco]
+  date: 2010-09-23
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/software-carpentry-at-ucsf.html
+  time: 09:00:00
+  title: Software Carpentry at UCSF
+- &id422
+  author: Jon Pipitone
+  category: [Community]
+  date: 2010-09-28
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/site-redesign.html
+  time: 09:00:00
+  title: A New Site Design
+- &id423
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-09-30
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/tracking-utility-and-impact.html
+  time: 36000
+  title: Tracking Utility and Impact
+- &id424
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-09-30
+  favorite: null
+  folder: blog/2010/09
+  layout: blog
+  path: blog/2010/09/ten-short-papers-every-computational-scientist-should-read.html
+  time: 09:00:00
+  title: Ten Short Papers Every Computational Scientist Should Read
+- &id425
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-03
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/what-questions-do-you-frequently-ask.html
+  time: 36000
+  title: What Questions Do You (Frequently) Ask?
+- &id426
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-10-03
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/do-you-use-software-carpentry.html
+  time: 09:00:00
+  title: Do You Use Software Carpentry?
+- &id427
+  author: Greg Wilson
+  category: [Online]
+  date: 2010-10-04
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/aaaand-were-off.html
+  time: 09:00:00
+  title: Aaaand We're Off!
+- &id428
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-05
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/using-subversion-from-the-command-line.html
+  time: 09:00:00
+  title: Using Subversion from the Command Line
+- &id429
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-12
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/python-lecture-coming-online.html
+  time: 09:00:00
+  title: Python Lecture Coming Online
+- &id430
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-13
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/three-more-episodes-on-spreadsheets.html
+  time: 09:00:00
+  title: Three More Episodes on Spreadsheets
+- &id431
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-10-14
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/five-rules.html
+  time: 36000
+  title: Five Rules for Computational Scientists
+- &id432
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-10-14
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/nature-article-on-scientific-programming.html
+  time: 39600
+  title: Nature Article on Scientific Programming
+- &id433
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-14
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/three-python-screencasts-up.html
+  time: 43200
+  title: Three Python Screencasts Up
+- &id434
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-14
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/dexy.html
+  time: 09:00:00
+  title: Dexy
+- &id435
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-15
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/six-more-python-episodes.html
+  time: 09:00:00
+  title: Six More Python Episodes
+- &id436
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2010-10-17
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/ratings-revised.html
+  time: 09:00:00
+  title: Ratings Revised
+- &id437
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-10-18
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/how-did-you-find-us.html
+  time: 36000
+  title: How Did You Find Us?
+- &id438
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-18
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/final-four-episodes-of-python-lecture.html
+  time: 09:00:00
+  title: Final Four Episodes of Python Lecture
+- &id439
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-21
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/slides-available-as-pdf-and-ppt.html
+  time: 09:00:00
+  title: Slides Available as PDF and PPT
+- &id440
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-24
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/configuration-files.html
+  time: 09:00:00
+  title: Configuration Files
+- &id441
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-10-27
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/computerworld-canada-educator-of-the-year.html
+  time: 09:00:00
+  title: ComputerWorld Canada Educator of the Year
+- &id442
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2010-10-28
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/how-weve-helped.html
+  time: 36000
+  title: How We've Helped
+- &id443
+  author: Greg Wilson
+  category: [Assessment, UK Met Office]
+  date: 2010-10-28
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/feedback-at-ukmo.html
+  time: 09:00:00
+  title: Feedback at UKMO
+- &id444
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-29
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/provenance-or-what-we-didnt-quite-get-to-at-the-met-office.html
+  time: 09:00:00
+  title: Provenance (Or, What We Didn't Quite Get to at the Met Office)
+- &id445
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-30
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/need-something-to-debug.html
+  time: 36000
+  title: Need Something to Debug
+- &id446
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-30
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/would-you-prefer.html
+  time: 39600
+  title: Would You Prefer...
+- &id447
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-30
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/dubois-on-maintaining-correctness.html
+  time: 09:00:00
+  title: Dubois on Maintaining Correctness
+- &id448
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-10-31
+  favorite: null
+  folder: blog/2010/10
+  layout: blog
+  path: blog/2010/10/counting-things-part-1.html
+  time: 09:00:00
+  title: Counting Things (Part 1)
+- &id449
+  author: Greg Wilson
+  category: [Assessment, Queen Mary University London]
+  date: 2010-11-05
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/done-in-london.html
+  time: 09:00:00
+  title: Done In London
+- &id450
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-07
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/counting-things-part-2.html
+  time: 09:00:00
+  title: Counting Things (Part 2)
+- &id451
+  author: Greg Wilson
+  category: [Content, Education, Opinion]
+  date: 2010-11-16
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/ratios-and-rework.html
+  time: 09:00:00
+  title: Ratios and Rework
+- &id452
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-17
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/new-section-for-essays.html
+  time: 36000
+  title: New Section for Essays
+- &id453
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-11-17
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/making-software-screencast.html
+  time: 09:00:00
+  title: Making Software Screencast
+- &id454
+  author: Jon Pipitone
+  category: [Assessment]
+  date: 2010-11-18
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/summary-of-student-check-ins.html
+  time: 09:00:00
+  title: Summary of student check-ins
+- &id455
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-19
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/now-annotated.html
+  time: 09:00:00
+  title: Now Annotated
+- &id456
+  author: Ainsley Lawson
+  category: [Assessment]
+  date: 2010-11-20
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/mid-term-quiz-results.html
+  time: 09:00:00
+  title: Mid-term Quiz Results
+- &id457
+  author: Jon Pipitone
+  category: [Tooling]
+  date: 2010-11-21
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/repository-url-change.html
+  time: 09:00:00
+  title: Repository URL Change
+- &id458
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-23
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/phylogenetic-trees.html
+  time: 36000
+  title: Phylogenetic Trees
+- &id459
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-23
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/four-episodes-on-matrix-programming.html
+  time: 09:00:00
+  title: Four Episodes on Matrix Programming
+- &id460
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-25
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/hours-so-far.html
+  time: 09:00:00
+  title: Hours So Far
+- &id461
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-26
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/next-part-of-persistence-essay-online.html
+  time: 09:00:00
+  title: Next Part of Persistence Essay Online
+- &id462
+  author: Greg Wilson
+  category: [Community, Online]
+  date: 2010-11-29
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/winter-2011-online-course-now-full.html
+  time: 09:00:00
+  title: Winter 2011 Online Course Now Full
+- &id463
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-11-30
+  favorite: null
+  folder: blog/2010/11
+  layout: blog
+  path: blog/2010/11/first-four-episodes-on-multimedia.html
+  time: 09:00:00
+  title: First Four Episodes on Multimedia
+- &id464
+  author: Ainsley Lawson
+  category: [Assessment]
+  date: 2010-12-02
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/fall-2010-what-went-right-what-went-wrong.html
+  time: 36000
+  title: 'Fall 2010:  What Went Right, What Went Wrong'
+- &id465
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-12-02
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/peer-to-peer.html
+  time: 39600
+  title: Peer to Peer
+- &id466
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-02
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/prerequisites-or-when-to-say-no.html
+  time: 43200
+  title: Prerequisites (or, When to Say No)
+- &id467
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-12-02
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/programmer-competency-matrix.html
+  time: 46800
+  title: Programmer Competency Matrix
+- &id468
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-12-02
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/red-r.html
+  time: 50400
+  title: Red-R
+- &id469
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-02
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/cast-your-votes.html
+  time: 09:00:00
+  title: Cast Your Votes
+- &id470
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-06
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/pins-balls-and-arbitrary-decisions.html
+  time: 09:00:00
+  title: Pins, Balls, and Arbitrary Decisions
+- &id471
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-07
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/approaching-objects-from-a-new-direction.html
+  time: 09:00:00
+  title: Approaching Objects from a New Direction
+- &id472
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-08
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/how-do-you-manage-a-terabyte.html
+  time: 09:00:00
+  title: How Do You Manage a Terabyte?
+- &id473
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-09
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/where-are-my-keys.html
+  time: 09:00:00
+  title: Where Are My Keys?
+- &id474
+  author: Greg Wilson
+  category: [Online]
+  date: 2010-12-10
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/winter-2011-signup-vs-spam-filters.html
+  time: 36000
+  title: Winter 2011 Signup vs. Spam Filters
+- &id475
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-10
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/performance-and-parallelism.html
+  time: 09:00:00
+  title: Performance and Parallelism
+- &id476
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-13
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/slides-for-first-five-oo-episodes-online.html
+  time: 09:00:00
+  title: Slides for First Five OO Episodes Online
+- &id477
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-12-14
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/presents-for-the-holidays.html
+  time: 09:00:00
+  title: Presents for the Holidays
+- &id478
+  author: Greg Wilson
+  category: [Community]
+  date: 2010-12-15
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/building-a-recommendation-engine-with-numpy.html
+  time: 09:00:00
+  title: Building a Recommendation Engine with NumPy
+- &id479
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2010-12-20
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/executable-papers.html
+  time: 09:00:00
+  title: Executable Papers
+- &id480
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2010-12-21
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/compute-canadas-strategic-plan-isnt.html
+  time: 09:00:00
+  title: Compute Canada's 'Strategic' Plan Isn't
+- &id481
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-23
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/extended-examples.html
+  time: 09:00:00
+  title: Extended Examples
+- &id482
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-26
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/local-subversion-repositories.html
+  time: 09:00:00
+  title: Local Subversion Repositories
+- &id483
+  author: Greg Wilson
+  category: [Community, Noticed, Research]
+  date: 2010-12-27
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/open-research-computation.html
+  time: 36000
+  title: Open Research Computation
+- &id484
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-27
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/elimination.html
+  time: 09:00:00
+  title: Elimination
+- &id485
+  author: Greg Wilson
+  category: [Content]
+  date: 2010-12-30
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/more-detailed-outline-for-hpc-lecture.html
+  time: 09:00:00
+  title: More Detailed Outline for HPC Lecture
+- &id486
+  author: Greg Wilson
+  category: [Community, University of Wisconsin - Madison]
+  date: 2010-12-31
+  favorite: null
+  folder: blog/2010/12
+  layout: blog
+  path: blog/2010/12/software-carpentry-boot-camp-jan-12-14-in-madison.html
+  time: 09:00:00
+  title: Software Carpentry Bootcamp Jan 12-14 in Madison
+- &id487
+  author: Greg Wilson
+  category: [UK Met Office]
+  date: 2011-01-06
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/what-i-learned-from-software-carpentry.html
+  time: 36000
+  title: What I Learned From Software Carpentry
+- &id488
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-01-06
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/first-half-of-lecture-on-object-oriented-programming.html
+  time: 09:00:00
+  title: First Half of Lecture on Object-Oriented Programming
+- &id489
+  author: Greg Wilson
+  category: [Community]
+  date: 2011-01-09
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/funding-a-plea-for-contacts.html
+  time: 09:00:00
+  title: Funding (A Plea for Contacts)
+- &id490
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-01-10
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/software-carpentry-in-one-picture-and-five-words.html
+  time: 36000
+  title: Software Carpentry in One Picture and Five Words
+- &id491
+  author: Jon Pipitone
+  category: [University of Toronto]
+  date: 2011-01-10
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/the-spring-2011-course-begins.html
+  time: 39600
+  title: The Spring 2011 Course Begins
+- &id492
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-01-10
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/slower-than-expected.html
+  time: 09:00:00
+  title: Slower Than Expected
+- &id493
+  author: Greg Wilson
+  category: [University of Wisconsin - Madison]
+  date: 2011-01-14
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/the-hacker-within-2.html
+  time: 36000
+  title: The Hacker Within
+- &id494
+  author: Greg Wilson
+  category: [Sponsors]
+  date: 2011-01-14
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/our-funding-pitch.html
+  time: 09:00:00
+  title: Our Funding Pitch
+- &id495
+  author: Greg Wilson
+  category: [Online]
+  date: 2011-01-16
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/demographics-part-one.html
+  time: 09:00:00
+  title: Demographics (part one)
+- &id496
+  author: Greg Wilson
+  category: [Online]
+  date: 2011-01-17
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/demographics-part-two.html
+  time: 09:00:00
+  title: Demographics (part two)
+- &id497
+  author: Greg Wilson
+  category: [Online]
+  date: 2011-01-18
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/exercises-for-shell-posted.html
+  time: 09:00:00
+  title: Exercises for Shell Posted
+- &id498
+  author: Luis Zarrabeitia
+  category: [Content]
+  date: 2011-01-19
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/newline.html
+  time: 36000
+  title: Version Control and Newline Conventions
+- &id499
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2011-01-19
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/making-system-administrators-lives-easier.html
+  time: 09:00:00
+  title: Making System Administrators' Lives Easier
+- &id500
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-01-20
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/mit-rethinking-opencourseware.html
+  time: 36000
+  title: MIT Rethinking OpenCourseWare
+- &id501
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-01-20
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/how-to-cite-software-carpentry.html
+  time: 09:00:00
+  title: How to Cite Software Carpentry
+- &id502
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-01-21
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/scientists-arent-stupid-software-is.html
+  time: 09:00:00
+  title: 'Scientists Aren''t Stupid: Software Is'
+- &id503
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-01-26
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/software-carpentry-sprint-in-july.html
+  time: 36000
+  title: Software Carpentry Sprint in July
+- &id504
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-01-26
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/the-case-against-peer-review.html
+  time: 39600
+  title: The Case Against Peer Review
+- &id505
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2011-01-26
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/thinking-like-the-web.html
+  time: 43200
+  title: Thinking Like the Web
+- &id506
+  author: Jon Pipitone
+  category: [Tooling]
+  date: 2011-01-26
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/fighting-spam.html
+  time: 09:00:00
+  title: Fighting Spam
+- &id507
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-01-27
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/notes-toward-a-lecture-on-high-performance-computing.html
+  time: 36000
+  title: Notes Toward a Lecture on High-Performance Computing
+- &id508
+  author: Greg Wilson
+  category: [Research]
+  date: 2011-01-27
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/research-study-how-do-you-test-your-matlab.html
+  time: 39600
+  title: 'Research Study: How Do You Test Your MATLAB?'
+- &id509
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2011-01-27
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/boot-camp.html
+  time: 09:00:00
+  title: Bootcamp
+- &id510
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-01-31
+  favorite: null
+  folder: blog/2011/01
+  layout: blog
+  path: blog/2011/01/a-competence-matrix-for-software-carpentry.html
+  time: 09:00:00
+  title: A Competence Matrix for Software Carpentry
+- &id511
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-01
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/first-episode-on-software-engineering.html
+  time: 09:00:00
+  title: First Episode on Software Engineering
+- &id512
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-02-02
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/three-months-two-spikes-one-conclusion.html
+  time: 09:00:00
+  title: Three Months, Two Spikes, One Conclusion
+- &id513
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-03
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/scripts-for-two-more-software-engineering-episodes.html
+  time: 09:00:00
+  title: Scripts for Two More Software Engineering Episodes
+- &id514
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-08
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/what-computational-science-means-to-me.html
+  time: 09:00:00
+  title: What Computational Science Means to Me
+- &id515
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-11
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/updates-to-spreadsheet-lecture.html
+  time: 09:00:00
+  title: Updates to Spreadsheet Lecture
+- &id516
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-14
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/two-more-episodes-on-spreadsheets.html
+  time: 36000
+  title: Two More Episodes on Spreadsheets
+- &id517
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-14
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/audio-for-three-software-engineering-episodes.html
+  time: 09:00:00
+  title: Audio for Three Software Engineering Episodes
+- &id518
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-02-15
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/top-ten-why-nots.html
+  time: 36000
+  title: Top Ten Why Nots
+- &id519
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-15
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/first-four-matlab-episodes.html
+  time: 09:00:00
+  title: First Four MATLAB Episodes
+- &id520
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-02-16
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/i-want-their-software.html
+  time: 36000
+  title: I Want Their Software
+- &id521
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2011-02-16
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/how-to-contribute.html
+  time: 09:00:00
+  title: How to Contribute
+- &id522
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-02-17
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/reddit-on-scientific-programming.html
+  time: 09:00:00
+  title: Reddit on Scientific Programming
+- &id523
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2011-02-18
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/scientific-computing-podcast.html
+  time: 36000
+  title: Scientific Computing Podcast
+- &id524
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2011-02-18
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/mirroring-software-carpentry.html
+  time: 09:00:00
+  title: Mirroring Software Carpentry
+- &id525
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-19
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/three-more-episodes-on-matlab.html
+  time: 09:00:00
+  title: Three More Episodes on MATLAB
+- &id526
+  author: Greg Wilson
+  category: [Community]
+  date: 2011-02-22
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/what-better-looks-like.html
+  time: 09:00:00
+  title: What Better Looks Like
+- &id527
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-23
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/ask-and-ye-shall-receive.html
+  time: 09:00:00
+  title: Ask, And Ye Shall Receive
+- &id528
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-02-24
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/an-easy-place-to-start-systems-programming.html
+  time: 09:00:00
+  title: 'An Easy Place to Start: Systems Programming'
+- &id529
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-02-25
+  favorite: null
+  folder: blog/2011/02
+  layout: blog
+  path: blog/2011/02/we-got-a-mention-in-comm-acm.html
+  time: 09:00:00
+  title: We Got a Mention in Comm. ACM
+- &id530
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-03-01
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/tuple-spaces-or-good-ideas-dont-always-win.html
+  time: 09:00:00
+  title: Tuple Spaces (or, Good Ideas Don't Always Win)
+- &id531
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-03-07
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/literate-programming.html
+  time: 09:00:00
+  title: Literate Programming
+- &id532
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-03-09
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/high-tech-that-looks-low-tech.html
+  time: 36000
+  title: High Tech That Looks Low Tech
+- &id533
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-03-09
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/advanced-scientific-programming-in-python.html
+  time: 09:00:00
+  title: Advanced Scientific Programming in Python
+- &id534
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-03-11
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/science-illustrated.html
+  time: 36000
+  title: Science Illustrated
+- &id535
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2011-03-11
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/musing-about-reorganization.html
+  time: 09:00:00
+  title: Musing About Reorganization
+- &id536
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-03-12
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/what-to-demand.html
+  time: 09:00:00
+  title: What To Demand
+- &id537
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2011-03-15
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/twenty-questions-minus-two.html
+  time: 36000
+  title: Twenty Questions (Minus Two)
+- &id538
+  author: Greg Wilson
+  category: [Research]
+  date: 2011-03-15
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/call-for-participation.html
+  time: 09:00:00
+  title: Call for Participation
+- &id539
+  author: Greg Wilson
+  category: [Michigan State University, Noticed]
+  date: 2011-03-16
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/next-generation-sequencing-course-at-msu.html
+  time: 36000
+  title: Next-Generation Sequencing Course at MSU
+- &id540
+  author: Greg Wilson
+  category: [Content, Opinion]
+  date: 2011-03-16
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/graph-layout-models-vs-views-and-computational-thinking.html
+  time: 09:00:00
+  title: Graph Layout, Models vs. Views, and Computational Thinking
+- &id541
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2011-03-17
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/questions-and-answers.html
+  time: 09:00:00
+  title: Questions and Answers
+- &id542
+  author: Greg Wilson
+  category: [Community]
+  date: 2011-03-18
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/on-a.html
+  time: 09:00:00
+  title: On a Personal Note...
+- &id543
+  author: Greg Wilson
+  category: [Content, Queen Mary University London]
+  date: 2011-03-21
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/videos-of-autumn-school-lectures.html
+  time: 36000
+  title: Videos of Autumn School Lectures
+- &id544
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-03-21
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/using-a-debugger.html
+  time: 09:00:00
+  title: Using a Debugger
+- &id545
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-03-22
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/youll-need-a-large-screen.html
+  time: 36000
+  title: You'll Need a Large Screen
+- &id546
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2011-03-22
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/id-settle-for-0-1.html
+  time: 09:00:00
+  title: I'd Settle for 0.1%
+- &id547
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-03-23
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/our-first-episode-on-microsoft-access.html
+  time: 09:00:00
+  title: Our First Episode on Microsoft Access
+- &id548
+  author: Greg Wilson
+  category: [Content, Education, Noticed]
+  date: 2011-03-24
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/a-better-way-to-teach-programming-to-scientists.html
+  time: 09:00:00
+  title: A Better Way to Teach Programming to Scientists
+- &id549
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2011-03-26
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/and-im-on-a-horse.html
+  time: 09:00:00
+  title: And I'm on a Horse
+- &id550
+  author: Orion Buske
+  category: [Education, Assessment]
+  date: 2011-03-30
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/spring-2011-course-over.html
+  time: 36000
+  title: Spring 2011 Course Over
+- &id551
+  author: Greg Wilson
+  category: [Stanford University]
+  date: 2011-03-30
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/practical-computing-for-scientists-at-stanford.html
+  time: 09:00:00
+  title: Practical Computing for Scientists at Stanford
+- &id552
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-03-31
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/using-bein.html
+  time: 36000
+  title: Using Bein
+- &id553
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-03-31
+  favorite: null
+  folder: blog/2011/03
+  layout: blog
+  path: blog/2011/03/harder-than-it-should-be.html
+  time: 09:00:00
+  title: Harder Than It Should Be
+- &id554
+  author: Greg Wilson
+  category: [Community]
+  date: 2011-04-09
+  favorite: null
+  folder: blog/2011/04
+  layout: blog
+  path: blog/2011/04/by-the-numbers.html
+  time: 09:00:00
+  title: By The Numbers
+- &id555
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-04-11
+  favorite: null
+  folder: blog/2011/04
+  layout: blog
+  path: blog/2011/04/prototyping.html
+  time: 09:00:00
+  title: Prototyping
+- &id556
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-04-18
+  favorite: null
+  folder: blog/2011/04
+  layout: blog
+  path: blog/2011/04/holding-up-a-mirror.html
+  time: 09:00:00
+  title: Holding Up a Mirror
+- &id557
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-04-22
+  favorite: null
+  folder: blog/2011/04
+  layout: blog
+  path: blog/2011/04/in-praise-of-street-fighting.html
+  time: 09:00:00
+  title: In Praise of Street Fighting
+- &id558
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-04-23
+  favorite: null
+  folder: blog/2011/04
+  layout: blog
+  path: blog/2011/04/chapters.html
+  time: 09:00:00
+  title: Chapters
+- &id559
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-05-02
+  favorite: null
+  folder: blog/2011/05
+  layout: blog
+  path: blog/2011/05/managing-data.html
+  time: 09:00:00
+  title: Managing Data
+- &id560
+  author: Greg Wilson
+  category: [Community, Michigan State University]
+  date: 2011-05-03
+  favorite: null
+  folder: blog/2011/05
+  layout: blog
+  path: blog/2011/05/the-hacker-within-at-msu-in-june.html
+  time: 09:00:00
+  title: The Hacker Within at MSU in June
+- &id561
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-05-06
+  favorite: null
+  folder: blog/2011/05
+  layout: blog
+  path: blog/2011/05/the-architecture-of-open-source-applications.html
+  time: 09:00:00
+  title: The Architecture of Open Source Applications
+- &id562
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-05-13
+  favorite: null
+  folder: blog/2011/05
+  layout: blog
+  path: blog/2011/05/damn-the-torpedoes.html
+  time: 09:00:00
+  title: Damn the Torpedoes (but I could use some help navigating)
+- &id563
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-05-14
+  favorite: null
+  folder: blog/2011/05
+  layout: blog
+  path: blog/2011/05/more-interested-in-the-asides.html
+  time: 09:00:00
+  title: More Interested in the Asides
+- &id564
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-05-23
+  favorite: null
+  folder: blog/2011/05
+  layout: blog
+  path: blog/2011/05/the-architecture-of-open-source-applications-is-now-available.html
+  time: 09:00:00
+  title: '''The Architecture of Open Source Applications'' is Now Available'
+- &id565
+  author: Greg Wilson
+  category: [CEF 2011]
+  date: 2011-06-01
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/workshop-at-cef11.html
+  time: 09:00:00
+  title: Workshop at CEF'11
+- &id566
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-06-02
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/five-on-systems-programming.html
+  time: 09:00:00
+  title: Five on Systems Programming
+- &id567
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-06-04
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/programming-for-scientists-at-newcastle-university-june-20-2011.html
+  time: 09:00:00
+  title: 'Programming for Scientists at Newcastle University: June 20, 2011'
+- &id568
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2011-06-07
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/practical-computing-for-everyone-not-just-biologists.html
+  time: 09:00:00
+  title: Practical Computing for Everyone (not just biologists)
+- &id569
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-06-10
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/audio-processing-in-python.html
+  time: 09:00:00
+  title: Audio Processing in Python
+- &id570
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2011-06-14
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/a-new-look.html
+  time: 09:00:00
+  title: A New Look
+- &id571
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-06-15
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/new-episode-matlab-structs-and-cell-arrays.html
+  time: 09:00:00
+  title: 'New Episode: MATLAB Structs and Cell Arrays'
+- &id572
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-06-18
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/health-informatics-resources.html
+  time: 09:00:00
+  title: Health Informatics Resources
+- &id573
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-06-20
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/doing-the-math.html
+  time: 09:00:00
+  title: Doing the Math
+- &id574
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-06-22
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/michael-nielsen-talks-about-open-science-in-san-francisco-on-june-29.html
+  time: 09:00:00
+  title: Michael Nielsen Talks About Open Science in San Francisco on June 29
+- &id575
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-06-29
+  favorite: null
+  folder: blog/2011/06
+  layout: blog
+  path: blog/2011/06/it-will-never-work-in-theory.html
+  time: 09:00:00
+  title: It Will Never Work in Theory
+- &id576
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-01
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/mentioned-in-nature-methods.html
+  time: 09:00:00
+  title: Mentioned in Nature Methods
+- &id577
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-06
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/reproducible-computational-geophysics.html
+  time: 09:00:00
+  title: Reproducible Computational Geophysics
+- &id578
+  author: Greg Wilson
+  category: [Stanford University]
+  date: 2011-07-10
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/stanford-course-went-well.html
+  time: 09:00:00
+  title: Stanford Course Went Well
+- &id579
+  author: Greg Wilson
+  category: [Community]
+  date: 2011-07-11
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/architecture-of-open-source-applications-webinars-tuesday-july-12-and-19.html
+  time: 09:00:00
+  title: Architecture of Open Source Applications Webinars Tuesday July 13 and 20
+- &id580
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-20
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/how-much-do-you-need.html
+  time: 36000
+  title: How Much Do You Need?
+- &id581
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-20
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/material-from-newcastle-workshop-now-available.html
+  time: 39600
+  title: Material from Newcastle Workshop Now Available
+- &id582
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-20
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/the-case-of-abinit.html
+  time: 43200
+  title: The Case of Abinit
+- &id583
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-20
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/and-speaking-of-titus-brown.html
+  time: 09:00:00
+  title: And Speaking of Titus Brown...
+- &id584
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-07-22
+  favorite: null
+  folder: blog/2011/07
+  layout: blog
+  path: blog/2011/07/software-carpentry-in-hpcwire.html
+  time: 09:00:00
+  title: Software Carpentry in HPCWire
+- &id585
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-08-04
+  favorite: null
+  folder: blog/2011/08
+  layout: blog
+  path: blog/2011/08/computing-in-physics-101-what-were-doing-wrong.html
+  time: 09:00:00
+  title: 'Computing in Physics 101: What We''re Doing Wrong'
+- &id586
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-08-08
+  favorite: null
+  folder: blog/2011/08
+  layout: blog
+  path: blog/2011/08/introducing-programming-a-different-way.html
+  time: 09:00:00
+  title: Introducing Programming a Different Way
+- &id587
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-08-17
+  favorite: null
+  folder: blog/2011/08
+  layout: blog
+  path: blog/2011/08/demos-reinforce-errors-and-confusion-is-good.html
+  time: 09:00:00
+  title: Demos Reinforce Errors, and Confusion is Good
+- &id588
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-09-01
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/renting-cycles-has-never-been-easier.html
+  time: 09:00:00
+  title: Renting Cycles Has Never Been Easier (For Some Definition of 'Easier')
+- &id589
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-09-02
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/teaching-security-to-scientists.html
+  time: 09:00:00
+  title: Teaching Security to Scientists
+- &id590
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-09-05
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/where-the-puck-is-going-to-be.html
+  time: 09:00:00
+  title: Where is the Puck Going to Be?
+- &id591
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-09-08
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/what-happens-when-you-install-something.html
+  time: 09:00:00
+  title: What Happens When You Install Something?
+- &id592
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-09-13
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/progress-of-a-sort.html
+  time: 09:00:00
+  title: Progress Of A Sort
+- &id593
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-09-17
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/the-simplest-web-that-could-possibly-work.html
+  time: 09:00:00
+  title: The Simplest Web That Could Possibly Work
+- &id594
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-09-20
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/im-not-normally-lost-for-words.html
+  time: 09:00:00
+  title: I'm Not Normally Lost for Words
+- &id595
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-09-22
+  favorite: null
+  folder: blog/2011/09
+  layout: blog
+  path: blog/2011/09/plus-ca-change.html
+  time: 09:00:00
+  title: Plus Ca Change...
+- &id596
+  author: Tommy Guy
+  category: [University of Toronto]
+  date: 2011-10-04
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/2011-software-carpentry-bootcamp-sold-out.html
+  time: 09:00:00
+  title: 2011 Software Carpentry Bootcamp Sold Out!
+- &id597
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2011-10-05
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/revamping-this-site.html
+  time: 09:00:00
+  title: Revamping This Site
+- &id598
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-10-07
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/four-new-episodes-on-databases-using-microsoft-access.html
+  time: 09:00:00
+  title: Four New Episodes on Databases Using Microsoft Access
+- &id599
+  author: Greg Wilson
+  category: [Content]
+  date: 2011-10-14
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/updating-to-html-5.html
+  time: 36000
+  title: Updating to HTML 5
+- &id600
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-10-14
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/the-science-code-manifestos-five-cs.html
+  time: 09:00:00
+  title: The Science Code Manifesto's Five C's
+- &id601
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-10-19
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/american-scientist-article-on-empirical-studies-of-software-engineering.html
+  time: 09:00:00
+  title: American Scientist Article on Empirical Studies of Software Engineering
+- &id602
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-10-21
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/slides-from-hans-martin.html
+  time: 09:00:00
+  title: Slides from Hans-Martin
+- &id603
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-10-22
+  favorite: null
+  folder: blog/2011/10
+  layout: blog
+  path: blog/2011/10/research-without-walls.html
+  time: 09:00:00
+  title: Research Without Walls
+- &id604
+  author: Greg Wilson
+  category: [University of Toronto]
+  date: 2011-11-06
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/nirvana-on-monday-night.html
+  time: 09:00:00
+  title: Nirvana on Monday Night
+- &id605
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-11-08
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/the-ladder-of-abstraction-and-the-future-of-online-teaching.html
+  time: 36000
+  title: The Ladder of Abstraction and the Future of Online Teaching
+- &id606
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-11-08
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/the-best-vs-the-good.html
+  time: 09:00:00
+  title: The Best vs. the Good
+- &id607
+  author: Tommy Guy
+  category: [Community, University of Toronto]
+  date: 2011-11-11
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/successful-bootcamp.html
+  time: 09:00:00
+  title: Successful Bootcamp
+- &id608
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-11-14
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/surviving-the-tsunami.html
+  time: 36000
+  title: Surviving the Tsunami
+- &id609
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-11-14
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/clearing-up-code.html
+  time: 09:00:00
+  title: Clearing Up Code
+- &id610
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-11-18
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/quantifying-installation-costs.html
+  time: 36000
+  title: Quantifying Installation Costs
+- &id611
+  author: Greg Wilson
+  category: [Opinion, Research]
+  date: 2011-11-18
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/show-me-the-data.html
+  time: 39600
+  title: Show Me the Data
+- &id612
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-11-18
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/accessible-to-all.html
+  time: 09:00:00
+  title: Accessible to All?
+- &id613
+  author: Katy Huff
+  category: [University of Wisconsin - Madison]
+  date: 2011-11-19
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/knowledge-of-the-second-kind.html
+  time: 09:00:00
+  title: Knowledge of the Second Kind
+- &id614
+  author: Greg Wilson
+  category: [Research]
+  date: 2011-11-25
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/building-a-bibliography.html
+  time: 09:00:00
+  title: Building a Bibliography
+- &id615
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-11-29
+  favorite: null
+  folder: blog/2011/11
+  layout: blog
+  path: blog/2011/11/three-short-thoughts.html
+  time: 09:00:00
+  title: Three Short Thoughts
+- &id616
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-07
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/how-to-teach-webcraft-and-programming-to-free-range-students.html
+  time: 09:00:00
+  title: How to Teach Webcraft and Programming to Free-Range Students
+- &id617
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2011-12-13
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/new-features-in-excel-for-scientists.html
+  time: 09:00:00
+  title: New Features in Excel for Scientists
+- &id618
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-20
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/what-ive-learned-so-far.html
+  time: 36000
+  title: What I've Learned So Far
+- &id619
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2011-12-20
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/it-just-keeps-on-hurting.html
+  time: 09:00:00
+  title: It Just Keeps On Hurting
+- &id620
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-24
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/what-success-looks-like-five-years-out.html
+  time: 36000
+  title: What Success Looks Like Five Years Out
+- &id621
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-24
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/organizing-instruction-and-study-to-improve-student-learning.html
+  time: 09:00:00
+  title: Organizing Instruction and Study to Improve Student Learning
+- &id622
+  author: Greg Wilson
+  category: [Research]
+  date: 2011-12-29
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/yet-another-survey.html
+  time: 09:00:00
+  title: Yet Another Survey
+- &id022
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-30
+  favorite: true
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/fork-merge-and-share.html
+  time: 09:00:00
+  title: Fork, Merge, and Share
+- &id623
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-31
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/the-fire-last-time.html
+  time: 36000
+  title: The Fire Last Time
+- &id624
+  author: Greg Wilson
+  category: [Education]
+  date: 2011-12-31
+  favorite: null
+  folder: blog/2011/12
+  layout: blog
+  path: blog/2011/12/some-responses-to-some-comments.html
+  time: 09:00:00
+  title: Some Responses to Some Comments
+- &id625
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-01-04
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/settings-our-sights-a-little-bit-lower.html
+  time: 09:00:00
+  title: Settings Our Sights a Little Bit Lower
+- &id626
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-01-11
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/sloan-foundation-grant-to-software-carpentry-and-mozilla.html
+  time: 09:00:00
+  title: Sloan Foundation Grant to Software Carpentry and Mozilla
+- &id627
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-01-13
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/the-what-why-and-how-of-boot-camps.html
+  time: 09:00:00
+  title: The What, Why, and How of Bootcamps
+- &id628
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-01-15
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/why-is-this-hard.html
+  time: 09:00:00
+  title: Why Is This Hard?
+- &id629
+  author: Greg Wilson
+  category: [Space Telescope Science Institute]
+  date: 2012-01-20
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/the-first-boot-camp-of-2012.html
+  time: 09:00:00
+  title: The First Bootcamp of 2012
+- &id630
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-01-23
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/revising-the-curriculum.html
+  time: 09:00:00
+  title: Revising the Curriculum
+- &id631
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-01-24
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/take-out-agile-and-add-what.html
+  time: 36000
+  title: Take Out Agile, and Add...What?
+- &id632
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-01-24
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/test-driven-public-speaking.html
+  time: 39600
+  title: Test-Driven Public Speaking
+- &id633
+  author: Greg Wilson
+  category: [Community, Sloan Foundation]
+  date: 2012-01-24
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/badging.html
+  time: 09:00:00
+  title: Badging
+- &id634
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-01-25
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/the-big-picture-2.html
+  time: 09:00:00
+  title: The Big Picture
+- &id635
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-01-26
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/our-long-tail.html
+  time: 36000
+  title: Our Long Tail
+- &id636
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-01-26
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/never-mind-the-content-what-about-the-format.html
+  time: 09:00:00
+  title: Never Mind the Content, What About the Format?
+- &id637
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-01-29
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/terminology.html
+  time: 36000
+  title: Terminology
+- &id638
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-01-29
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/learners-and-their-needs.html
+  time: 09:00:00
+  title: Learners and Their Needs
+- &id639
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2012-01-31
+  favorite: null
+  folder: blog/2012/01
+  layout: blog
+  path: blog/2012/01/reorganizing-this-web-site.html
+  time: 09:00:00
+  title: Reorganizing This Web Site
+- &id640
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-01
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/re-doing-the-three-minute-pitch.html
+  time: 09:00:00
+  title: Re-doing the Three-Minute Pitch
+- &id641
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-02-02
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/where-to-host-qa-and-discussion.html
+  time: 36000
+  title: Where To Host Q+A and Discussion?
+- &id642
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-02
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/software-carpentry-in-a-minute-and-a-half.html
+  time: 09:00:00
+  title: Software Carpentry in a Minute and a Half
+- &id643
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-02-03
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/were-going-to-be-busy.html
+  root: ../../..
+  time: 36000
+  title: We're Going to Be Busy
+- &id644
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-02-03
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/first-online-tutorial.html
+  time: 09:00:00
+  title: First Online Tutorial
+- &id645
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2012-02-07
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/why-we-dont-teach-parallel-computing-in-software-carpentry.html
+  time: 09:00:00
+  title: Why We Don't Teach Parallel Computing in Software Carpentry
+- &id646
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-09
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/multiple-pitches.html
+  time: 36000
+  title: Multiple Pitches
+- &id647
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-02-09
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/comparing-software-carpentry-to-cs-principles.html
+  time: 09:00:00
+  title: Comparing Software Carpentry to CS Principles
+- &id648
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-02-10
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/audrey-watters-on-software-carpentry.html
+  time: 36000
+  title: Audrey Watters on Software Carpentry
+- &id649
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-02-10
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/advanced-scientific-programming-in-python-2.html
+  time: 09:00:00
+  title: Advanced Scientific Programming in Python
+- &id650
+  author: Greg Wilson
+  category: [Content, Education, Assessment]
+  date: 2012-02-12
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/pre-workshop-questionnaire.html
+  time: 09:00:00
+  title: Pre-Workshop Questionnaire
+- &id651
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-13
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/formatting-revisited.html
+  time: 36000
+  title: Formatting Revisited
+- &id652
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-02-13
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/how-many-legs-does-science-have.html
+  time: 39600
+  title: How Many Legs Does Science Have?
+- &id653
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-13
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/our-new-look.html
+  time: 43200
+  title: Our New Look
+- &id654
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-13
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/advertising-flyer.html
+  time: 09:00:00
+  title: Advertising Flyer
+- &id655
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2012-02-14
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/stack-underflow.html
+  time: 36000
+  title: Stack Underflow?
+- &id656
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-02-14
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/new-kinds-of-content.html
+  time: 09:00:00
+  title: New Kinds of Content
+- &id657
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-02-15
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/and-speaking-of-new.html
+  time: 36000
+  title: And Speaking of New...
+- &id658
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-02-15
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/slide-drive.html
+  time: 39600
+  title: Slide Drive
+- &id659
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2012-02-15
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/watch-me-volunteers-wanted.html
+  time: 43200
+  title: 'Watch Me: Volunteers Wanted'
+- &id660
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-02-15
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/analyzing-next-generation-sequencing-data.html
+  time: 09:00:00
+  title: Analyzing Next-Generation Sequencing Data
+- &id661
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-02-16
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/how-they-see-us-part-n.html
+  time: 09:00:00
+  title: How They See Us, Part N
+- &id662
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-19
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/a-flash-well-mp4-from-the-past.html
+  time: 09:00:00
+  title: A Flash (well, MP4) from the Past
+- &id663
+  author: Greg Wilson
+  category: [Community, Content, Education, Assessment]
+  date: 2012-02-21
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/badges-mark-1.html
+  time: 36000
+  title: Badges (Mark 1)
+- &id664
+  author: Tommy Guy
+  category: [International Center for Theoretical Physics]
+  date: 2012-02-21
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/hello-from-trieste.html
+  time: 39600
+  title: Hello from Trieste!
+- &id665
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-02-21
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/why-not-use-python.html
+  time: 43200
+  title: Why *Not* Use Python
+- &id666
+  author: Greg Wilson
+  category: [Education, Assessment]
+  date: 2012-02-21
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/assessment-redux.html
+  time: 09:00:00
+  title: Assessment Redux
+- &id667
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-22
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/watch-me-trial-run.html
+  time: 36000
+  title: 'Watch Me: Trial Run'
+- &id668
+  author: Greg Wilson
+  category: [Education, Assessment]
+  date: 2012-02-22
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/what-deep-thoughts-look-like.html
+  time: 39600
+  title: What Deep Thoughts Look Like
+- &id669
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2012-02-22
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/granules-of-research.html
+  time: 09:00:00
+  title: Granules of Research
+- &id670
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-23
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/should-we-relocate-our-repository.html
+  time: 09:00:00
+  title: Should We Relocate Our Repository?
+- &id671
+  author: Katy Huff
+  category: [International Center for Theoretical Physics]
+  date: 2012-02-24
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/trieste-italy-workshop-week-1.html
+  time: 36000
+  title: Trieste, Italy Workshop - Week 1
+- &id672
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-24
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/fourth-or-sixth-online-tutorial.html
+  time: 09:00:00
+  title: Fourth (or Sixth) Online Tutorial
+- &id673
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-02-27
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/frustration-continued.html
+  time: 36000
+  title: Frustration (continued)
+- &id674
+  author: Greg Wilson
+  category: [Community, Content, Education, Assessment]
+  date: 2012-02-27
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/badges-finalized.html
+  time: 09:00:00
+  title: Badges (Finalized)
+- &id675
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2012-02-28
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/reproducibility-redux.html
+  time: 09:00:00
+  title: Reproducibility Redux
+- &id676
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-02-29
+  favorite: null
+  folder: blog/2012/02
+  layout: blog
+  path: blog/2012/02/worth-reading-worth-watching.html
+  time: 09:00:00
+  title: Worth Reading, Worth Watching
+- &id677
+  author: Greg Wilson
+  category: [Assessment, University of Toronto]
+  date: 2012-03-01
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/toronto-boot-camp-february-2012-how-we-did.html
+  root: ../../..
+  time: 36000
+  title: 'Toronto Bootcamp February 2012: How We Did'
+- &id678
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-03-01
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/ulp-or-this-is-tricky-and-perhaps-profound.html
+  time: 39600
+  title: ULP (or, This is tricky and perhaps profound)
+- &id679
+  author: Greg Wilson
+  category: [International Center for Theoretical Physics, Noticed]
+  date: 2012-03-01
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/inscight-from-trieste.html
+  root: ../../..
+  time: 09:00:00
+  title: Inscight from Trieste
+- &id680
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-03-04
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/performance-curves-curriculum-design-and-trust.html
+  time: 09:00:00
+  title: Performance Curves, Curriculum Design, and Trust
+- &id681
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2012-03-05
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/help-us-write-assessment-questions.html
+  time: 36000
+  title: Help Us Write Assessment Questions
+- &id682
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-03-05
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/open-education-week.html
+  time: 39600
+  title: Open Education Week
+- &id021
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-03-05
+  favorite: true
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/programs-as-experimental-apparatus.html
+  time: 43200
+  title: Programs as Experimental Apparatus
+- &id683
+  author: Greg Wilson
+  category: [International Center for Theoretical Physics]
+  date: 2012-03-05
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/happy-people.html
+  time: 09:00:00
+  title: Happy People
+- &id684
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-03-07
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/software-carpentry-meetup-at-pycon.html
+  time: 36000
+  title: Software Carpentry Meetup at PyCon
+- &id685
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-03-07
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/i-resemble-that-remark.html
+  time: 09:00:00
+  title: I Resemble That Remark
+- &id686
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-03-09
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/whats-the-model-kenneth.html
+  time: 36000
+  title: What's the Model, Kenneth?
+- &id687
+  author: Greg Wilson
+  category: [Indiana University]
+  date: 2012-03-09
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/our-indiana-u-workshop-went-well.html
+  time: 09:00:00
+  title: Our Indiana U Workshop Went Well
+- &id688
+  author: Tommy Guy
+  category: [International Center for Theoretical Physics]
+  date: 2012-03-12
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/the-trieste-workshop-one-week-later.html
+  time: 36000
+  title: The Trieste Workshop, One Week Later
+- &id689
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-03-12
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/the-ipython-notebook.html
+  time: 09:00:00
+  title: The IPython Notebook
+- &id690
+  author: Greg Wilson
+  category: [Indiana University]
+  date: 2012-03-14
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/how-were-doing.html
+  time: 36000
+  title: How We're Doing
+- &id691
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2012-03-14
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/where-next-for-the-next-gen-course.html
+  time: 39600
+  title: Where Next for the Next-Gen Course (and Software Carpentry)?
+- &id692
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-03-14
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/ask-the-compusciencegeek.html
+  time: 09:00:00
+  title: Ask the CompuScienceGeek?
+- &id693
+  author: Greg Wilson
+  category: [Education, Indiana University, University of Toronto]
+  date: 2012-03-15
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/first-homework-for-indiana-students-and-a-few-from-ontario.html
+  time: 09:00:00
+  title: First Homework for Indiana Students (and a few from Ontario)
+- &id694
+  author: Greg Wilson
+  category: [Assessment, Online, Space Telescope Science Institute]
+  date: 2012-03-16
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/wrapping-up-the-stsci-course.html
+  time: 36000
+  title: Wrapping Up the STScI Course
+- &id695
+  author: Greg Wilson
+  category: [Enthought]
+  date: 2012-03-16
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/thank-you-enthought.html
+  time: 09:00:00
+  title: Thank You, Enthought
+- &id696
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-03-18
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/the-dark-matter-of-computational-science.html
+  time: 36000
+  title: The Dark Matter of Computational Science
+- &id697
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-03-18
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/and-while-were-stuck-here-with-21-seconds-worth-of-music-to-fill.html
+  time: 09:00:00
+  title: And While We're Stuck Here With 21 Seconds Worth of Music to Fill...
+- &id698
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-03-23
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/object-oriented-programming-in-fortran-2003.html
+  time: 09:00:00
+  title: Object-Oriented Programming in Fortran 2003
+- &id699
+  author: Greg Wilson
+  category: [Monterey Bay Aquarium Research Institute]
+  date: 2012-03-28
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/wrapping-up-mbari-workshop.html
+  time: 36000
+  title: Wrapping Up MBARI Workshop
+- &id700
+  author: Greg Wilson
+  category: [INRIA Paris]
+  date: 2012-03-28
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/boot-camp-in-paris-june-28-29-2012.html
+  root: ../../..
+  time: 09:00:00
+  title: Bootcamp in Paris June 28-29, 2012
+- &id701
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-03-30
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/what-we-teach-in-two-days.html
+  time: 36000
+  title: What We Teach in Two Days
+- &id702
+  author: Greg Wilson
+  category: [NERSC]
+  date: 2012-03-30
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/wrapping-up-in-oakland.html
+  time: 39600
+  title: Wrapping Up in Oakland
+- &id703
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-03-30
+  favorite: null
+  folder: blog/2012/03
+  layout: blog
+  path: blog/2012/03/momentum.html
+  time: 09:00:00
+  title: Maintaining Momentum
+- &id704
+  author: Greg Wilson
+  category: [Content, Opinion]
+  date: 2012-04-01
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/what-to-teach-researchers-about-the-web.html
+  time: 36000
+  title: What to Teach Researchers About the Web
+- &id705
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-04-01
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/sending-email-back-in-time.html
+  time: 09:00:00
+  title: Sending Email Back in Time
+- &id706
+  author: Greg Wilson
+  category: [Indiana University, Tutorial]
+  date: 2012-04-03
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/solution-to-the-first-image-processing-homework.html
+  time: 36000
+  title: Solution to the First Image Processing Homework
+- &id707
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-04-03
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/upcoming-events-for-webmaking-instructors.html
+  time: 39600
+  title: Upcoming Events for Webmaking Instructors
+- &id708
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-04-03
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/a-four-day-curriculum.html
+  time: 09:00:00
+  title: A Four-Day Curriculum
+- &id709
+  author: Greg Wilson
+  category: [Space Telescope Science Institute, Tutorial]
+  date: 2012-04-04
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/solution-to-data-checking-problem.html
+  time: 09:00:00
+  title: Solution to Data Checking Problem
+- &id710
+  author: Katy Huff
+  category: [University of Chicago]
+  date: 2012-04-05
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/lessons-learned-at-the-university-of-chicago.html
+  time: 09:00:00
+  title: Lessons Learned at the University Of Chicago
+- &id711
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-04-06
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/titus-brown-finds-a-theme.html
+  time: 36000
+  title: Titus Brown Finds a Theme
+- &id712
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2012-04-06
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/on-crossing-australia.html
+  time: 09:00:00
+  title: On Crossing Australia (or, Further Thoughts on What to Teach Researchers
+    about the Web)
+- &id713
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-04-09
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/a-future-student.html
+  time: 09:00:00
+  title: A Future Student
+- &id714
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-04-10
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/straw-man-for-web-programming.html
+  time: 09:00:00
+  title: Straw Man for Web Programming
+- &id715
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-04-12
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/video-update.html
+  time: 36000
+  title: Video Update
+- &id716
+  author: Greg Wilson
+  category: [Tutorial]
+  date: 2012-04-12
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/solution-to-data-merging-with-dictionaries.html
+  time: 09:00:00
+  title: Solution to Data Merging with Dictionaries
+- &id717
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-04-14
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/were-neutral-but-not-really.html
+  time: 09:00:00
+  title: We're Neutral (but Not Really)
+- &id718
+  author: Greg Wilson
+  category: [Tutorial]
+  date: 2012-04-15
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/data-munging-with-regular-expressions.html
+  time: 09:00:00
+  title: Data Munging with Regular Expressions
+- &id719
+  author: Greg Wilson
+  category: [Utah State University]
+  date: 2012-04-16
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/utah-state-university-wrap-up.html
+  time: 09:00:00
+  title: Utah State University Wrap-Up
+- &id720
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2012-04-17
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/halfway-home.html
+  time: 36000
+  title: Halfway Home
+- &id721
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-04-17
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/in-search-of-prior-arguments.html
+  time: 39600
+  title: In Search of Prior Arguments
+- &id722
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2012-04-17
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/github-for-education.html
+  time: 09:00:00
+  title: GitHub for Education
+- &id723
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-04-18
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/where-next.html
+  time: 36000
+  title: Where Next?
+- &id724
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-04-18
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/behind-the-scenes-or-the-ethics-of-cultivating-discontent.html
+  time: 09:00:00
+  title: Behind the Scenes (or, the Ethics of Cultivating Discontent)
+- &id725
+  author: Hanah Chapman
+  category: [Stories]
+  date: 2012-04-19
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/three-years-later.html
+  time: 09:00:00
+  title: Three Years Later
+- &id726
+  author: Greg Wilson
+  category: [Tutorial]
+  date: 2012-04-20
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/an-exercise-with-sets-and-dictionaries.html
+  time: 09:00:00
+  title: An Exercise With Sets and Dictionaries
+- &id727
+  author: Greg Wilson
+  category: [Tutorial]
+  date: 2012-04-26
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/solution-to-sets-and-dictionaries-exercise.html
+  time: 09:00:00
+  title: Solution to Sets and Dictionaries Exercise
+- &id728
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2012-04-28
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/stop-me-if-youve-heard-this-one.html
+  time: 09:00:00
+  title: Stop Me If You've Heard This One
+- &id729
+  author: Neil Chue Hong
+  category: [Opinion, University College London]
+  date: 2012-04-30
+  favorite: null
+  folder: blog/2012/04
+  layout: blog
+  path: blog/2012/04/better-across-the-pond.html
+  time: 09:00:00
+  title: Better Across the Pond?
+- &id730
+  author: Neil Chue Hong
+  category: [Assessment, University College London]
+  date: 2012-05-02
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/the-good-and-the-bad-of-it.html
+  time: 09:00:00
+  title: The Good and the Bad of It
+- &id731
+  author: Chris Cannam
+  category: [Assessment, University College London]
+  date: 2012-05-04
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/ucl-bootcamp-version-control-wrap-up.html
+  root: ../../..
+  time: 09:00:00
+  title: 'UCL Bootcamp: Version Control Wrap-Up'
+- &id732
+  author: Mike Hansen
+  category: [Content]
+  date: 2012-05-06
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/an-exercise-with-functions-and-plotting.html
+  time: 09:00:00
+  title: An Exercise With Functions and Plotting
+- &id733
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-05-08
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/the-architecture-of-open-source-applications-volume-2.html
+  time: 09:00:00
+  title: 'The Architecture of Open Source Applications: Volume 2'
+- &id734
+  author: Greg Wilson
+  category: [MIT]
+  date: 2012-05-09
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/boot-camp-in-boston-july-9-10.html
+  time: 09:00:00
+  title: Bootcamp in Boston, July 9-10
+- &id735
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-05-10
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/fish-and-bugs.html
+  time: 09:00:00
+  title: Fish and Bugs
+- &id736
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-05-11
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/run-my-code.html
+  time: 09:00:00
+  title: Run My Code
+- &id737
+  author: Greg Wilson
+  category: [Michigan State University]
+  date: 2012-05-12
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/feedback-from-michigan-state.html
+  time: 09:00:00
+  title: Feedback from Michigan State
+- &id738
+  author: Greg Wilson
+  category: [Tutorial]
+  date: 2012-05-14
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/solution-to-indented-list-problem.html
+  time: 09:00:00
+  title: Solution to Indented List Problem
+- &id739
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-05-15
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/fooling-the-internet.html
+  time: 36000
+  title: Fooling the Internet
+- &id740
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-05-15
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/two-boot-camps-in-ontario-in-july.html
+  root: ../../..
+  time: 39600
+  title: Two Bootcamps in Ontario in July
+- &id741
+  author: Chris Cannam
+  category: [University of Newcastle]
+  date: 2012-05-15
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/feedback-from-newcastle-upon-tyne.html
+  root: ../../..
+  time: 09:00:00
+  title: Feedback from Newcastle upon Tyne
+- &id742
+  author: Greg Wilson
+  category: [Johns Hopkins University]
+  date: 2012-05-16
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/and-one-more-johns-hopkins-in-june.html
+  time: 09:00:00
+  title: 'And One More: Johns Hopkins in June'
+- &id743
+  author: Greg Wilson
+  category: [Saint Mary's University]
+  date: 2012-05-17
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/halifax-in-july.html
+  time: 09:00:00
+  title: Halifax in July
+- &id020
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-05-18
+  favorite: true
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/the-most-important-scientific-result-published-in-the-last-year.html
+  time: 36000
+  title: The Most Important Scientific Result Published in the Last Year
+- &id744
+  author: Greg Wilson
+  category: [University of Alberta]
+  date: 2012-05-18
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/feedback-from-alberta.html
+  time: 09:00:00
+  title: Feedback from Alberta
+- &id745
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-05-19
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/space-at-upcoming-events.html
+  time: 09:00:00
+  title: Space at Upcoming Events
+- &id746
+  author: Greg Wilson
+  category: [Opinion, Tooling]
+  date: 2012-05-20
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/whats-wrong-with-all-this.html
+  time: 09:00:00
+  title: What's Wrong With All This?
+- &id747
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-05-21
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/being-more-systematic-about-publicity.html
+  time: 36000
+  title: Being More Systematic About Publicity
+- &id748
+  author: Mike Hansen
+  category: [Tutorial]
+  date: 2012-05-21
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/an-exercise-with-matplotlib-and-numpy.html
+  time: 09:00:00
+  title: An Exercise With Matplotlib and Numpy
+- &id749
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-05-22
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/citing-versions.html
+  time: 09:00:00
+  title: Citing Versions
+- &id750
+  author: Greg Wilson
+  category: [Noticed, Opinion]
+  date: 2012-05-23
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/responsible-conduct.html
+  time: 36000
+  title: Responsible Conduct
+- &id751
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-05-23
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/alone-and-misunderstood.html
+  time: 09:00:00
+  title: Alone and Misunderstood
+- &id752
+  author: Greg Wilson
+  category: [Education, Research]
+  date: 2012-05-24
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/no-ct-without-pl.html
+  time: 36000
+  title: No CT Without PL
+- &id753
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-05-24
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/spot-the-workshops.html
+  time: 39600
+  title: Spot the Workshops
+- &id754
+  author: Greg Wilson
+  category: [University of British Columba]
+  date: 2012-05-24
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/feedback-from-the-university-of-british-columbia.html
+  time: 09:00:00
+  title: Feedback from the University of British Columbia
+- &id019
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-05-27
+  favorite: true
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/what-to-read-if-youre-teaching-software-carpentry.html
+  time: 09:00:00
+  title: What to Read If You're Teaching Software Carpentry
+- &id755
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-05-29
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/how-to-run-a-bootcamp.html
+  time: 09:00:00
+  title: How to Run a Bootcamp
+- &id756
+  author: Luis Figueira
+  category: [Community, Education, Content, Research]
+  date: 2012-05-30
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/soundsoftware-2012-workshop.html
+  time: 36000
+  title: 'SoundSoftware 2012: Workshop on Software and Data for Audio and Music Research'
+- &id757
+  author: Greg Wilson
+  category: [INRIA Paris]
+  date: 2012-05-30
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/a-poster-for-the-software-carpentry-workshop-at-inria.html
+  time: 09:00:00
+  title: A Poster for the Software Carpentry Workshop at INRIA
+- &id758
+  author: Dan McGlinn
+  category: [Education, Tutorial]
+  date: 2012-05-31
+  favorite: null
+  folder: blog/2012/05
+  layout: blog
+  path: blog/2012/05/dictionaries-are-a-scientists-friend.html
+  time: 09:00:00
+  title: Dictionaries are a Scientist's Friend
+- &id759
+  author: Matt Davis
+  category: [Tutorial]
+  date: 2012-06-01
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/introduction-to-numpy-tutorial.html
+  time: 09:00:00
+  title: Introduction to NumPy Tutorial
+- &id760
+  author: Carlos Anderson
+  category: [Tutorial]
+  date: 2012-06-03
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/git-tutorial-links.html
+  time: 09:00:00
+  title: Git tutorial links
+- &id761
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2012-06-04
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/what-skills-are-required-to-implement-open-access.html
+  time: 36000
+  title: What Skills Are Required to Implement Open Access?
+- &id762
+  author: Greg Wilson
+  category: [Noticed, Tooling]
+  date: 2012-06-04
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/software-carpentry-the-e-book-version.html
+  time: 09:00:00
+  title: 'Software Carpentry: The E-Book Version?'
+- &id763
+  author: Matt Davis
+  category: [Tutorial]
+  date: 2012-06-07
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/tutorial-numpy-scipy-and-matplotlib.html
+  time: 36000
+  title: 'Tutorial: NumPy, SciPy, and matplotlib'
+- &id764
+  author: Greg Wilson
+  category: [Content, Noticed]
+  date: 2012-06-07
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/ten-simple-rules.html
+  time: 09:00:00
+  title: Ten Simple Rules
+- &id765
+  author: Greg Wilson
+  category: [Community, University of British Columba]
+  date: 2012-06-08
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/we-get-mail.html
+  time: 36000
+  title: We Get Mail
+- &id766
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-06-08
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/but-the-greatest-of-these-is.html
+  time: 09:00:00
+  title: But the Greatest of These Is...
+- &id767
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2012-06-10
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/first-workshop-on-maintainable-software-practices-in-e-science.html
+  time: 09:00:00
+  title: First Workshop on Maintainable Software Practices in e-Science
+- &id768
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-06-14
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/all-entries-for-the-executable-paper-grand-challenge.html
+  time: 09:00:00
+  title: All Entries for the Executable Paper Grand Challenge
+- &id769
+  author: Greg Wilson
+  category: [Tutorial]
+  date: 2012-06-15
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/this-weeks-tutorials.html
+  time: 36000
+  title: This Week's Tutorials
+- &id770
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-06-15
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/pretty-well-sums-it-up.html
+  time: 09:00:00
+  title: Pretty Well Sums It Up
+- &id771
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-06-18
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/a-busy-week.html
+  time: 09:00:00
+  title: A Busy Week (And Schwag!)
+- &id772
+  author: Matt Davis
+  category: [Johns Hopkins University]
+  date: 2012-06-20
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/feedback-from-johns-hopkins.html
+  time: 09:00:00
+  title: Feedback from Johns Hopkins
+- &id773
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2012-06-25
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/if-you-want-to-teach-isnt-it-only-fair-to-learn-a-few-things-first.html
+  root: ../../..
+  time: 09:00:00
+  title: If You Want to Teach, Isn't It Only Fair to Learn a Few Things First?
+- &id774
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-06-26
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/pessimism-and-doom.html
+  time: 36000
+  title: Pessimism and Doom
+- &id775
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-06-26
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/two-posts-on-scientific-workflows.html
+  time: 39600
+  title: Two Posts on Scientific Workflows
+- &id776
+  author: Greg Wilson
+  category: [Content, Tutorial]
+  date: 2012-06-26
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/handling-variant-configuration-files.html
+  time: 09:00:00
+  title: Handling Variant Configuration Files
+- &id777
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-06-27
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/fortran-format-statements-and-regular-expressions.html
+  time: 36000
+  title: Fortran Format Statements and Regular Expressions
+- &id778
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-06-27
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/where-we-are-june-2012-edition.html
+  time: 39600
+  title: Where We Are (June 2012 edition)
+- &id779
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2012-06-27
+  favorite: null
+  folder: blog/2012/06
+  layout: blog
+  path: blog/2012/06/a-supercomputing-drivers-license.html
+  time: 09:00:00
+  title: A Supercomputing Driver's License
+- &id780
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2012-07-05
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/independent-assessment-of-the-past-six-months.html
+  root: ../../..
+  time: 09:00:00
+  title: Independent Assessment of the Past Six Months
+- &id781
+  author: Greg Wilson
+  category: [MIT]
+  date: 2012-07-10
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/wrapping-up-in-boston.html
+  time: 09:00:00
+  title: Wrapping Up in Boston
+- &id782
+  author: Greg Wilson
+  category: [Saint Mary's University]
+  date: 2012-07-17
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/wrapping-up-in-halifax.html
+  time: 09:00:00
+  title: Wrapping Up in Halifax
+- &id783
+  author: Tommy Guy
+  category: [Rutherford Appleton Laboratory]
+  date: 2012-07-19
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/workshop-wrap-up-from-the-rutherford-appleton-laboratory.html
+  time: 09:00:00
+  title: Workshop wrap up from the Rutherford Appleton Laboratory
+- &id784
+  author: Nelle Varoquaux
+  category: [INRIA Paris]
+  date: 2012-07-21
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/software-carpentry-in-paris.html
+  time: 36000
+  title: Software Carpentry in Paris !
+- &id785
+  author: Greg Wilson
+  category: [Education, Opinion, Tooling]
+  date: 2012-07-21
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/how-robust-is-your-programming-language.html
+  time: 09:00:00
+  title: How Robust Is Your Programming Language?
+- &id786
+  author: Greg Wilson
+  category: [Education, Tooling]
+  date: 2012-07-22
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/ipython-notebook-towtruck-etherpad-slide-drive-win.html
+  time: 09:00:00
+  title: IPython Notebook + Towtruck + Etherpad + Slide Drive = Win
+- &id787
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-07-28
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/software-carpentry-needs-you.html
+  time: 09:00:00
+  title: Software Carpentry Needs You!
+- &id788
+  author: Greg Wilson
+  category: [Content, Tooling]
+  date: 2012-07-30
+  favorite: null
+  folder: blog/2012/07
+  layout: blog
+  path: blog/2012/07/record-and-playback.html
+  time: 09:00:00
+  title: Record and Playback
+- &id789
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-08-01
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/were-going-to-be-busy-2.html
+  time: 36000
+  title: We're Going to Be Busy
+- &id790
+  author: Greg Wilson
+  category: [University of California - Berkeley]
+  date: 2012-08-01
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/that-was-quick.html
+  time: 09:00:00
+  title: That Was Quick
+- &id791
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-08-14
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/applying-pedagogical-principles-in-this-course.html
+  time: 36000
+  title: Applying Pedagogical Principles in This Course
+- &id792
+  author: Greg Wilson
+  category: [Community, Interviews]
+  date: 2012-08-14
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/interview-about-software-carpentry-and-education.html
+  time: 39600
+  title: Interview about Software Carpentry (and Education)
+- &id793
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-08-14
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/a-question-and-answer-matrix-for-software-carpentry.html
+  time: 09:00:00
+  title: A Question and Answer Matrix for Software Carpentry
+- &id794
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2012-08-16
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/alpha-test-of-drivers-license-exam.html
+  time: 09:00:00
+  title: Alpha Test of Driver's License Exam
+- &id795
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-08-17
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/who-are-you.html
+  time: 09:00:00
+  title: Who Are You?
+- &id796
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-08-20
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/what-we-talk-about-when-we-talk-about-software-carpentry.html
+  time: 09:00:00
+  title: What We Talk About When We Talk About Software Carpentry
+- &id797
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-08-21
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/an-updated-list-of-upcoming-workshops.html
+  time: 09:00:00
+  title: An Updated List of Upcoming Workshops
+- &id798
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2012-08-27
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/an-interview-with-titus-brown.html
+  time: 09:00:00
+  title: An Interview with Titus Brown
+- &id799
+  author: Greg Wilson
+  category: [Community, Research]
+  date: 2012-08-29
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/linking-forward-from-a-bibliography.html
+  time: 36000
+  title: Linking Forward From a Bibliography?
+- &id800
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-08-29
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/please-help-the-hunter-family.html
+  time: 39600
+  title: Please Help the Hunter Family
+- &id801
+  author: Greg Wilson
+  category: [Community, Content, Education]
+  date: 2012-08-29
+  favorite: null
+  folder: blog/2012/08
+  layout: blog
+  path: blog/2012/08/a-problem-with-badges.html
+  time: 09:00:00
+  title: A Problem With Badges
+- &id802
+  author: Greg Wilson
+  category: [Content, Education, Opinion]
+  date: 2012-09-02
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/lifted-by-the-audience.html
+  time: 09:00:00
+  title: Lifted by the Audience
+- &id803
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2012-09-04
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/free-as-in-pretty-much-whatever-you-want.html
+  time: 36000
+  title: Free As In Pretty Much Whatever You Want
+- &id804
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-09-04
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/not-really-disjoint.html
+  time: 39600
+  title: Not Really Disjoint
+- &id805
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-09-04
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/final-results-of-demographic-survey.html
+  time: 09:00:00
+  title: Final Results of Demographic Survey
+- &id806
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-09-06
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/how-quickly-do-workshops-fill-up.html
+  time: 09:00:00
+  title: How Quickly Do Workshops Fill Up?
+- &id807
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-09-12
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/the-software-is-open-even-if-the-interviews-arent.html
+  time: 36000
+  title: The Software Is Open (even if the interviews aren't)
+- &id808
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-09-12
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/patterns-wanted.html
+  time: 09:00:00
+  title: Patterns Wanted
+- &id809
+  author: Matt Davis
+  category: [Community]
+  date: 2012-09-13
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/number-crunching-with-python-dc-python-workshop.html
+  time: 09:00:00
+  title: 'Number Crunching with Python: DC Python Workshop'
+- &id810
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-09-16
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/systematic-curriculum-design.html
+  time: 09:00:00
+  title: Systematic Curriculum Design
+- &id811
+  author: Greg Wilson
+  category: [Community, Content]
+  date: 2012-09-18
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/whats-in-your-stack.html
+  time: 36000
+  title: What's In Your Stack?
+- &id812
+  author: Greg Wilson
+  category: [Community, Assessment]
+  date: 2012-09-18
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/post-mortem-on-the-ngs-course.html
+  time: 09:00:00
+  title: Post-Mortem on the NGS Course
+- &id813
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-09-20
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/why-this-stuff-is-hard-to-teach.html
+  time: 36000
+  title: Why This Stuff Is Hard To Teach
+- &id814
+  author: Chris Cannam
+  category: [University of York, SoundSoftware]
+  date: 2012-09-20
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/feedback-and-wrap-up-from-york.html
+  time: 09:00:00
+  title: Feedback and wrap-up from York
+- &id815
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2012-09-26
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/computational-thinking-and-ice-floating-in-bathtubs.html
+  time: 09:00:00
+  title: Computational Thinking and Ice Floating in Bathtubs
+- &id816
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-09-27
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/how-to-run-a-bootcamp-new-and-improved.html
+  time: 09:00:00
+  title: How to Run a Bootcamp (new and improved)
+- &id817
+  author: Greg Wilson
+  category: [University of Newcastle]
+  date: 2012-09-29
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/workshop-at-the-university-of-newcastle-in-october.html
+  time: 09:00:00
+  title: Workshop at the University of Newcastle in October
+- &id018
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2012-09-30
+  favorite: true
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/the-real-hard-work.html
+  time: 36000
+  title: The Real Hard Work
+- &id818
+  author: Greg Wilson
+  category: [Columbia University, University of Oslo]
+  date: 2012-09-30
+  favorite: null
+  folder: blog/2012/09
+  layout: blog
+  path: blog/2012/09/oslo-and-columbia.html
+  time: 09:00:00
+  title: Oslo and Columbia
+- &id819
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-10-01
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/what-would-you-like-in-an-instructors-guide.html
+  time: 09:00:00
+  title: What Would You Like in an Instructor's Guide?
+- &id820
+  author: Katy Huff
+  category: [Community]
+  date: 2012-10-02
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/how-to-help-at-a-boot-camp.html
+  time: 09:00:00
+  title: How to Help at a Bootcamp
+- &id821
+  author: Greg Wilson
+  category: [Content, Research]
+  date: 2012-10-03
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/best-practices-for-scientific-computing.html
+  time: 09:00:00
+  title: Best Practices for Scientific Computing
+- &id822
+  author: Greg Wilson
+  category: [Community, Opinion]
+  date: 2012-10-04
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/wanted-an-entry-level-provenance-library.html
+  time: 36000
+  title: 'Wanted: An Entry-Level Provenance Library'
+- &id823
+  author: Matt Davis
+  category: [Content]
+  date: 2012-10-04
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/transitioning-to-the-ipython-notebook.html
+  time: 09:00:00
+  title: Transitioning to the IPython Notebook
+- &id824
+  author: Ben Waugh
+  category: [Community]
+  date: 2012-10-05
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/ucl-researchers-to-get-help-with-software-development.html
+  time: 36000
+  title: UCL Researchers to Get Help with Software Development
+- &id825
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-10-05
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/convergent-evolution.html
+  time: 09:00:00
+  title: Convergent Evolution
+- &id826
+  author: Mike Hansen
+  category: [Purdue University]
+  date: 2012-10-10
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/purdue.html
+  time: 36000
+  title: Purdue
+- &id017
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-10-10
+  favorite: true
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/dark-matter-public-health-and-scientific-computing.html
+  time: 09:00:00
+  title: Dark Matter, Public Health, and Scientific Computing
+- &id827
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-10-12
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/why-we-teach-version-control.html
+  time: 36000
+  title: Why We Teach Version Control
+- &id828
+  author: Greg Wilson
+  category: [Content, Opinion, Tooling]
+  date: 2012-10-12
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/rebuilding-redux.html
+  time: 09:00:00
+  title: Rebuilding Redux
+- &id829
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-10-17
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/i-screwed-up-or-why-too-much-automation-isnt-necessarily-a-good-thing.html
+  time: 09:00:00
+  title: I Screwed Up (or, Why Automation Isn't Always a Good Thing)
+- &id830
+  author: Matt Davis
+  category: [Lawrence Berkeley National Laboratory]
+  date: 2012-10-20
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/feedback-from-lawrence-berkeley-lab.html
+  time: 09:00:00
+  title: Feedback from Lawrence Berkeley National Lab
+- &id831
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-10-21
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/why-teaching-people-to-program-is-hard.html
+  time: 09:00:00
+  title: Why Teaching People to Program Is Hard
+- &id832
+  author: Matt Davis
+  category: [University of California - Berkeley]
+  date: 2012-10-22
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/feedback-from-uc-berkeley.html
+  time: 36000
+  title: Feedback from UC Berkeley
+- &id833
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-10-22
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/getting-credit.html
+  time: 39600
+  title: Getting Credit
+- &id834
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-10-22
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/excel-isnt-intrinsically-evil.html
+  time: 09:00:00
+  title: Excel Isn't Intrinsically Evil
+- &id835
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-10-23
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/key-points.html
+  time: 36000
+  title: Key Points
+- &id016
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-10-23
+  favorite: true
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/twenty-percent.html
+  time: 39600
+  title: Twenty Percent
+- &id836
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-10-23
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/25-questions.html
+  time: 09:00:00
+  title: 25 Questions
+- &id837
+  author: Mike Jackson
+  category: [Assessment]
+  date: 2012-10-24
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/feedback-from-newcastle.html
+  time: 09:00:00
+  title: Feedback from Newcastle
+- &id838
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-10-25
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/prime-numbers-biologists-and-data-visualization.html
+  time: 09:00:00
+  title: Prime Numbers, Biologists, and Data Visualization
+- &id839
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-10-26
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/mozilla-web-literacies-white-paper.html
+  time: 36000
+  title: Mozilla Web Literacies White Paper
+- &id840
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2012-10-26
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/two-self-assessments.html
+  time: 39600
+  title: Two Self-Assessments
+- &id841
+  author: Greg Wilson
+  category: [Education, Tooling, Tutorial]
+  date: 2012-10-26
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/counting-to-five-or-a-plan-for-online-tutorials-and-whats-wrong-with-it.html
+  time: 09:00:00
+  title: Counting to Five (or, A Plan for Online Tutorials and What's Wrong With It)
+- &id842
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-10-27
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/why-this-is-hard-part-deux.html
+  time: 09:00:00
+  title: Why This Is Hard (Part Deux)
+- &id843
+  author: Greg Wilson
+  category: [Content, Education]
+  date: 2012-10-28
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/usability-testing-instructional-design.html
+  time: 09:00:00
+  title: Usability Testing and Instructional Design
+- &id844
+  author: Greg Wilson
+  category: [Jobs]
+  date: 2012-10-29
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/position-available-director-webmaking-science-lab-mozilla.html
+  time: 09:00:00
+  title: 'Position Available: Director, Webmaking Science Lab, Mozilla'
+- &id845
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-10-30
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/minutes-2012-10-29-meeting.html
+  time: 36000
+  title: Minutes from 2012-10-29 All-Hands Meeting
+- &id846
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2012-10-30
+  favorite: null
+  folder: blog/2012/10
+  layout: blog
+  path: blog/2012/10/a-list-of-bioinformatics-courses.html
+  time: 09:00:00
+  title: A List of Bioinformatics Courses
+- &id847
+  author: Greg Wilson
+  category: [Oxford University]
+  date: 2012-11-01
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/oxford-wrap-up-with-charts.html
+  time: 36000
+  title: Oxford Wrap-Up (with charts!)
+- &id848
+  author: Jon Pipitone
+  category: [Content, Tooling]
+  date: 2012-11-01
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/pelican-guts.html
+  time: 39600
+  title: 'Pelican Guts: on content management for Software Carpentry'
+- &id849
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-11-01
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/charging-and-being-charged.html
+  time: 09:00:00
+  title: Charging and Being Charged
+- &id850
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2012-11-03
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/how-to-help-at-a-boot-camp-2.html
+  time: 09:00:00
+  title: How to Help at a Bootcamp
+- &id851
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-11-04
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/winter-school-on-reproducible-research.html
+  time: 09:00:00
+  title: Winter School on Reproducible Research
+- &id852
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2012-11-05
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/an-administrative-note.html
+  time: 09:00:00
+  title: An Administrative Note
+- &id853
+  author: Greg Wilson
+  category: [Oxford University, Teaching]
+  date: 2012-11-06
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/more-tips.html
+  time: 09:00:00
+  title: More Tips
+- &id854
+  author: Mike Jackson
+  category: [Oxford University]
+  date: 2012-11-07
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/more-oxford-feedback.html
+  time: 09:00:00
+  title: More Oxford feedback
+- &id855
+  author: Greg Wilson
+  category: [Community, Noticed, Opinion]
+  date: 2012-11-13
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/web-4-science.html
+  time: 36000
+  title: Web 4 Science
+- &id856
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2012-11-13
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/pre-assessment.html
+  time: 09:00:00
+  title: Pre-Assessment
+- &id857
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-11-14
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/fosdem-2013.html
+  time: 36000
+  title: FOSDEM 2013
+- &id858
+  author: Ben Waugh
+  category: [University College London]
+  date: 2012-11-14
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/workshop-for-high-energy-physics-at-ucl.html
+  time: 39600
+  title: Workshop for High-Energy Physics at UCL
+- &id859
+  author: Greg Wilson
+  category: [Community, Noticed, Tooling]
+  date: 2012-11-14
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/a-mostly-successful-decade.html
+  time: 09:00:00
+  title: A Mostly Successful Decade
+- &id860
+  author: Greg Wilson
+  category: [Community, Scripps Institute]
+  date: 2012-11-15
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/this-is-what-we-do.html
+  time: 09:00:00
+  title: This Is What We Do
+- &id861
+  author: Greg Wilson
+  category: [Caltech, Lawrence Berkeley National Laboratory, University of California
+      - Berkeley]
+  date: 2012-11-16
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/matt-daviss-great-californian-adventure.html
+  time: 36000
+  title: Matt Davis's Great Californian Adventure
+- &id862
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-11-16
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/we-apologize-for-the-interruption-in-our-service.html
+  time: 39600
+  title: We Apologize for the Interruption in Our Service
+- &id863
+  author: Greg Wilson
+  category: [Community, Tooling]
+  date: 2012-11-16
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/who-wants-to-write-a-little-code.html
+  time: 43200
+  title: Who Wants To Write a Little Code?
+- &id864
+  author: Matt Davis
+  category: [Community, Lawrence Berkeley National Laboratory]
+  date: 2012-11-16
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/making-a-difference-at-lbl.html
+  time: 09:00:00
+  title: Making a Difference at LBL
+- &id865
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-11-17
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/updating-our-reading-list.html
+  time: 09:00:00
+  title: Updating Our Reading List
+- &id866
+  author: Greg Wilson
+  category: [Education, Tooling]
+  date: 2012-11-19
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/who-wants-to-build-a-faded-example-tool-for-the-ipython-notebook.html
+  time: 36000
+  title: Who Wants To Build a Faded Example Tool for the IPython Notebook?
+- &id867
+  author: Greg Wilson
+  category: [Education, Tooling]
+  date: 2012-11-19
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/the-tool-i-think-we-need-to-do-peer-instruction-online.html
+  time: 09:00:00
+  title: The Tool (I Think) We Need To Do Peer Instruction Online
+- &id868
+  author: Greg Wilson
+  category: [Scripps Institute]
+  date: 2012-11-24
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/cait-pickens-on-the-scripps-institute-boot-camp.html
+  time: 09:00:00
+  title: Cait Pickens on the Scripps Institute Bootcamp
+- &id869
+  author: Greg Wilson
+  category: [Scripps Institute]
+  date: 2012-11-25
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/titus-brown-on-the-scripps-institute-boot-camp.html
+  time: 09:00:00
+  title: Titus Brown on the Scripps Institute Bootcamp
+- &id870
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2012-11-27
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/alpha-testing-ideas-for-the-ipython-notebook.html
+  time: 09:00:00
+  title: Alpha Testing Ideas for the IPython Notebook
+- &id871
+  author: Greg Wilson
+  category: [Community, Mozilla, Sloan Foundation]
+  date: 2012-11-30
+  favorite: null
+  folder: blog/2012/11
+  layout: blog
+  path: blog/2012/11/good-news-about-software-carpentry-and-more.html
+  time: 09:00:00
+  title: Good News About Software Carpentry (and More)
+- &id872
+  author: Greg Wilson
+  category: [Community, University of Manchester, EGI Forum]
+  date: 2012-12-01
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/european-grid-infrastructure-is-organizing-a-software-carpentry-workshop.html
+  time: 09:00:00
+  title: European Grid Infrastructure is Organizing a Software Carpentry Workshop
+- &id873
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-04
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/see-you-at-pycon-2013.html
+  time: 09:00:00
+  title: See You at PyCon 2013
+- &id874
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-05
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/our-first-hackathon.html
+  time: 36000
+  title: Our First Hackathon
+- &id875
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-05
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/six-years-later.html
+  time: 39600
+  title: Six Years Later
+- &id876
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-05
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/sustainability.html
+  time: 43200
+  title: Sustainability
+- &id877
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-05
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/who-can-run-a-software-carpentry-workshop.html
+  time: 46800
+  title: Who Can Run a Software Carpentry Workshop?
+- &id878
+  author: Greg Wilson
+  category: [Community, Opinion]
+  date: 2012-12-05
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/why-be-an-instructor.html
+  time: 50400
+  title: Why Be an Instructor
+- &id879
+  author: Greg Wilson
+  category: [Content]
+  date: 2012-12-05
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/moving-up-and-moving-down.html
+  time: 09:00:00
+  title: Moving Up and Moving Down
+- &id880
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-08
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/creating-a-task-list.html
+  time: 09:00:00
+  title: Creating a Task List
+- &id881
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-09
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/what-to-work-on-in-2013.html
+  time: 09:00:00
+  title: What To Work On In 2013
+- &id882
+  author: Greg Wilson
+  category: [University of Texas - Austin]
+  date: 2012-12-10
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/things-are-going-well-in-texas-on-ada-lovelaces-birthday.html
+  time: 09:00:00
+  title: Things Are Going Well in Texas on Ada Lovelace's Birthday
+- &id883
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-12-11
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/some-of-the-things-weve-learned-about-teaching-git.html
+  time: 09:00:00
+  title: Some of the Things We've Learned About Teaching Git
+- &id884
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-12
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/ipython-funding-hurray.html
+  time: 36000
+  title: 'IPython Funding: Hurray!'
+- &id885
+  author: Mike Jackson
+  category: [University of Edinburgh]
+  date: 2012-12-12
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/feedback-from-edinburgh.html
+  time: 09:00:00
+  title: Feedback from Edinburgh
+- &id886
+  author: Greg Wilson
+  category: [University of British Columba]
+  date: 2012-12-13
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/two-r-workshops-at-ubc-in-2013.html
+  time: 09:00:00
+  title: Two R Workshops at UBC in 2013
+- &id887
+  author: Nicolas Limare
+  category: [Community]
+  date: 2012-12-15
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/three-non-trivial-uses-cases-for-git.html
+  time: 36000
+  title: Three Non-trivial Use Cases for Git
+- &id888
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2012-12-15
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/lorena-barbas-reproducibility-pi-manifesto.html
+  time: 09:00:00
+  title: Lorena Barba's Reproducibility PI Manifesto
+- &id889
+  author: Greg Wilson
+  category: [Opinion, Tooling]
+  date: 2012-12-16
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/youve-shown-me-the-c-now-wheres-the-python.html
+  time: 09:00:00
+  title: You've Shown Me the C, Now Where's the Python?
+- &id890
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-19
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/minutes-2012-12-19-meeting.html
+  time: 09:00:00
+  title: Minutes from 2012-12-19
+- &id891
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2012-12-21
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/sample-data-management-plans.html
+  time: 36000
+  title: Sample Data Management Plans
+- &id892
+  author: Greg Wilson
+  category: [Community]
+  date: 2012-12-21
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/code-of-conduct.html
+  root: ../../..
+  time: 09:00:00
+  title: Code of Conduct
+- &id893
+  author: Greg Wilson
+  category: [Education]
+  date: 2012-12-23
+  favorite: null
+  folder: blog/2012/12
+  layout: blog
+  path: blog/2012/12/computer-science-curricula-2013.html
+  time: 09:00:00
+  title: Computer Science Curricula 2013
+- &id015
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-01-04
+  favorite: true
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/why-we-teach.html
+  time: 36000
+  title: Why We Teach
+- &id894
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-01-04
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/advice-from-a-newbie-no-more.html
+  time: 09:00:00
+  title: Advice From a Newbie No More
+- &id895
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2013-01-05
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/cold-call.html
+  root: ../../..
+  time: 09:00:00
+  title: The Art of Cold Calling
+- &id896
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-01-10
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/plos-ad.html
+  time: 09:00:00
+  title: PLoS Ad for Software Carpentry
+- &id014
+  author: Greg Wilson
+  category: [Community, Licensing]
+  date: 2013-01-11
+  favorite: true
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/teaching-commercially.html
+  root: ../../..
+  time: 09:00:00
+  title: Teaching Commercially
+- &id897
+  author: Ross Dickson
+  category: [McGill University]
+  date: 2013-01-14
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/montreal-in-january.html
+  time: 09:00:00
+  title: Montreal in January
+- &id898
+  author: Anthony Scopatz
+  category: [University of Chicago]
+  date: 2013-01-16
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/uchicago-in-january.html
+  time: 09:00:00
+  title: University of Chicago in January
+- &id899
+  author: Jon Pipitone
+  category: [Online]
+  date: 2013-01-21
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/online-office-hours.html
+  time: 09:00:00
+  title: Online Office Hours
+- &id900
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2013-01-22
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/record-and-playback-in-the-ipython-notebook.html
+  time: 09:00:00
+  title: Record and Playback in the IPython Notebook
+- &id901
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-01-23
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/how-to-become-an-instructor.html
+  root: ../../..
+  time: 09:00:00
+  title: How to Become an Instructor
+- &id902
+  author: Joshua L. Peterson
+  category: [Stories]
+  date: 2013-01-24
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/visualizing-nuclear-fuel-inventories.html
+  time: 09:00:00
+  title: Visualizing Nuclear Fuel Inventories
+- &id903
+  author: Greg Wilson
+  category: [Education, Opinion]
+  date: 2013-01-28
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/novelty-efficiency-and-trust.html
+  time: 09:00:00
+  title: Novelty, Efficiency, and Trust
+- &id904
+  author: Ted Hart
+  category: [University of British Columba]
+  date: 2013-01-30
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/ubc-swc-r.html
+  time: 36000
+  title: Teaching R at UBC
+- &id905
+  author: Greg Wilson
+  category: [Mozilla (Toronto)]
+  date: 2013-01-30
+  favorite: null
+  folder: blog/2013/01
+  layout: blog
+  path: blog/2013/01/boot-camp-at-mozilla.html
+  time: 09:00:00
+  title: A Bootcamp at Mozilla
+- &id906
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-02-01
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/ngs-course-2013.html
+  time: 36000
+  title: Next-Generation Sequencing Course 2013
+- &id907
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2013-02-01
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/a-bunch-of-bootcamps.html
+  time: 09:00:00
+  title: A Bunch of Bootcamps
+- &id908
+  author: Ethan White
+  category: [Community, Education, Noticed]
+  date: 2013-02-02
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/a-short-report-from-utah-state.html
+  time: 09:00:00
+  title: A Short Report from Utah State
+- &id909
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-02-03
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/features-and-scope-in-open-courseware.html
+  time: 36000
+  title: Features and Scope in Open Courseware
+- &id910
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-02-03
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/the-missing-side-of-the-triangle.html
+  time: 39600
+  title: The Missing Side of the Triangle
+- &id911
+  author: Greg Wilson
+  category: [Max Planck Institute - Tuebingen]
+  date: 2013-02-03
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/a-short-report-from-tuebingen.html
+  time: 09:00:00
+  title: A Short Report from Tuebingen
+- &id912
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-02-06
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/we-have-a-facebook-page.html
+  time: 09:00:00
+  title: We Have a Facebook Page
+- &id913
+  author: Greg Wilson
+  category: [Macquarie Universty]
+  date: 2013-02-08
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/macquarie-went-well.html
+  time: 09:00:00
+  title: Macquarie Went Well
+- &id914
+  author: Greg Wilson
+  category: [University of British Columba]
+  date: 2013-02-11
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/ubc-went-well.html
+  time: 36000
+  title: UBC Went Well
+- &id013
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-02-11
+  favorite: true
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/correctness-isnt-compelling.html
+  time: 09:00:00
+  title: Correctness Isn't Compelling
+- &id915
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-02-12
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/partnering-with-the-ssi.html
+  time: 09:00:00
+  title: Partnering with the SSI
+- &id916
+  author: Mike Jackson
+  category: [Community, Education]
+  date: 2013-02-13
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/dirac-dry-run-two.html
+  time: 09:00:00
+  title: Second Dry-Run of DiRAC Driver's License Exam
+- &id917
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-02-14
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/more-news-from-the-uk.html
+  time: 36000
+  title: More News from the UK
+- &id918
+  author: Amy Brown
+  category: [Vrije Universiteit]
+  date: 2013-02-14
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/amsterdam-open.html
+  time: 09:00:00
+  title: Registration for Amsterdam Bootcamp is Open
+- &id919
+  author: Greg Wilson
+  category: [University of Melbourne]
+  date: 2013-02-15
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/wrapping-up-in-melbourne.html
+  time: 36000
+  title: Wrapping Up in Melbourne
+- &id920
+  author: Matt Davis
+  category: [Bootcamps]
+  date: 2013-02-15
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/expanding-boot-camp-types.html
+  time: 09:00:00
+  title: Expanding Our Bootcamp Types
+- &id921
+  author: Ben Waugh
+  category: [University College London]
+  date: 2013-02-27
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/workshop-for-high-energy-physics-at-ucl-part-2.html
+  time: 36000
+  title: Workshop for High-Energy Physics at UCL, Part 2
+- &id922
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-02-27
+  favorite: null
+  folder: blog/2013/02
+  layout: blog
+  path: blog/2013/02/bootcamp-for-wise.html
+  time: 09:00:00
+  title: A Bootcamp for Women in Science and Engineering
+- &id923
+  author: Matt Davis
+  category: [University of Washington]
+  date: 2013-03-01
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/uw-b-feedback.html
+  time: 36000
+  title: Feedback from UW Room B
+- &id924
+  author: Greg Wilson
+  category: [University of Washington]
+  date: 2013-03-01
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/washington-went-well.html
+  time: 39600
+  title: Washington Went Well
+- &id925
+  author: Greg Wilson
+  category: [Education]
+  date: 2013-03-01
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/alternative-teaching-models.html
+  time: 09:00:00
+  title: Alternative Teaching Models
+- &id926
+  author: Matt Davis
+  category: [University of Washington, Tooling]
+  date: 2013-03-02
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/teaching-with-ipythonblocks-at-uw.html
+  time: 09:00:00
+  title: Teaching with ipythonblocks at UW
+- &id927
+  author: Greg Wilson
+  category: [Lawrence Berkeley National Laboratory]
+  date: 2013-03-05
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/first-round-at-lawrence-berkeley.html
+  time: 09:00:00
+  title: First Round at Lawrence Berkeley
+- &id928
+  author: Greg Wilson
+  category: [MathWorks]
+  date: 2013-03-12
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/new-testing-framework-for-matlab.html
+  time: 09:00:00
+  title: A New Testing Framework for MATLAB
+- &id929
+  author: Justin Kitzes
+  category: [Lawrence Berkeley National Laboratory]
+  date: 2013-03-13
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/second-round-at-lawrence-berkeley.html
+  time: 09:00:00
+  title: Second Round at Lawrence Berkeley
+- &id930
+  author: Amy Brown
+  category: [Bootcamps]
+  date: 2013-03-14
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/new-camps.html
+  time: 09:00:00
+  title: New Camps Coming Up
+- &id931
+  author: Greg Wilson
+  category: [University of Virginia]
+  date: 2013-03-15
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/snowstorms-and-blackouts-in-virginia.html
+  time: 09:00:00
+  title: Snowstorms and Blackouts in Virginia
+- &id932
+  author: Greg Wilson
+  category: [Content]
+  date: 2013-03-17
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/testing-image-processing.html
+  time: 36000
+  title: Testing Image Processing
+- &id933
+  author: Greg Wilson
+  category: [Community, Assessment]
+  date: 2013-03-17
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/cumulative-enrollment.html
+  time: 09:00:00
+  title: Cumulative Enrollment
+- &id934
+  author: Greg Wilson
+  category: [Education, Tooling]
+  date: 2013-03-24
+  favorite: null
+  folder: blog/2013/03
+  layout: blog
+  path: blog/2013/03/using-notebook-as-a-teaching-tool.html
+  time: 09:00:00
+  title: Using the IPython Notebook as a Teaching Tool
+- &id935
+  author: Paul Wilson
+  category: [Content, University of Wisconsin - Madison]
+  date: 2013-04-03
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/connecting-content-to-best-practices.html
+  time: 09:00:00
+  title: Connecting Bootcamp Content to Motivation and Best Practices
+- &id936
+  author: Frank Pennekamp
+  category: [Community]
+  date: 2013-04-05
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/pennekamp-image-analysis.html
+  time: 09:00:00
+  title: An Image Analysis Success Story
+- &id937
+  author: Greg Wilson
+  category: [Women in Science and Engineering]
+  date: 2013-04-07
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/announcing-wise-bootcamp.html
+  time: 09:00:00
+  title: Announcing a Bootcamp for Women in Science and Engineering
+- &id938
+  author: Greg Wilson
+  category: [Education]
+  date: 2013-04-08
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/evaluation-revisited.html
+  time: 36000
+  title: Evaluation Revisited
+- &id939
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2013-04-08
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/installation-revisited.html
+  time: 39600
+  title: Installation Revisited
+- &id940
+  author: Greg Wilson
+  category: [Mozilla (Toronto)]
+  date: 2013-04-08
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/announcing-toronto-bootcamp-may-2013.html
+  time: 09:00:00
+  title: A Bootcamp in Toronto May 9-10, 2013
+- &id941
+  author: Justin Kitzes
+  category: [University of California - Berkeley]
+  date: 2013-04-16
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/ucb-feedback.html
+  time: 36000
+  title: Feedback from UC Berkeley
+- &id942
+  author: Mike Jackson
+  category: [EGI Forum]
+  date: 2013-04-16
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/egi-forum.html
+  time: 09:00:00
+  title: Feedback from the EGI Forum
+- &id943
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-04-19
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/spreadsheets-retractions-and-bias.html
+  time: 36000
+  title: Spreadsheets, Retractions, and Bias
+- &id944
+  author: Amy Brown
+  category: [University of Arizona]
+  date: 2013-04-19
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/arizona-feedback.html
+  time: 09:00:00
+  title: Feedback from Arizona
+- &id945
+  author: Matt Davis
+  category: [Community]
+  date: 2013-04-23
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/swc-at-scipy2013.html
+  time: 09:00:00
+  title: Software Carpentry at SciPy 2013
+- &id946
+  author: Aron Ahmadia
+  category: [American University of Beirut, King Abdullah University of Science and
+      Technology, Stellenbosch University]
+  date: 2013-04-24
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/middle-east-south-africa.html
+  time: 36000
+  title: 'Bootcamp Recap: Middle East and South Africa'
+- &id947
+  author: Greg Wilson
+  category: [University of Manchester]
+  date: 2013-04-24
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/manchester-once-again.html
+  time: 09:00:00
+  title: Manchester Once Again
+- &id948
+  author: Luis Figueira
+  category: [Community, SoundSoftware]
+  date: 2013-04-27
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/sound-software-competition.html
+  time: 09:00:00
+  title: Sound Software Competition
+- &id949
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-04-29
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/cumulative-enrolment-update.html
+  time: 09:00:00
+  title: An Update on Cumulative Enrolment
+- &id950
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2013-04-30
+  favorite: null
+  folder: blog/2013/04
+  layout: blog
+  path: blog/2013/04/pre-assessment-results.html
+  time: 09:00:00
+  title: Pre-Assessment Results
+- &id951
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2013-05-02
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/translucent-badges.html
+  time: 36000
+  title: Translucent Badges
+- &id952
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-05-02
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/rational-computing-process.html
+  time: 09:00:00
+  title: 'A Rational Computing Process: How and Why to Fake It'
+- &id953
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-05-03
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/reuse-your-data.html
+  time: 36000
+  title: Make It Easier to (Re)use Your Data
+- &id954
+  author: Greg Wilson
+  category: [University of Melbourne]
+  date: 2013-05-03
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/melbourne-feedback.html
+  time: 09:00:00
+  title: More Detailed Feeback from Melbourne
+- &id955
+  author: Greg Wilson
+  category: [Assessment, Opinion]
+  date: 2013-05-10
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/git-vs-svn-feedback.html
+  time: 09:00:00
+  title: Git vs. Subversion and Feedback in General
+- &id956
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-05-14
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/science-careers-article.html
+  time: 09:00:00
+  title: A Mention in Science Careers
+- &id957
+  author: Ariel Rokem
+  category: [Stanford University]
+  date: 2013-05-16
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/stanford.html
+  time: 36000
+  title: Stanford Bootcamp Recap
+- &id958
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-05-16
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/announcing-hack4ac.html
+  time: 09:00:00
+  title: Announcing Hack4ac
+- &id959
+  author: Greg Wilson
+  category: [University of California - Davis]
+  date: 2013-05-17
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/uc-davis-experience.html
+  time: 36000
+  title: Wrapping Up at UC Davis
+- &id960
+  author: Mike Jackson
+  category: [Oxford University]
+  date: 2013-05-17
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/oxford-dtc-experiences.html
+  time: 09:00:00
+  title: Experiences with the Oxford DTCs
+- &id961
+  author: Jonathan Cooper
+  category: [Oxford University]
+  date: 2013-05-24
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/oxford-dtc-feedback.html
+  time: 36000
+  title: Feedback from the Oxford DTCs
+- &id962
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-05-24
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/planning-for-the-break.html
+  time: 39600
+  title: Planning for the Break
+- &id963
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-05-24
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/where-we-are.html
+  time: 43200
+  title: Where We Are (More or Less)
+- &id964
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2013-05-24
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/browsercast.html
+  time: 09:00:00
+  title: Browsercast
+- &id965
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2013-05-25
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/our-infrastructure.html
+  time: 09:00:00
+  title: Our Infrastructure
+- &id012
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-05-26
+  favorite: true
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/what-does-victory-look-like.html
+  time: 36000
+  title: What Does Victory Look Like?
+- &id011
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-05-26
+  favorite: true
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/what-does-done-look-like.html
+  time: 09:00:00
+  title: What Does Done Look Like?
+- &id966
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-05-30
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/the-great-licenceathon.html
+  time: 36000
+  title: The Great Licenceathon
+- &id967
+  author: Aleksandra Pawlik
+  category: [Jagiellonian University]
+  date: 2013-05-30
+  favorite: null
+  folder: blog/2013/05
+  layout: blog
+  path: blog/2013/05/krakow-experience.html
+  time: 09:00:00
+  title: Krakow Bootcamp Experience
+- &id968
+  author: Mike Jackson
+  category: [Community]
+  date: 2013-06-02
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/intecol13.html
+  time: 36000
+  title: Software Carpentry at INTECOL13
+- &id969
+  author: Aleksandra Pawlik
+  category: [Community]
+  date: 2013-06-02
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/from-helper-to-instructor.html
+  time: 09:00:00
+  title: From a Helper to an Instructor
+- &id970
+  author: Robin Wilson
+  category: [University of Southampton]
+  date: 2013-06-05
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/soton-feedback.html
+  time: 09:00:00
+  title: Feedback and Experiences from Southampton
+- &id971
+  author: Onno Broekmans
+  category: [Vrije Universiteit]
+  date: 2013-06-06
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/amsterdam-bootcamp.html
+  time: 09:00:00
+  title: Amsterdam Bootcamp
+- &id972
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2013-06-07
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/running-bootcamps.html
+  time: 36000
+  title: Running Bootcamps
+- &id973
+  author: Ted Hart
+  category: [National Center for Atmospheric Research]
+  date: 2013-06-07
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/boulder-bootcamp.html
+  time: 09:00:00
+  title: Thoughts on an Advanced Bootcamp at Boulder
+- &id974
+  author: Ben Morris
+  category: [Duke University, NESCENT]
+  date: 2013-06-09
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/north-carolina-bootcamps.html
+  time: 09:00:00
+  title: North Carolina Bootcamps
+- &id975
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2013-06-13
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/lab-meeting.html
+  time: 09:00:00
+  title: June 2013 Lab Meeting
+- &id976
+  author: Greg Wilson
+  category: [Mozilla]
+  date: 2013-06-14
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/mozilla-science-lab-announcement.html
+  time: 09:00:00
+  title: Announcing the Mozilla Science Lab
+- &id977
+  author: Mike Jackson
+  category: [University of Bristol]
+  date: 2013-06-15
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/announcing-bristol.html
+  root: ../../..
+  time: 09:00:00
+  title: Bootcamp in Bristol, September 12-13, 2013
+- &id978
+  author: Greg Wilson
+  category: [Salk Institute]
+  date: 2013-06-17
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/salk-institute-bootcamp.html
+  time: 09:00:00
+  title: Salk Institute Feedback
+- &id979
+  author: Terri Yu
+  category: [University of Massachusetts - Amherst]
+  date: 2013-06-18
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/umass-bootcamp.html
+  time: 09:00:00
+  title: 'UMass Amherst Bootcamp: Perspective from a Helper'
+- &id980
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-06-19
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/twelve-bar-blues-of-science.html
+  time: 09:00:00
+  title: The Twelve Bar Blues of Open Science
+- &id981
+  author: Greg Wilson
+  category: [Assessment, Bootcamps, Community, Research]
+  date: 2013-06-20
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/lessons-learned.html
+  time: 09:00:00
+  title: 'Software Carpentry: Lessons Learned'
+- &id982
+  author: Terri Yu
+  category: [Women in Science and Engineering]
+  date: 2013-06-27
+  favorite: null
+  folder: blog/2013/06
+  layout: blog
+  path: blog/2013/06/after-wise.html
+  time: 43200
+  title: After WISE
+- &id983
+  author: Greg Wilson
+  category: [Women in Science and Engineering]
+  date: 2013-07-05
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/wise-roundup.html
+  time: 36000
+  title: WiSE Bootcamp Roundup
+- &id984
+  author: Greg Wilson
+  category: [Sloan Foundation]
+  date: 2013-07-05
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/sloan-proposal-round-2.html
+  time: 09:00:00
+  title: Sloan Foundation Proposal Round 2
+- &id985
+  author: Greg Wilson
+  category: [Community, Education, Noticed]
+  date: 2013-07-06
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/ssi-training.html
+  time: 09:00:00
+  title: Workshop for e-Infrastructure Trainers
+- &id986
+  author: Karin Lagesen
+  category: [University of Oslo]
+  date: 2013-07-10
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/oslo-bootcamp.html
+  time: 09:00:00
+  title: The Oslo Bootcamp
+- &id987
+  author: Shreyas Cholia
+  category: [eResearch New Zealand]
+  date: 2013-07-14
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/nz-roundup.html
+  time: 09:00:00
+  title: eResearch New Zealand 2013 Bootcamp Roundup
+- &id988
+  author: Greg Wilson
+  category: [Assessment, Education]
+  date: 2013-07-16
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/computational-competence-for-biologists.html
+  time: 09:00:00
+  title: Computational Competence for Biologists
+- &id989
+  author: Greg Wilson
+  category: [Education]
+  date: 2013-07-17
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/biological-computing-user-stories.html
+  time: 09:00:00
+  title: Biological Computing User Stories
+- &id990
+  author: Mike Jackson
+  category: [Community, Education]
+  date: 2013-07-18
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/dirac-roll-out.html
+  time: 600
+  title: DiRAC Driving Test Ready to Roll
+- &id991
+  author: Greg Wilson
+  category: [Education]
+  date: 2013-07-18
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/data-workflows.html
+  time: 660
+  title: Data Science Workflows
+- &id992
+  author: Mike Jackson
+  category: [University of Bath]
+  date: 2013-07-18
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/bath-feedback.html
+  root: ../../..
+  time: 09:00
+  title: Feedback from Bath
+- &id993
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-07-19
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/fourteenth-anniversary.html
+  time: 600
+  title: The Fourteenth Anniversary
+- &id994
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2013-07-19
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/welcome-new-instructors.html
+  time: 09:00
+  title: Welcome Our New Instructors
+- &id995
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-07-20
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/miscellaneous-videos.html
+  time: 09:00:00
+  title: Miscellaneous Videos
+- &id996
+  author: Greg Wilson
+  category: [Indiana University]
+  date: 2013-07-26
+  favorite: null
+  folder: blog/2013/07
+  layout: blog
+  path: blog/2013/07/indiana-bootcamp.html
+  time: 09:00:00
+  title: Report on the Indiana Bootcamp
+- &id997
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2013-08-13
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/what-we-cover-in-instructor-training.html
+  time: 09:00
+  title: What We Cover in Instructor Training
+- &id998
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-08-14
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/summary-of-funding-survey.html
+  time: 888
+  title: Summary of Host Survey
+- &id999
+  author: Greg Wilson
+  category: [Announcements, Administration]
+  date: 2013-08-18
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/new-operations-guide.html
+  time: 09:00
+  title: Our New Operations Guide
+- &id1000
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2013-08-19
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/questionnaires.html
+  time: 09:00:00
+  title: Bootcamp Questionnaires
+- &id1001
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2013-08-19
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/august-2013-lab-meeting.html
+  time: '13:00:00'
+  title: August 2013 Lab Meeting
+- &id1002
+  author: Jory Schossau
+  category: [Assessment]
+  date: 2013-08-20
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/creating-assessments.html
+  time: 09:00:00
+  title: Creating Assessments and What to do With the Data
+- &id1003
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-08-22
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/sesync-video.html
+  time: 09:00:00
+  title: Video Interviews from SESYNC Workshop
+- &id1004
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2013-08-23
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/august-2013-lab-meeting-summary.html
+  time: 09:00:00
+  title: August 2013 Lab Meeting
+- &id1005
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-08-23
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/two-cheers-for-github.html
+  time: '10:00:00'
+  title: Two Cheers for GitHub
+- &id1006
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2013-08-23
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/instructor-training-stats.html
+  time: '15:00:00'
+  title: Instructor Training Statistics
+- &id1007
+  author: Mike Jackson
+  category: [Community]
+  date: 2013-08-23
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/intecol13-good-code.html
+  time: '15:30:00'
+  title: What Makes Good Code Good at INTECOL13
+- &id1008
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-08-30
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/dursi-compute-canada.html
+  time: 50400
+  title: Jonathan Dursi Joins Compute Canada
+- &id1009
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2013-08-30
+  favorite: null
+  folder: blog/2013/08
+  layout: blog
+  path: blog/2013/08/open-access-button.html
+  time: 52200
+  title: Open Access Button Hackathon is Sept 7-8
+- &id1010
+  author: Kimberly Gilbert
+  category: [Announcements, Community]
+  date: 2013-09-02
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/sharing-code-molecular-ecologist.html
+  time: 09:00:00
+  title: Share Your Code With the Molecular Ecologist Blog
+- &id1011
+  author: Greg Wilson
+  category: [Bootcamps, Harvard University]
+  date: 2013-09-02
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/teaching-librarians-at-harvard.html
+  time: 09:30:00
+  title: Teaching Librarians at Harvard
+- &id1012
+  author: Greg Wilson
+  category: [Community, Mozilla]
+  date: 2013-09-02
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/science-lab-plans.html
+  time: '10:00:00'
+  title: Our Plan for the Science Lab
+- &id1013
+  author: Greg Wilson
+  category: [Community, Tooling]
+  date: 2013-09-02
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/introducing-citation-files.html
+  time: '10:30:00'
+  title: Introducing Citation Files
+- &id1014
+  author: Diego Barneche
+  category: [Community, Experience Report]
+  date: 2013-09-09
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/diego-barneche.html
+  time: 09:00:00
+  title: 'Diego Barneche: What I''ve Learned'
+- &id1015
+  author: Konrad Hinsen
+  category: [Community, Experience Report]
+  date: 2013-09-11
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/konrad-hinsen.html
+  time: 09:00:00
+  title: 'Konrad Hinsen: What I''ve Learned'
+- &id1016
+  author: Anthony Scopatz
+  category: [Assessment, Teaching, Stories]
+  date: 2013-09-15
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/scientific-computing-at-aims.html
+  time: 09:00:00
+  title: Scientific Computing at AIMS
+- &id1017
+  author: Sarah Supp
+  category: [Community, Experience Report]
+  date: 2013-09-21
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/sarah-supp.html
+  time: 09:00:00
+  title: 'Sarah Supp: What I''ve Learned'
+- &id1018
+  author: Sarah Supp
+  category: [Community, Experience Report]
+  date: 2013-09-21
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/hummingbird-data.html
+  time: 09:30:00
+  title: Software Skills and Hummingbird Diversity
+- &id1019
+  author: Lex Nederbragt
+  category: [Community, Experience Report]
+  date: 2013-09-21
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/lex-nederbragt.html
+  time: '10:00:00'
+  title: 'Lex Nederbragt: What I''ve Learned'
+- &id1020
+  author: Aleksandra Pawlik
+  category: [Community, Announcements, Support]
+  date: 2013-09-24
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/ssi-fellowship-fund.html
+  time: 09:00:00
+  title: SSI Fellowship Programme 2014
+- &id1021
+  author: Greg Wilson
+  category: [Content]
+  date: 2013-09-24
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/how-much-testing-is-enough.html
+  time: '10:00:00'
+  title: How Much Testing Is Enough?
+- &id1022
+  author: Michael Hansen
+  category: [Community, Experience Report]
+  date: 2013-09-25
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/hansen-what-ive-learned.html
+  time: '12:00:00'
+  title: 'Michael Hansen: What I''ve Learned'
+- &id1023
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-09-26
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/code-data-social-sciences.html
+  time: '10:30:00'
+  title: Code and Data for the Social Sciences
+- &id1024
+  author: Greg Wilson
+  category: [Opinion, Noticed]
+  date: 2013-09-27
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/the-future-today.html
+  time: '14:30:00'
+  title: 'The Future: Today'
+- &id1025
+  author: Anthony Scopatz
+  category: [Assessment, Teaching]
+  date: 2013-09-30
+  favorite: null
+  folder: blog/2013/09
+  layout: blog
+  path: blog/2013/09/bootcamp-student-domains.html
+  time: 09:00:00
+  title: Bootcamp Student Composition by Domain
+- &id1026
+  author: Steven Koenig
+  category: [Community, Experience Report]
+  date: 2013-10-01
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/steven-koenig.html
+  time: 09:00:00
+  title: 'Steven Koenig: What I''ve Learned'
+- &id1027
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2013-10-04
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/october-2013-lab-meeting.html
+  root: ../../..
+  time: 09:00:00
+  title: October 2013 Lab Meeting
+- &id1028
+  author: Greg Wilson
+  category: [Bootcamps, Community]
+  date: 2013-10-04
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/bootcamp-at-pycon-2014.html
+  time: '10:00:00'
+  title: Our Biggest Bootcamp Ever at PyCon 2014
+- &id1029
+  author: Mike Jackson
+  category: [Community]
+  date: 2013-10-08
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/uk-admin.html
+  root: ../../..
+  time: 09:00:00
+  title: A new UK administrator for Software Carpentry
+- &id1030
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2013-10-09
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/enrolment-fall-2013.html
+  time: 09:00:00
+  title: Enrolment Figures (Fall 2013)
+- &id1031
+  author: Greg Wilson
+  category: [Teaching, Content]
+  date: 2013-10-14
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/curriculum-design.html
+  root: ../../..
+  time: '19:00:00'
+  title: Curriculum Design
+- &id1032
+  author: Martin Jones
+  category: [Noticed]
+  date: 2013-10-14
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/python-for-biologists.html
+  root: ../../..
+  time: '19:30:00'
+  title: Python for Biologists
+- &id1033
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-10-17
+  favorite: null
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/the-state-of-open-science.html
+  time: '11:00:00'
+  title: The State of Open Science
+- &id010
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-10-17
+  favorite: true
+  folder: blog/2013/10
+  layout: blog
+  path: blog/2013/10/you-keep-using-that-word.html
+  root: ../../..
+  time: '19:00:00'
+  title: You Keep Using That Word
+- &id1034
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2013-11-02
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/nov-2013-lab-meeting-announcement.html
+  root: ../../..
+  time: '11:00:00'
+  title: November 2013 Lab Meeting
+- &id1035
+  author: Greg Wilson
+  category: [Announcements, Content]
+  date: 2013-11-02
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/reorganizing.html
+  root: ../../..
+  time: '12:00:00'
+  title: Reorganizing
+- &id1036
+  author: Greg Wilson
+  category: [Announcements, Content]
+  date: 2013-11-02
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/scope.html
+  root: ../../..
+  time: '12:30:00'
+  title: Software Carpentry's Scope
+- &id1037
+  author: Philipp Bayer
+  category: [Bootcamps, University of Adelaide]
+  date: 2013-11-08
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/adelaide-post-mortem.html
+  root: ../../..
+  time: '13:30:00'
+  title: Our First Bootcamp in Adelaide
+- &id1038
+  author: Greg Wilson
+  category: [Research]
+  date: 2013-11-12
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/code-review-report.html
+  root: ../../..
+  time: 09:30:00
+  title: Report on the PLOS/Mozilla Code Review Pilot
+- &id1039
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-11-13
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/wise-pydata-nyc.html
+  root: ../../..
+  time: 08:30:00
+  title: Women in Tech Workshop at PyData NYC
+- &id1040
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2013-11-13
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/data-science-centers.html
+  root: ../../..
+  time: 09:00:00
+  title: Data Science Centers at UCB, UW, and NYU
+- &id1041
+  author: Greg Wilson
+  category: [Announcements, Instructor Training]
+  date: 2013-11-16
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/instructor-training-in-three-days.html
+  root: ../../..
+  time: 06:00:00
+  title: Instructor Training in Three Days
+- &id1042
+  author: Greg Wilson
+  category: [Announcements, Community]
+  date: 2013-11-16
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/creating-a-forum.html
+  root: ../../..
+  time: 06:30:00
+  title: Creating a Forum
+- &id1043
+  author: Greg Wilson
+  category: [Administration, Community]
+  date: 2013-11-16
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/citing-us-in-your-cv.html
+  root: ../../..
+  time: 07:00:00
+  title: Citing Us In Your CV
+- &id1044
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2013-11-16
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/sigcse-workshop.html
+  root: ../../..
+  time: 07:30:00
+  title: Workshop at SIGCSE 2014
+- &id1045
+  author: Greg Wilson
+  category: [Bootcamps, Woods Hole]
+  date: 2013-11-17
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/thanks-from-woods-hole.html
+  root: ../../..
+  time: 06:00:00
+  title: Thanks from Woods Hole
+- &id1046
+  author: Jory Schossau
+  category: [Assessment]
+  date: 2013-11-17
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/commence-interviews.html
+  root: ../../..
+  time: '23:00:00'
+  title: 'Moving Forward with Assessment: Interviews'
+- &id009
+  author: Damien Irving
+  category: [Bootcamps]
+  date: 2013-11-19
+  favorite: true
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/why-attend-bootcamp.html
+  root: ../../..
+  time: 68400
+  title: What to Say at a Bootcamp, After It's All Said and Done
+- &id1047
+  author: Joshua Ryan Smith
+  category: [Stories]
+  date: 2013-11-19
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/helping-write-a-paper.html
+  root: ../../..
+  time: 09:30:00
+  title: How Software Carpentry Helped Me Write a Paper
+- &id008
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2013-11-21
+  favorite: true
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/updated-cold-call.html
+  root: ../../..
+  time: 54000
+  title: The Art of Cold Calling (Updated)
+- &id1048
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2013-11-24
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/southampton-cdt.html
+  root: ../../..
+  time: '10:00:00'
+  title: Centre for Doctoral Training at Southampton
+- &id1049
+  author: Greg Wilson
+  category: [Announcements, Instructor Training]
+  date: 2013-11-25
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/instructor-training-in-toronto.html
+  root: ../../..
+  time: 07:00:00
+  title: Registration Now Open for Instructor Training Course
+- &id1050
+  author: Lynne Williams
+  category: [Stories]
+  date: 2013-11-26
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/what-ive-learned.html
+  root: ../../..
+  time: '18:00:00'
+  title: Things I Wish Someone Had Told Me About Scientific Computing
+- &id1051
+  author: Nick Brown
+  category: [Community, Education]
+  date: 2013-11-28
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/dirac-edinburgh.html
+  root: ../../..
+  time: 750
+  title: DiRAC Driving Test Comes to Edinburgh
+- &id1052
+  author: Greg Wilson
+  category: [Women in Science and Engineering]
+  date: 2013-11-29
+  favorite: null
+  folder: blog/2013/11
+  layout: blog
+  path: blog/2013/11/wise-bootcamp-at-lbl.html
+  root: ../../..
+  time: '14:00:00'
+  title: WiSE Bootcamp at Lawrence Berkeley National Laboratory
+- &id1053
+  author: Aleksandra Pawlik
+  category: [Announcements]
+  date: 2013-12-02
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/agu-session.html
+  root: ../../..
+  time: 09:00:00
+  title: Software and Research Session at AGU 2013
+- &id1054
+  author: Mike Jackson
+  category: [University of Edinburgh]
+  date: 2013-12-05
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/edinburgh-feedback.html
+  root: ../../..
+  time: 840
+  title: Feedback from Edinburgh
+- &id1055
+  author: Martin Jones
+  category: [Announcements]
+  date: 2013-12-05
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/martin-jones-python-book.html
+  root: ../../..
+  time: '10:30:00'
+  title: Advanced Python for Biologists
+- &id1056
+  author: Greg Wilson
+  category: [Community, Education]
+  date: 2013-12-05
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/two-to-the-fifth-instructors.html
+  root: ../../..
+  time: '20:00:00'
+  title: Two to the Fifth New Instructors
+- &id1057
+  author: Kaitlin Thaney
+  category: [Announcements, Mozilla Science Lab]
+  date: 2013-12-09
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/msl-meeting-dec-2013.html
+  root: ../../..
+  time: '14:00:00'
+  title: Mozilla Science Lab Community Call for December 2013
+- &id1058
+  author: Greg Wilson
+  category: [Announcements, Software Sustainability Institute]
+  date: 2013-12-09
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/ssi-news-dec-2013.html
+  root: ../../..
+  time: '14:45:00'
+  title: News from the SSI
+- &id1059
+  author: Aron Ahmadia
+  category: [Announcements, Content, Lessons]
+  date: 2013-12-10
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/release-2013-11.html
+  root: ../../..
+  time: '11:30:00'
+  title: Release 2013.11
+- &id1060
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-12-10
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/there-ought-to-be-a-badge.html
+  root: ../../..
+  time: '13:30:00'
+  title: There Ought to Be a Badge
+- &id1061
+  author: Kaitlin Thaney
+  category: [Announcements, Mozilla Science Lab]
+  date: 2013-12-11
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/code-as-a-research-object.html
+  root: ../../..
+  time: '13:00:00'
+  title: Code as a Research Object
+- &id1062
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2013-12-19
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/instructor-stats.html
+  root: ../../..
+  time: 09:00:00
+  title: So How Is Instructor Training Going?
+- &id1063
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2013-12-19
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/andromedas-advice.html
+  root: ../../..
+  time: 09:30:00
+  title: Andromeda's Advice
+- &id1064
+  author: Greg Wilson
+  category: [Bootcamps, Oxford University, Assessment]
+  date: 2013-12-25
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/oxford-one-year-on.html
+  root: ../../..
+  time: '15:00:00'
+  title: Oxford, One Year On
+- &id1065
+  author: Greg Wilson
+  category: [Opinion, Community]
+  date: 2013-12-27
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/catch-and-hold.html
+  root: ../../..
+  time: 09:00:00
+  title: Catch and Hold
+- &id007
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2013-12-31
+  favorite: true
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/tools-conversations-and-cultures.html
+  root: ../../..
+  time: '18:00:00'
+  title: Tools, Conversations, and Cultures
+- &id1066
+  author: Greg Wilson
+  category: [Community]
+  date: 2013-12-31
+  favorite: null
+  folder: blog/2013/12
+  layout: blog
+  path: blog/2013/12/our-store-is-open.html
+  root: ../../..
+  time: '18:30:00'
+  title: Our Store Is Open
+- &id1067
+  author: Amy Brown
+  category: [Administration]
+  date: 2014-01-06
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/introducing-arliss-collins.html
+  root: ../../..
+  time: '14:30:00'
+  title: Introducing Arliss Collins
+- &id1068
+  author: Greg Wilson
+  category: [Research, Teaching]
+  date: 2014-01-07
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/mental-models.html
+  root: ../../..
+  time: 06:30:00
+  title: Mental Models and Vicious Circles
+- &id1069
+  author: Jeff Carver
+  category: [Research]
+  date: 2014-01-07
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/tdd-in-science.html
+  root: ../../..
+  time: '12:30:00'
+  title: Test-Driven Development in Scientific Computing
+- &id1070
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-01-07
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/a-beautiful-diagram.html
+  root: ../../..
+  time: '13:30:00'
+  title: We Need More of These
+- &id1071
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2014-01-07
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/best-practices-has-been-published.html
+  root: ../../..
+  time: '22:00:00'
+  title: '''Best Practices'' Has Been Published'
+- &id1072
+  author: Amy Brown
+  category: [Jobs]
+  date: 2014-01-09
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/UCL-job-opportunity.html
+  root: ../../..
+  time: '10:40:00'
+  title: Job Opportunity at University College London
+- &id1073
+  author: Paul Wilson
+  category: [Research, Teaching]
+  date: 2014-01-10
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/not-just-tools.html
+  root: ../../..
+  time: 01:00:00
+  title: It's Not Just the Tools that Differ Between the Two Cultures
+- &id1074
+  author: Greg Wilson
+  category: [Research]
+  date: 2014-01-14
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/code-review-round-2.html
+  root: ../../..
+  time: '10:00:00'
+  title: Code Review, Round 2
+- &id006
+  author: Greg Wilson
+  category: [Opinion, Publishing, Tooling, Community]
+  date: 2014-01-15
+  favorite: true
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/publishing-on-the-web.html
+  root: ../../..
+  time: '10:30:00'
+  title: Publishing on the Web
+- &id1075
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-01-15
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/bootcamp-for-librarians.html
+  root: ../../..
+  time: '21:30:00'
+  title: From 0 to 1 to 10
+- &id1076
+  author: Michael Hansen
+  category: [Tooling]
+  date: 2014-01-16
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/introducing-the-image-novice-module.html
+  root: ../../..
+  time: '23:00:00'
+  title: Introducing the Image Novice Module
+- &id1077
+  author: Ivan Gonzalez
+  category: [Bootcamps, University of Rhode Island]
+  date: 2014-01-18
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/uri-bootcamp.html
+  root: ../../..
+  time: 07:30:00
+  title: Wrapping Up in Narrangasett
+- &id1078
+  author: Aleksandra Pawlik
+  category: [Bootcamps, Cambridge University]
+  date: 2014-01-18
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/feedback-cam-r-bootcamp.html
+  root: ../../..
+  time: 08:30:00
+  title: Feedback from the First Cambridge R Bootcamp
+- &id1079
+  author: Greg Wilson
+  category: [Teaching, Opinion]
+  date: 2014-01-19
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/why-not-a-mooc.html
+  root: ../../..
+  time: 07:00:00
+  title: Why Not a MOOC?
+- &id1080
+  author: Aleksandra Pawlik
+  category: [Bootcamps, Manchester University]
+  date: 2014-01-24
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/feedback-manchester-matlab-bootcamp.html
+  root: ../../..
+  time: '10:00:00'
+  title: Feedback from the First MATLAB Bootcamp
+- &id1081
+  author: Greg Wilson
+  category: [Jobs]
+  date: 2014-01-26
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/bitss-job-ad.html
+  root: ../../..
+  time: 07:00:00
+  title: Research Transparency Job at UC Berkeley
+- &id1082
+  author: Greg Wilson
+  category: [Bootcamps, Online]
+  date: 2014-01-28
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/announcing-online-classes.html
+  root: ../../..
+  time: '10:30:00'
+  title: Teaching Online (Sort Of) in 2014
+- &id1083
+  author: Greg Wilson
+  category: [Bootcamps, PyCon, Montreal]
+  date: 2014-01-28
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/pycon-bootcamp.html
+  root: ../../..
+  time: '11:00:00'
+  title: Workshops at PyCon in Montreal This April
+- &id1084
+  author: Greg Wilson
+  category: [Bootcamps, Women in Science and Engineering, Lawrence Berkeley National
+      Laboratory]
+  date: 2014-01-28
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/wise-bootcamp-lbl.html
+  root: ../../..
+  time: '12:00:00'
+  title: 'Workshop for Women in Science and Engineering: April 14-15 at LBL'
+- &id1085
+  author: Greg Wilson
+  category: [Bootcamps, University of California - Berkeley, New York University,
+    University of Washington]
+  date: 2014-01-30
+  favorite: null
+  folder: blog/2014/01
+  layout: blog
+  path: blog/2014/01/data-science-bootcamps.html
+  root: ../../..
+  time: '16:00:00'
+  title: Workshops at the Data Science Centers
+- &id1086
+  author: Greg Wilson
+  category: [Bootcamps, Tooling, Community]
+  date: 2014-02-05
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/keeping-track-of-problems.html
+  root: ../../..
+  time: 06:00:00
+  title: Keeping Track of Problems
+- &id1087
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-02-09
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/a-reminder-about-instructor-training.html
+  root: ../../..
+  time: 08:30:00
+  title: Wrapping Up Round 7 (and a Reminder About Instructor Training)
+- &id1088
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-02-09
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/online-peer-instruction-tool.html
+  root: ../../..
+  time: 09:00:00
+  title: An Online Peer Instruction Tool
+- &id1089
+  author: Karthik Ram
+  category: [R, Community, Hackathon]
+  date: 2014-02-12
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/ropensci-hackathon.html
+  root: ../../..
+  time: '10:30:00'
+  title: rOpenSci Hackathon
+- &id1090
+  author: Greg Wilson
+  category: [PyCon, Bootcamps]
+  date: 2014-02-13
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/pycon-bootcamps.html
+  root: ../../..
+  time: 09:00:00
+  title: Our Biggest Event Ever
+- &id1091
+  author: Greg Wilson
+  category: [Research]
+  date: 2014-02-19
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/f1000-lessons-learned.html
+  root: ../../..
+  time: '13:00:00'
+  title: Lessons Learned Has Been Published
+- &id1092
+  author: Greg Wilson
+  category: [Instructor Training, Mozilla]
+  date: 2014-02-21
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/the-bigger-picture.html
+  root: ../../..
+  time: '12:00:00'
+  title: From Training to Engagement
+- &id1093
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-02-23
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/lab-meeting-feb-2014.html
+  root: ../../..
+  time: '20:30:00'
+  title: Lab Meeting (Feb 2014)
+- &id1094
+  author: Damien Irving
+  category: [Education]
+  date: 2014-02-24
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/university-course.html
+  root: ../../..
+  time: '12:00:00'
+  title: 'Software Carpentry: the University Course'
+- &id1095
+  author: Greg Wilson
+  category: [Community, Open Science]
+  date: 2014-02-25
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/open-scoop-challenge.html
+  root: ../../..
+  time: '21:00:00'
+  title: The Open Scoop Challenge
+- &id1096
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-03-01
+  favorite: null
+  folder: blog/2014/02
+  layout: blog
+  path: blog/2014/02/software-carpentry-on-the-cbc.html
+  root: ../../..
+  time: '14:00:00'
+  title: Software Carpentry on the CBC
+- &id1097
+  author: Aleksandra Pawlik
+  category: [Software Sustainability Institute, Community]
+  date: 2014-03-03
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/ssi-collaborations-workshop.html
+  root: ../../..
+  time: '12:30:00'
+  title: SSI Collaborations Workshop and Hackday
+- &id1098
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-03-03
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/feb-2014-lab-meeting-summary.html
+  root: ../../..
+  time: '13:00:00'
+  title: Summary of Feb 2014 Lab Meeting
+- &id1099
+  author: Greg Wilson
+  category: [Teaching, PyCon]
+  date: 2014-03-04
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/instructor-training-at-pycon.html
+  root: ../../..
+  time: 09:30:00
+  title: Learn How to Teach People to Program
+- &id1100
+  author: Greg Wilson
+  category: [Teaching, PyCon]
+  date: 2014-03-04
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/bootcamp-for-librarians-at-pycon.html
+  root: ../../..
+  time: 09:35:00
+  title: A Workshop for Librarians at PyCon
+- &id1101
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2014-03-07
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/reproducibility-workshop-at-xsede.html
+  root: ../../..
+  time: 06:00:00
+  title: Reproducibility Workshop at XSEDE
+- &id1102
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-03-07
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/anatole-france-updated.html
+  root: ../../..
+  time: 06:45:00
+  title: Anatole France, Updated
+- &id1103
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2014-03-12
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/john-hunter-fellowship-2014.html
+  root: ../../..
+  time: '14:30:00'
+  title: John Hunter Technology Fellowship 2014
+- &id1104
+  author: Greg Wilson
+  category: [Noticed, Opinion, Tooling]
+  date: 2014-03-14
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/everything-old-is-new-again.html
+  root: ../../..
+  time: 08:45:00
+  title: Everything Old is New Again
+- &id1105
+  author: Justin Kitzes
+  category: [Teaching, Education]
+  date: 2014-03-14
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/collaborative-lesson-development.html
+  root: ../../..
+  time: 09:00:00
+  title: Collaborative Lesson Development - Why Not?
+- &id1106
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-03-14
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/you-and-jimi-hendrix.html
+  root: ../../..
+  time: 09:10:00
+  title: You and Jimi Hendrix
+- &id1107
+  author: Aleksandra Pawlik
+  category: [Bootcamps]
+  date: 2014-03-14
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/tgac-bootcamp.html
+  root: ../../..
+  time: '14:30:00'
+  title: Software Carpentry at TGAC
+- &id1108
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2014-03-14
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/von-neumann-quote.html
+  root: ../../..
+  time: '16:00:00'
+  title: A Letter from John von Neumann
+- &id1109
+  author: Diana Clark
+  category: [Announcements]
+  date: 2014-03-17
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/pycon-is-just-a-month-away.html
+  root: ../../..
+  time: '13:00:00'
+  title: PyCon is Just a Month Away
+- &id1110
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-03-18
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/original-logo.html
+  root: ../../..
+  time: '11:00:00'
+  title: Our Original Logo
+- &id1111
+  author: Greg Wilson
+  category: [Community, Noticed, Announcements]
+  date: 2014-03-18
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/data-science-workshops-in-seattle.html
+  root: ../../..
+  time: '19:0:00'
+  title: Data Science Workshops in Seattle
+- &id1112
+  author: Greg Wilson
+  category: [Research, Teaching]
+  date: 2014-03-19
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/empirical-software-engineering-papers.html
+  root: ../../..
+  time: '10:00:00'
+  title: Empirical Software Engineering Papers
+- &id1113
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-03-23
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/not-on-the-shelves.html
+  root: ../../..
+  time: '10:00:00'
+  title: Not on the Shelves
+- &id1114
+  author: David Rio
+  category: [Opinion]
+  date: 2014-03-23
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/what-do-you-use-to-get-your-job-done.html
+  root: ../../..
+  time: '20:00:00'
+  title: What Tools Do You Use to Get Your Job Done?
+- &id1115
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-03-27
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/announcing-april-2014-lab-meeting.html
+  root: ../../..
+  time: '14:00:00'
+  title: Announcing Our Next Lab Meeting
+- &id1116
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2014-03-27
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/creating-an-online-presence.html
+  root: ../../..
+  time: '14:20:00'
+  title: Building a Minimal Online Presence
+- &id1117
+  author: Greg Wilson
+  category: [Content, Teaching]
+  date: 2014-03-27
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/changing-our-core-curriculum.html
+  root: ../../..
+  time: '14:30:00'
+  title: Changing Our Core Curriculum
+- &id1118
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-03-27
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/one-of-our-inspirations.html
+  root: ../../..
+  time: '20:00:00'
+  title: One of Our Inspirations
+- &id1119
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-03-29
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/updating-checklists.html
+  root: ../../..
+  time: '10:00:00'
+  title: Updating Our Checklists
+- &id1120
+  author: Greg Wilson
+  category: [Announcements, Tooling]
+  date: 2014-03-30
+  favorite: null
+  folder: blog/2014/03
+  layout: blog
+  path: blog/2014/03/announcing-nbdiff.html
+  root: ../../..
+  time: 08:00:00
+  title: Announcing NBDiff
+- &id1121
+  author: Bill Mills
+  category: [Teaching]
+  date: 2014-04-04
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/uniting_the_narrative.html
+  root: ../../..
+  time: 08:00:00
+  title: Uniting the Narrative
+- &id1122
+  author: John Blischak
+  category: [Community]
+  date: 2014-04-04
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/novice-r-discussion-summary.html
+  root: ../../..
+  time: '17:00:00'
+  title: Summary of March 2014 Meeting to Discuss Novice R Material
+- &id1123
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-04-05
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/continuous-publication-requires-continuous-attention.html
+  root: ../../..
+  time: 08:30:00
+  title: Does Continuous Publication Require Continuous Attention?
+- &id1124
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-04-06
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/bridging-the-authoring-gap.html
+  root: ../../..
+  time: 06:00:00
+  title: Bridging the Writing Gap
+- &id1125
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-04-15
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/summarizing-our-instructors-skills.html
+  root: ../../..
+  time: 09:30:00
+  title: Summarizing Our Instructors' Skills
+- &id1126
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-04-16
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/do-not-be-worried.html
+  root: ../../..
+  time: '15:00:00'
+  title: Do Not Be Worried
+- &id1127
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-04-18
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/changing-the-channel.html
+  root: ../../..
+  time: 09:00:00
+  title: Changing the Channel
+- &id1128
+  author: Steven Koenig
+  category: [Bootcamps]
+  date: 2014-04-18
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/sdu-workshop.html
+  root: ../../..
+  time: '20:00:00'
+  title: Workshop at University of Southern Denmark, Odense
+- &id1129
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2014-04-19
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/announcing-sesync-workshops.html
+  root: ../../..
+  time: '11:00:00'
+  title: Workshops at SESYNC
+- &id1130
+  author: Aleksandra Pawlik, Christina Koch
+  category: [Bootcamps]
+  date: 2014-04-22
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/garnet-bootcamp.html
+  root: ../../..
+  time: 07:00:00
+  title: Software Carpentry bootcamp at GARNet
+- &id1131
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2014-04-22
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/gsoc-projects-2014.html
+  root: ../../..
+  time: 09:00:00
+  title: GSoC Projects for 2014
+- &id1132
+  author: Kaitlin Thaney
+  category: [Announcements]
+  date: 2014-04-22
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/code-research-object-office-hours.html
+  root: ../../..
+  time: '16:00:00'
+  title: Office Hours for Code as a Research Object
+- &id1133
+  author: Raniere Silva
+  category: [Tooling]
+  date: 2014-04-23
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/mathui.html
+  root: ../../..
+  time: 08:00:00
+  title: Math Authoring Gap and MathUI
+- &id1134
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-04-23
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/import-lesson.html
+  root: ../../..
+  time: 08:30:00
+  title: Import Lesson
+- &id1135
+  author: Greg Wilson
+  category: [Opinion, Teaching]
+  date: 2014-04-23
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/mr-biczo-was-right.html
+  root: ../../..
+  time: 09:00:00
+  title: Mr. Biczo Was Right
+- &id1136
+  author: Lauren Michael
+  category: [Jobs]
+  date: 2014-04-24
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/uwm-chtc-job.html
+  root: ../../..
+  time: 09:00:00
+  title: 'Position: Systems Integration Developer at UW-Madison'
+- &id1137
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-04-25
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/apr-2014-lab-meeting-summary.html
+  root: ../../..
+  time: '14:00:00'
+  title: April 2014 Lab Meeting
+- &id1138
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-04-27
+  favorite: null
+  folder: blog/2014/04
+  layout: blog
+  path: blog/2014/04/pycon-2014-videos.html
+  root: ../../..
+  time: '11:00:00'
+  title: PyCon 2014 Videos
+- &id1139
+  author: Greg Wilson
+  category: [Teaching, Women in Science and Engineering]
+  date: 2014-05-01
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/wise-as-athena.html
+  root: ../../..
+  time: '10:00:00'
+  title: Wise as Athena...
+- &id1140
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-05-02
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/improving-instructor-training.html
+  root: ../../..
+  time: '13:00:00'
+  title: How to Improve Instructor Training
+- &id1141
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-05-05
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/playing-the-kazoo.html
+  root: ../../..
+  time: '10:00:00'
+  title: Playing the Kazoo
+- &id1142
+  author: Greg Wilson
+  category: [Announcements, Community]
+  date: 2014-05-05
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/multisite-sprint-in-july.html
+  root: ../../..
+  time: '18:00:00'
+  title: A Multi-Site Sprint in July
+- &id1143
+  author: Greg Wilson
+  category: [Opinion, Tooling]
+  date: 2014-05-08
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/knocking-on-the-futures-door.html
+  root: ../../..
+  time: '12:00:00'
+  title: Knocking on the Future's Door
+- &id1144
+  author: Christina Koch
+  category: [Instructor Training]
+  date: 2014-05-08
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/training-veteran.html
+  root: ../../..
+  time: '14:00:00'
+  title: A Training Veteran Weighs In
+- &id1145
+  author: Jory Schossau
+  category: [Assessment]
+  date: 2014-05-08
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/assessment-results-first-batch.html
+  root: ../../..
+  time: '22:00:00'
+  title: 'Assessment Results: First Batch'
+- &id1146
+  author: Greg Wilson
+  category: [Announcements, Community, Lab Meeting]
+  date: 2014-05-13
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/agenda-for-may-lab-meeting.html
+  root: ../../..
+  time: '17:00:00'
+  title: Agenda for This Month's Lab Meeting
+- &id1147
+  author: Greg Wilson
+  category: [Jobs, Mozilla Science Lab]
+  date: 2014-05-14
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/job-openings-at-mozilla-science-lab.html
+  root: ../../..
+  time: 07:00:00
+  title: Job Openings at the Mozilla Science Lab
+- &id1148
+  author: Karen Cranston
+  category: [Bootcamps, Data Carpentry]
+  date: 2014-05-14
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/our-first-data-carpentry-workshop.html
+  root: ../../..
+  time: 07:30:00
+  title: Our First Data Carpentry Workshop
+- &id1149
+  author: Aleksandra Pawlik
+  category: [Jobs, The Genome Analysis Centre]
+  date: 2014-05-14
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/job-opening-at-tgac.html
+  root: ../../..
+  time: '15:00:00'
+  title: Technical Training Officer (LVT Training Officer) position at TGAC
+- &id1150
+  author: Greg Wilson
+  category: [Announcements, Bootcamps]
+  date: 2014-05-20
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/a-lot-of-bootcamps-in-the-works.html
+  root: ../../..
+  time: 06:00:00
+  title: A Lot of Bootcamps in the Works
+- &id1151
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-05-20
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/behind-the-scenes.html
+  root: ../../..
+  time: 08:30:00
+  title: Behind the Scenes
+- &id1152
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-05-21
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/lab-meeting-reminder.html
+  root: ../../..
+  time: 08:30:00
+  title: Lab Meeting Reminder
+- &id1153
+  author: Greg Wilson
+  category: [Announcements, Assessment, Research]
+  date: 2014-05-24
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/data-science-study-invitation.html
+  root: ../../..
+  time: 07:00:00
+  title: Data Science Study Invitation
+- &id1154
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-05-24
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/may-2014-lab-meeting-summary.html
+  root: ../../..
+  time: '22:00:00'
+  title: Summary of May 2014 Lab Meeting
+- &id1155
+  author: Greg Wilson
+  category: [Women in Science and Engineering]
+  date: 2014-05-26
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/announcing-two-more-wise-bootcamps.html
+  root: ../../..
+  time: '20:30:00'
+  title: Announcing Two More WiSE Bootcamps
+- &id1156
+  author: Dhavide Aruliah
+  category: [Bootcamps, Librarians]
+  date: 2014-05-28
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/teaching-librarians-in-montreal.html
+  root: ../../..
+  time: 09:00:00
+  title: Teaching Librarians in Montreal
+- &id1157
+  author: Aleksandra Pawlik
+  category: [Instructor Training]
+  date: 2014-05-28
+  favorite: null
+  folder: blog/2014/05
+  layout: blog
+  path: blog/2014/05/after-instructor-training.html
+  root: ../../..
+  time: '10:00:00'
+  title: Learning to Teach Never Ends
+- &id1158
+  author: Greg Wilson
+  category: [Community, Noticed]
+  date: 2014-06-05
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/collected-links.html
+  root: ../../..
+  time: '12:00:00'
+  title: Collected Links
+- &id1159
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-06-05
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/instructor-training-in-norwich.html
+  root: ../../..
+  time: '12:15:00'
+  title: Instructor Training in Norwich, October 2014
+- &id1160
+  author: Greg Wilson
+  category: [Sprint 2014]
+  date: 2014-06-05
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/khmer-mini-hackathon.html
+  root: ../../..
+  time: '12:30:00'
+  title: Introducing Scientists to Testing and Code Review
+- &id1161
+  author: Greg Wilson
+  category: [Jobs]
+  date: 2014-06-05
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/research-computing-facilitators-in-wisconson.html
+  root: ../../..
+  time: '13:00:00'
+  title: Research Computing Facilitator Jobs in Wisconsin
+- &id1162
+  author: Jeff Hollister
+  category: [Bootcamps, University of Rhode Island]
+  date: 2014-06-05
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/post-mortem-on-uri-bootcamp.html
+  root: ../../..
+  time: '14:00:00'
+  title: Keeping the Bootcamp Fun Alive!
+- &id1163
+  author: Mike Jackson
+  category: [Bootcamps]
+  date: 2014-06-09
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/archer-cranfield-boot-camp.html
+  root: ../../..
+  time: '11:00:00'
+  title: ARCHER Software Carpentry Bootcamp and Introduction to Scientific Programming
+    in Python
+- &id1164
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-06-09
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/registration-open-for-norwich.html
+  root: ../../..
+  time: '19:00:00'
+  title: Registration Open for Instructor Training in Norwich in October
+- &id1165
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-06-09
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/announcing-june-2014-lab-meeting.html
+  root: ../../..
+  time: '20:30:00'
+  title: Announcing June 2014 Lab Meeting
+- &id1166
+  author: Greg Wilson
+  category: [Sprint 2014]
+  date: 2014-06-09
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/planning-our-summer-sprint.html
+  root: ../../..
+  time: '21:00:00'
+  title: Planning Our Summer Sprint
+- &id1167
+  author: Will Trimble
+  category: [Teaching, Tooling]
+  date: 2014-06-15
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/fixing-14-repositories.html
+  root: ../../..
+  time: '17:00:00'
+  title: Fixing 14 Repositories
+- &id1168
+  author: Tareq Malas
+  category: [Bootcamps, King Abdullah University of Science and Technology]
+  date: 2014-06-15
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/kaust-success-story.html
+  root: ../../..
+  time: '18:00:00'
+  title: A Success Story from KAUST
+- &id1169
+  author: Greg Wilson
+  category: [Bootcamps, Claremont Colleges, Duke University, Mozilla, UC Davis, SESAME]
+  date: 2014-06-15
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/a-double-handful-of-bootcamps.html
+  root: ../../..
+  time: '20:00:00'
+  title: A Double Handful of Bootcamps
+- &id1170
+  author: Greg Wilson
+  category: [Sprint 2014]
+  date: 2014-06-15
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/update-on-sprint-plans.html
+  root: ../../..
+  time: '22:00:00'
+  title: An Update on Our Sprint Plans
+- &id1171
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-06-17
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/reminder-june-2014-lab-meeting.html
+  root: ../../..
+  time: 09:00:00
+  title: 'Reminder: June 2014 Lab Meeting'
+- &id1172
+  author: Jeff Shelton
+  category: [Bootcamps, Engineering, MATLAB, PowerShell]
+  date: 2014-06-18
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/engineering-focused-bootcamp.html
+  root: ../../..
+  time: 09:00:00
+  title: Engineering-Focused Bootcamp
+- &id1173
+  author: Ben Waugh
+  category: [Jobs]
+  date: 2014-06-18
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/ucl-sysadmin-job.html
+  root: ../../..
+  time: '14:00:00'
+  title: Teaching Support IT Job at UCL Physics and Astronomy
+- &id1174
+  author: Bill Mills
+  category: [Bootcamps, Claremont Colleges]
+  date: 2014-06-19
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/reflections-on-claremont.html
+  root: ../../..
+  time: '21:00:00'
+  title: Reflections on Claremont
+- &id1175
+  author: Greg Wilson
+  category: [Administration, Tooling]
+  date: 2014-06-20
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/help-us-build-an-admin-tool-for-bootcamps.html
+  root: ../../..
+  time: 08:00:00
+  title: Help Us Build an Admin Tool for Bootcamps
+- &id1176
+  author: Greg Wilson
+  category: [Translations]
+  date: 2014-06-22
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/translating-software-carpentry-into-spanish.html
+  root: ../../..
+  time: 07:00:00
+  title: Translating Software Carpentry into Spanish
+- &id1177
+  author: Greg Wilson
+  category: [Lab Meeting]
+  date: 2014-06-25
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/lab-meeting-reminder.html
+  root: ../../..
+  time: 07:00:00
+  title: 'Reminder: Lab Meeting Tomorrow'
+- &id1178
+  author: Greg Wilson
+  category: [Funding, Research]
+  date: 2014-06-27
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/iuse-proposal-rejected.html
+  root: ../../..
+  time: '12:00:00'
+  title: Our IUSE Proposal Was Rejected
+- &id1179
+  author: Greg Wilson
+  category: [Community, Lab Meeting]
+  date: 2014-06-27
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/june-2014-lab-meeting-summary.html
+  root: ../../..
+  time: '13:00:00'
+  title: Summary of June 2014 Lab Meeting
+- &id1180
+  author: Aleksandra Pawlik
+  category: [Bootcamps]
+  date: 2014-06-30
+  favorite: null
+  folder: blog/2014/06
+  layout: blog
+  path: blog/2014/06/feedback-from-pisa-bootcamp.html
+  root: ../../..
+  time: '23:00:00'
+  title: Feedback from the bootcamp at Istituto Nazionale di Fisica Nucleare in Pisa
+- &id1181
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-07-05
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/scientific-groupware-revisited.html
+  root: ../../..
+  time: '16:00:00'
+  title: Scientific Groupware Revisited
+- &id1182
+  author: Daniel Chen
+  category: [Rockefeller University]
+  date: 2014-07-07
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/high-school-students-at-rockefeller.html
+  root: ../../..
+  time: '19:00:00'
+  title: Our First High School Workshop at Rockefeller University
+- &id1183
+  author: Raniere Silva
+  category: [Translations]
+  date: 2014-07-08
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/translating-software-carpentry-into-portuguese.html
+  root: ../../..
+  time: '18:35:05'
+  title: Translating Software Carpentry into Portuguese
+- &id1184
+  author: Mike Jackson
+  category: [Bootcamps]
+  date: 2014-07-11
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/archer-imperial-boot-camp.html
+  root: ../../..
+  time: '11:00:00'
+  title: ARCHER Software Carpentry Bootcamp at Imperial College London
+- &id1185
+  author: Alan O'Cais
+  category: [Cyprus Institute, SESAME, LinkSCEEM, Bootcamps]
+  date: 2014-07-17
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/bootcamps-in-cyprus-and-jordan.html
+  root: ../../..
+  time: '15:00:00'
+  title: Bootcamps in Cyprus and Jordan
+- &id1186
+  author: Raniere Silva, Piotr Banaszkiewicz and Gabriel Ivanica
+  category: [Sprint 2014]
+  date: 2014-07-21
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/sprint-gsoc.html
+  root: ../../..
+  time: 08:30:00
+  title: GSoC Projects at Summer Sprint
+- &id1187
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-07-21
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/scipy-2014-talks.html
+  root: ../../..
+  time: '12:45:00'
+  title: SciPy 2014 Talks and Lessons
+- &id1188
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-07-21
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/using-a-package-manager-for-lessons-and-papers.html
+  root: ../../..
+  time: '13:00:00'
+  title: Using a Package Manager for Lessons and Papers
+- &id1189
+  author: Greg Wilson
+  category: [Sprint 2014]
+  date: 2014-07-21
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/sprint-faq.html
+  root: ../../..
+  time: '15:00:00'
+  title: Summer Sprint FAQ
+- &id1190
+  author: Mike Jackson
+  category: [Bootcamps]
+  date: 2014-07-28
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/archer-cranfield-feedback.html
+  root: ../../..
+  time: '15:00:00'
+  title: Feedback from Cranfield
+- &id1191
+  author: Greg Wilson
+  category: [Sprint 2014]
+  date: 2014-07-29
+  favorite: null
+  folder: blog/2014/07
+  layout: blog
+  path: blog/2014/07/sprint-summary.html
+  root: ../../..
+  time: 09:00:00
+  title: Summer Sprint Summary
+- &id1192
+  author: Aleksandra Pawlik
+  category: [Sprint 2014]
+  date: 2014-08-04
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/krakow-sprint.html
+  root: ../../..
+  time: 09:00:00
+  title: The Real Purpose of Sprints
+- &id1193
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-08-04
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/sustainability.html
+  root: ../../..
+  time: '15:00:00'
+  title: Sustainability
+- &id1194
+  author: Simon Hettrick
+  category: [Announcements]
+  date: 2014-08-08
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/research-software-engineer-agm.html
+  root: ../../..
+  time: '12:00:00'
+  title: The Research Software Engineer AGM and Hackday
+- &id1195
+  author: James Hetherington
+  category: [Jobs]
+  date: 2014-08-11
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/position-at-ucl.html
+  root: ../../..
+  time: '12:00:00'
+  title: UCL Research Software Development is Hiring
+- &id1196
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-08-11
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/inessential-weirdness.html
+  root: ../../..
+  time: '14:00:00'
+  title: Inessential Weirdness in Software Carpentry
+- &id1197
+  author: Cam Macdonell
+  category: [Bootcamps]
+  date: 2014-08-13
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/bootcamps-for-librarians.html
+  root: ../../..
+  time: '13:00:00'
+  title: Three Bootcamps for Librarians
+- &id1198
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-08-13
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/news-from-australia.html
+  root: ../../..
+  time: '15:10:00'
+  title: News from Australia
+- &id1199
+  author: Greg Wilson
+  category: [Announcements]
+  date: 2014-08-14
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/practical-numerical-methods-mooc.html
+  root: ../../..
+  time: '21:00:00'
+  title: A MOOC on Practical Numerical Methods with Python
+- &id1200
+  archives: null
+  author: Greg Wilson
+  category: [Teaching, Community]
+  date: 2014-08-18
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/conversations-about-teaching.html
+  root: ../../..
+  time: '12:00:00'
+  title: Conversations About Teaching
+- &id1201
+  author: Greg Wilson
+  category: [Noticed, Teaching, Assessment]
+  date: 2014-08-21
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/fifth-angus-course.html
+  root: ../../..
+  time: '10:00:00'
+  title: The Fifth ANGUS Course
+- &id1202
+  author: Raniere Silva
+  category: [Opinion]
+  date: 2014-08-23
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/swc-at-rio.html
+  root: ../../..
+  time: '15:00:00'
+  title: Software Carpentry at Brazilian Open Science Conference
+- &id1203
+  author: Damien Irving
+  category: [MATLAB, Bootcamps, Opinion]
+  date: 2014-08-29
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/matlab-review.html
+  root: ../../..
+  time: 09:00:00
+  title: The New MATLAB Teaching Materials
+- &id1204
+  author: Rob Beagrie
+  category: [Bootcamps, Cambridge University]
+  date: 2014-08-29
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/cambridge-university-bootcamp.html
+  root: ../../..
+  time: '19:00:00'
+  title: Software Carpentry at Cambridge University
+- &id1205
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2014-08-30
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/fall-2014-bootcamps.html
+  root: ../../..
+  time: '12:00:00'
+  title: Fall 2014 Bootcamps (So Far)
+- &id1206
+  author: Raniere Silva
+  category: [Bootcamps, UFRGS]
+  date: 2014-08-30
+  favorite: null
+  folder: blog/2014/08
+  layout: blog
+  path: blog/2014/08/ufrgs-bootcamp.html
+  root: ../../..
+  time: '19:00:00'
+  title: Software Carpentry workshop at Universidade Federal do Rio Grande do Sul
+- &id1207
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2014-09-03
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/nature-interview-with-kaitlin-thaney.html
+  root: ../../..
+  time: '21:00:00'
+  title: Nature Interview with Kaitlin Thaney
+- &id1208
+  author: Greg Wilson
+  category: [Instructor Training, UC Davis]
+  date: 2014-09-03
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/instructor-training-at-uc-davis-jan-2015.html
+  root: ../../..
+  time: '22:00:00'
+  title: Instructor Training at UC Davis in January 2015
+- &id1209
+  author: Shauna Gordon-McKeon
+  category: [Community, Noticed]
+  date: 2014-09-03
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/open-source-comes-to-campus.html
+  root: ../../..
+  time: '22:30:00'
+  title: Open Source Comes to Campus
+- &id005
+  author: Greg Wilson
+  category: [Community, Opinion, Teaching]
+  date: 2014-09-04
+  favorite: true
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/building-better-teachers.html
+  root: ../../..
+  time: '13:00:00'
+  title: Building Better Teachers
+- &id1210
+  author: Greg Wilson
+  category: [Bootcamps]
+  date: 2014-09-06
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/update-on-fall-2014-bootcamps.html
+  root: ../../..
+  time: '12:00:00'
+  title: An Update on Upcoming Bootcamps
+- &id1211
+  author: Raniere Silva
+  category: [Bootcamps, USP]
+  date: 2014-09-09
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/ccsl-bootcamp.html
+  root: ../../..
+  time: '11:00:00'
+  title: Software Carpentry Workshop at Universidade of S&atilde;o Paulo
+- &id1212
+  author: Azalee Bostroem
+  category: [Community, Opinion, Teaching]
+  date: 2014-09-10
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/more-thoughts-on-better-teachers.html
+  root: ../../..
+  time: 08:00:00
+  title: More Thoughts on Better Teachers
+- &id1213
+  author: Justin Kitzes
+  category: [Community, Opinion, Teaching]
+  date: 2014-09-10
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/further-thoughts-on-better-teachers.html
+  root: ../../..
+  time: 09:00:00
+  title: Further Thoughts on Building Better Teachers
+- &id1214
+  author: Greg Wilson
+  category: [Teaching, Stanford]
+  date: 2014-09-12
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/videos-from-stanford.html
+  root: ../../..
+  time: '10:30:00'
+  title: Videos from Stanford
+- &id1215
+  author: Greg Wilson
+  category: [Lab Meeting]
+  date: 2014-09-12
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/sept-2014-lab-meeting.html
+  root: ../../..
+  time: '11:30:00'
+  title: September 2014 Lab Meeting
+- &id1216
+  author: Greg Wilson
+  category: [Governance]
+  date: 2014-09-16
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/minutes-2014-sept-16.html
+  root: ../../..
+  time: '19:30:00'
+  title: 'Interim Board Meeting: Sep 16, 2014'
+- &id1217
+  author: Tianhui Michael Li
+  category: [Community]
+  date: 2014-09-17
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/how-to-prepare-for-data-incubator.html
+  root: ../../..
+  time: '15:30:00'
+  title: How to Prepare for the Data Incubator
+- &id1218
+  author: Greg Wilson
+  category: [Administration, Community]
+  date: 2014-09-18
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/proposal-for-topic-maintainers.html
+  root: ../../..
+  time: '12:00:00'
+  title: A Proposal for Topic Maintainers
+- &id1219
+  author: Warren Code
+  category: [Teaching]
+  date: 2014-09-23
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/learning-goals.html
+  root: ../../..
+  time: '19:00:00'
+  title: Learning Goals
+- &id1220
+  author: Mike Jackson
+  category: [Bootcamps]
+  date: 2014-09-24
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/archer-imperial-feedback.html
+  root: ../../..
+  time: 08:00:00
+  title: Feedback from Imperial College London
+- &id1221
+  author: Greg Wilson
+  category: [Lab Meeting]
+  date: 2014-09-26
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/sept-2014-lab-meeting-report.html
+  root: ../../..
+  time: '11:30:00'
+  title: September 2014 Lab Meeting Report
+- &id1222
+  author: Greg Wilson
+  category: [Teaching, Noticed]
+  date: 2014-09-28
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/ucosp-as-a-model.html
+  root: ../../..
+  time: '10:30:00'
+  title: UCOSP as a Model
+- &id1223
+  author: Greg Wilson
+  category: [Administration, Community]
+  date: 2014-09-29
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/splitting-the-repo.html
+  root: ../../..
+  time: 09:00:00
+  title: Splitting the Repository
+- &id1224
+  author: Greg Wilson
+  category: [Governance]
+  date: 2014-09-30
+  favorite: null
+  folder: blog/2014/09
+  layout: blog
+  path: blog/2014/09/minutes-2014-sept-30.html
+  root: ../../..
+  time: '19:30:00'
+  title: 'Interim Board Meeting: Sep 30, 2014'
+- &id1225
+  author: Greg Wilson
+  category: [Teaching, Community]
+  date: 2014-10-03
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/welcome-our-new-instructors.html
+  root: ../../..
+  time: '14:00:00'
+  title: Welcome Our New Instructors
+- &id1226
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-10-04
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/a-new-template-for-workshop-websites.html
+  root: ../../..
+  time: '11:00:00'
+  title: A New Template for Workshop Websites
+- &id1227
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-10-04
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/browsercast.html
+  root: ../../..
+  time: '15:00:00'
+  title: Browsercast
+- &id1228
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-10-04
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/data-driven-discovery-investigators.html
+  root: ../../..
+  time: '16:00:00'
+  title: Congratulations to the Moore Investigators
+- &id1229
+  author: Alexandra Simperler
+  category: [Community, Research]
+  date: 2014-10-04
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/studying-impact.html
+  root: ../../..
+  time: '18:00:00'
+  title: Studying Impact
+- &id1230
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2014-10-04
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/reproducible-science-hackathon.html
+  root: ../../..
+  time: '18:15:00'
+  title: A Reproducible Science Hackathon
+- &id1231
+  author: Azalee Bostroem
+  category: [Community, Opinion, Teaching, UC Davis]
+  date: 2014-10-05
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/uc-davis-physics7.html
+  root: ../../..
+  time: '18:30:00'
+  title: Ideas to Improve Instructor Training
+- &id1232
+  author: Mike Jackson
+  category: [Workshops]
+  date: 2014-10-07
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/archer-edinburgh-workshop.html
+  root: ../../..
+  time: '14:00:00'
+  title: ARCHER Software Carpentry workshop at The University of Edinburgh
+- &id004
+  author: Greg Wilson
+  category: [Announcements, Community, Software Carpentry Foundation]
+  date: 2014-10-08
+  favorite: true
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/announcing-the-creation-of-the-software-carpentry-foundational.html
+  root: ../../..
+  time: '11:00:00'
+  title: Announcing the Creation of the Software Carpentry Foundation
+- &id1233
+  author: Damien Irving
+  category: [Teaching]
+  date: 2014-10-14
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/workshop-recording.html
+  root: ../../..
+  time: '11:00:00'
+  title: A Self-Recorded Workshop
+- &id1234
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-10-14
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/a-new-template-for-lessons.html
+  root: ../../..
+  time: '11:30:00'
+  title: A New Template for Lessons
+- &id1235
+  author: Gabriel A. Devenyi
+  category: [Tooling]
+  date: 2014-10-14
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/of-templates-and-metadata.html
+  root: ../../..
+  time: '11:45:00'
+  title: Of Templates and Metadata
+- &id1236
+  author: Raniere Silva
+  category: [Tooling]
+  date: 2014-10-14
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/yet-another-template-for-lessons.html
+  root: ../../..
+  time: '11:50:00'
+  title: Yet Another Template for Lessons
+- &id1237
+  author: Greg Wilson
+  category: [Governance]
+  date: 2014-10-14
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/minutes-2014-oct-14.html
+  root: ../../..
+  time: '19:30:00'
+  title: 'Interim Board Meeting: Oct 14, 2014'
+- &id1238
+  author: Greg Wilson
+  category: [Community, Software Sustainability Institute]
+  date: 2014-10-15
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/research-software-petition.html
+  root: ../../..
+  time: '10:00:00'
+  title: A Research Software Petition
+- &id1239
+  author: Greg Wilson
+  category: [Teaching, Community]
+  date: 2014-10-16
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/welcome-more-new-instructors.html
+  root: ../../..
+  time: '20:30:00'
+  title: Welcome More New Instructors
+- &id1240
+  author: Tommy Guy
+  category: [Workshops]
+  date: 2014-10-17
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/num-wrongs-plus-plus.html
+  root: ../../..
+  time: 07:00:00
+  title: Num Wrongs Plus Plus
+- &id1241
+  author: John Blischak
+  category: [Lessons, R]
+  date: 2014-10-20
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/announcing-novice-r-lessons.html
+  root: ../../..
+  time: '10:00:00'
+  title: Presenting the Novice R Materials and Future Plans for the SWC R Community
+- &id1242
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-10-23
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/new-lesson-template-v2.html
+  root: ../../..
+  time: '12:00:00'
+  title: A New Lesson Template, Version 2
+- &id1243
+  author: Greg Wilson
+  category: [Librarians, British Library]
+  date: 2014-10-27
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/british-library-courses.html
+  root: ../../..
+  time: 08:00:00
+  title: British Library Courses
+- &id1244
+  author: Greg Wilson
+  category: [Opinion, Teaching]
+  date: 2014-10-27
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/lost-in-space.html
+  root: ../../..
+  time: '12:00:00'
+  title: Lost in Space
+- &id1245
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-10-28
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/why-software-matters.html
+  root: ../../..
+  time: 09:00:00
+  title: Why Software Matters
+- &id1246
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-10-29
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/pandoc-and-gh-pages.html
+  root: ../../..
+  time: '11:30:00'
+  title: Pandoc and Building Pages
+- &id1247
+  author: Greg Wilson
+  category: [Opinion, Teaching]
+  date: 2014-10-30
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/why-we-dont-teach-testing.html
+  root: ../../..
+  time: '18:00:00'
+  title: Why We Don't Teach Testing (Even Though We'd Like To)
+- &id1248
+  author: Peter Steinbach
+  category: [Teaching]
+  date: 2014-10-31
+  favorite: null
+  folder: blog/2014/10
+  layout: blog
+  path: blog/2014/10/physicists-learning-to-develop-code.html
+  root: ../../..
+  time: '17:00:00'
+  title: Particle Physicists Pulling Themselves From The Swamp
+- &id1249
+  author: Daniel Chen
+  category: [Teaching]
+  date: 2014-11-02
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/revised-instructor-survey.html
+  root: ../../..
+  time: 06:00:00
+  title: Revamping the Instructor Survey
+- &id1250
+  author: Greg Wilson
+  category: [Software Carpentry Foundation]
+  date: 2014-11-03
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/scf-creation-faq.html
+  root: ../../..
+  time: 09:00:00
+  title: 'Software Carpentry Foundation: FAQ'
+- &id1251
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-11-04
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/a-joel-test-for-grassroots-programming-groups.html
+  root: ../../..
+  time: 07:00:00
+  title: A 'Joel Test' for Grassroots Programming Groups
+- &id1252
+  author: Diego Barneche
+  category: [Workshops, University of Sydney]
+  date: 2014-11-04
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/r-workshop-in-sydney.html
+  root: ../../..
+  time: 09:30:00
+  title: An R Workshop at the University of Sydney
+- &id1253
+  author: Greg Wilson
+  category: [Governance]
+  date: 2014-11-04
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/minutes-2014-nov-04.html
+  root: ../../..
+  time: '19:30:00'
+  title: 'Interim Board Meeting: Nov 4, 2014'
+- &id1254
+  author: Greg Wilson
+  category: [Teaching, Noticed]
+  date: 2014-11-06
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/you-should-read-juha-sorvas-thesis.html
+  root: ../../..
+  time: '15:30:00'
+  title: You Should Read Juha Sorva's Thesis
+- &id1255
+  author: Greg Wilson
+  category: [Instructor Training, TGAC]
+  date: 2014-11-06
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/instructor-training-at-tgac.html
+  root: ../../..
+  time: '15:45:00'
+  title: Instructor Training at TGAC
+- &id1256
+  author: Damien Irving
+  category: [Community, Software Carpentry Foundation]
+  date: 2014-11-06
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/institutional-partnerships.html
+  root: ../../..
+  time: '17:30:00'
+  title: Why Institutional Partnerships Make So Much Sense
+- &id1257
+  author: Greg Wilson
+  category: [Operations]
+  date: 2014-11-07
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/where-the-time-goes.html
+  root: ../../..
+  time: 07:00:00
+  title: Amdahl's Law and Software Carpentry
+- &id1258
+  author: Noam Ross
+  category: [Teaching, Community]
+  date: 2014-11-10
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/users-groups-for-ongoing-learning.html
+  root: ../../..
+  time: '13:30:00'
+  title: Ongoing Learning with User Groups
+- &id1259
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2014-11-11
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/why-it-matters.html
+  root: ../../..
+  time: 07:0:00
+  title: Why It Matters
+- &id1260
+  author: Stephen Turner
+  category: [Workshops, University of Virginia]
+  date: 2014-11-11
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/virginia-workshop.html
+  root: ../../..
+  time: '12:45:00'
+  title: Workshop at the University of Virginia
+- &id1261
+  author: Tiziano Zito
+  category: [Workshops, GeoSim]
+  date: 2014-11-11
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/geosim-worskhop.html
+  root: ../../..
+  time: '13:00:00'
+  title: Workshop at GeoSim (Potsdam)
+- &id1262
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-11-13
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/replacing-the-teaching-blog.html
+  root: ../../..
+  time: 05:0:00
+  title: Replacing the Teaching Blog
+- &id1263
+  author: Greg Wilson
+  category: [Lab Meeting]
+  date: 2014-11-14
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/announcing-nov-2014-lab-meeting.html
+  root: ../../..
+  time: 07:00:00
+  title: Announcing November 2014 Lab Meeting
+- &id1264
+  author: Pauline Barmby
+  category: [Workshops, University of Toronto]
+  date: 2014-11-14
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/toronto-gerstein-workshop.html
+  root: ../../..
+  time: 09:30:00
+  title: 'Workshop Summary: Gerstein Science Information Centre, University of Toronto'
+- &id1265
+  author: Gabriel A. Devenyi
+  category: [Tooling, Translations]
+  date: 2014-11-15
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/lessons-repo-split-and-translations.html
+  root: ../../..
+  time: '13:00:00'
+  title: Lessons, the Repository Split, and Translations
+- &id1266
+  author: Greg Wilson
+  category: [Testing]
+  date: 2014-11-18
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/close-enough-for-scientific-work.html
+  root: ../../..
+  time: '16:00:00'
+  title: Close Enough for Scientific Work
+- &id1267
+  author: Greg Wilson
+  category: [Governance]
+  date: 2014-11-18
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/minutes-2014-nov-18.html
+  root: ../../..
+  time: '19:30:00'
+  title: 'Interim Board Meeting: Nov 18, 2014'
+- &id1268
+  author: Greg Wilson
+  category: [Assessment]
+  date: 2014-11-19
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/new-instructor-post-assessment-questionnaire.html
+  root: ../../..
+  time: '13:00:00'
+  title: The New Instructor Post-Assessment Questionnaire
+- &id1269
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-11-20
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/adding-a-projects-page.html
+  root: ../../..
+  time: '12:00:00'
+  title: Adding a Projects Page
+- &id1270
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-11-22
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/instructor-training-stats.html
+  root: ../../..
+  time: 07:00:00
+  title: Instructor Training Stats
+- &id1271
+  author: Aleksandra Pawlik
+  category: [Workshops, Women in Science and Engineering]
+  date: 2014-11-23
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/announcing-wise-poland.html
+  root: ../../..
+  time: 08:00:00
+  title: Announcing WiSE Krakow!
+- &id1272
+  author: Greg Wilson
+  category: [Data Carpentry]
+  date: 2014-11-24
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/congratulations-to-data-carpentry.html
+  root: ../../..
+  time: 08:0:00
+  title: Congratulations to Data Carpentry
+- &id1273
+  author: Greg Wilson
+  category: [Translation, Korean, Lessons]
+  date: 2014-11-25
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/korean-translation.html
+  root: ../../..
+  time: 07:00:00
+  title: Translating Software Carpentry into Korean
+- &id1274
+  author: Greg Wilson
+  category: [Open Science]
+  date: 2014-11-27
+  favorite: null
+  folder: blog/2014/11
+  layout: blog
+  path: blog/2014/11/how-to-manage-confidential-data.html
+  root: ../../..
+  time: '18:00:00'
+  title: How to Manage Confidential Data
+- &id1275
+  author: Greg Wilson
+  category: [Lab Meeting]
+  date: 2014-12-01
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/lab-meeting-reminder.html
+  root: ../../..
+  time: 07:00:00
+  title: 'Reminder: Lab Meeting on Thursday'
+- &id1276
+  author: Greg Wilson
+  category: [Lessons]
+  date: 2014-12-01
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/goalposts-for-digital-humanities.html
+  root: ../../..
+  time: '19:00:00'
+  title: Goalposts for the Digital Humanities
+- &id1277
+  author: Greg Wilson
+  category: [Teaching]
+  date: 2014-12-02
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/what-about-moocs.html
+  root: ../../..
+  time: 09:00:00
+  title: What About MOOCs?
+- &id003
+  author: Greg Wilson
+  category: [Software Carpentry Foundation, Community]
+  date: 2014-12-03
+  favorite: true
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/scf-governance.html
+  root: ../../..
+  time: 09:00:00
+  title: 'Software Carpentry Foundation: Governance'
+- &id002
+  author: Greg Wilson
+  category: [Software Carpentry Foundation, Community]
+  date: 2014-12-03
+  favorite: true
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/scf-membership.html
+  root: ../../..
+  time: 09:05:00
+  title: 'Software Carpentry Foundation: Organizational Membership'
+- &id001
+  author: Greg Wilson
+  category: [Software Carpentry Foundation, Community]
+  date: 2014-12-03
+  favorite: true
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/scf-workshops.html
+  root: ../../..
+  time: 09:10:00
+  title: 'Software Carpentry Foundation: Workshops'
+- &id1278
+  author: Greg Wilson
+  category: [Instructor Training]
+  date: 2014-12-03
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/plans-for-2015-instructor-training.html
+  root: ../../..
+  time: 09:15:00
+  title: 'Plans for 2015: Instructor Training'
+- &id1279
+  author: Greg Wilson
+  category: [Administration]
+  date: 2014-12-03
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/plans-for-2015-workshop-organization.html
+  root: ../../..
+  time: 09:20:00
+  title: 'Plans for 2015: Workshop Organization'
+- &id1280
+  author: Greg Wilson
+  category: [Administration]
+  date: 2014-12-03
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/plans-for-2015-mentorship-and-assessment.html
+  root: ../../..
+  time: 09:25:00
+  title: 'Plans for 2015: Mentorship and Assessment'
+- &id1281
+  author: Greg Wilson
+  category: [Lessons]
+  date: 2014-12-03
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/plans-for-2015-lessons.html
+  root: ../../..
+  time: 09:30:00
+  title: 'Plans for 2015: Lessons'
+- &id1282
+  author: Greg Wilson
+  category: [Software Carpentry Foundation, Community]
+  date: 2014-12-03
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/election-date.html
+  root: ../../..
+  time: 09:35:00
+  title: Our First Election
+- &id1283
+  author: Greg Wilson
+  category: [Software Carpentry Foundation, Community]
+  date: 2014-12-03
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/summarizing-the-news.html
+  root: ../../..
+  time: 09:40:00
+  title: Summarizing the News
+- &id1284
+  author: Jonah Duckles
+  category: [Workshops, South Africa]
+  date: 2014-12-04
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/cape-town-swc.html
+  root: ../../..
+  time: '15:00:00'
+  title: Cape Town South Africa Workshop
+- &id1285
+  author: Andrew Walker
+  category: [Bootcamps, University of Leeds]
+  date: 2014-12-04
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/an-advanced-short-course-in-leeds.html
+  root: ../../..
+  time: '15:05:00'
+  title: An Advanced Short Course in Leeds
+- &id1286
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2014-12-04
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/se-hpcs-conference.html
+  root: ../../..
+  time: '15:20:00'
+  title: International Workshop on Software Engineering for High Performance Computing
+    in Science
+- &id1287
+  author: Aleksandra Pawlik
+  category: [Workshops, Women in Science and Engineering]
+  date: 2014-12-05
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/google-sponsor-wise-pl.html
+  root: ../../..
+  time: '13:40:00'
+  title: Google to Support WiSE Poland
+- &id1288
+  author: Raniere Silva and Andy Boughton
+  category: [Tooling]
+  date: 2014-12-05
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/announcing-validator.html
+  root: ../../..
+  time: '16:00:00'
+  title: Announcing the Lesson Validator
+- &id1289
+  author: Greg Wilson
+  category: [Accessiblity, Workshops]
+  date: 2014-12-05
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/new-accessibility-guidelines.html
+  root: ../../..
+  time: '16:05:00'
+  title: New Accessibility Guidelines
+- &id1290
+  author: Mike Jackson
+  category: [Workshops, University of Edinburgh]
+  date: 2014-12-08
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/archer-edinburgh-feedback.html
+  root: ../../..
+  time: '10:30:00'
+  title: Software Carpentry Returns to Edinburgh
+- &id1291
+  author: Greg Wilson
+  category: [Tooling]
+  date: 2014-12-09
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/templates-we-live-we-learn.html
+  root: ../../..
+  time: 06:00:00
+  title: 'Templates: We Live, We Learn'
+- &id1292
+  author: Rachel Slaybaugh
+  category: [Jobs]
+  date: 2014-12-13
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/ucb-nuclear-engineering.html
+  root: ../../..
+  time: '11:30:00'
+  title: UC Berkeley Postdoctoral Position in Nuclear Engineering
+- &id1293
+  author: Aleksandra Pawlik
+  category: [Workshops]
+  date: 2014-12-13
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/clinical-bioinformatics-feedback.html
+  root: ../../..
+  time: '12:00:00'
+  title: Feedback from the MSc Clinical Bioninformatics Workshop
+- &id1294
+  author: Aleksandra Pawlik
+  category: [Workshops, Women in Science and Engineering]
+  date: 2014-12-13
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/wise-pl-summary.html
+  root: ../../..
+  time: '12:30:00'
+  title: Feedback from WiSE in Krakow
+- &id1295
+  author: James Hetherington
+  category: [Jobs]
+  date: 2014-12-13
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/ucl-research-software-dashboard-developer.html
+  root: ../../..
+  time: '13:00:00'
+  title: UCL Research Software Dashboard Developer
+- &id1296
+  author: Greg Wilson
+  category: [Noticed]
+  date: 2014-12-13
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/results-of-ssi-survey.html
+  root: ../../..
+  time: '13:30:00'
+  title: Results of Software Sustainability Institute Survey
+- &id1297
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-12-15
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/who-are-you.html
+  root: ../../..
+  time: 06:15:00
+  title: Who Are We?
+- &id1298
+  author: Aaron O'Leary
+  category: [Tooling]
+  date: 2014-12-15
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/history-extraction.html
+  root: ../../..
+  time: 06:30:00
+  title: Guidelines for Extracting History
+- &id1299
+  author: Greg Wilson
+  category: [Lessons]
+  date: 2014-12-18
+  excerpt: '<p>   As <a href="{{page.root}}/blog/2014/10/new-lesson-template-v2.html">we
+    said back in October</a>,   we''re splitting the <a href="{{site.github_url}}/bc">existing
+    lesson repository</a>   into smaller and more manageable pieces.   To do that,   we
+    have defined   <a href="{{site.github_url}}/lesson-template">a new template for
+    lessons</a>,   and have been extracting the history of the existing material from
+    the current repository.   (We wanted to get the entire history of each lesson   so
+    that people would receive credit for the work they''ve done.)   The second step
+    has taken longer than planned,   but we now have all of the core novice lessons
+    in repositories of their own: </p>'
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/beta-release-of-new-format-lessons.html
+  root: ../../..
+  time: 06:00:00
+  title: All I Want for Christmas is a Pull Request...
+- &id1300
+  author: Greg Wilson
+  category: [Software Carpentry Foundation]
+  date: 2014-12-18
+  excerpt: '<p>   From 26-30 January,   an election will be held for the seven vacant
+    positions on the   inaugural Steering Committee of the Software Carpentry Foundation.   This
+    will be one of the biggest steps in the project''s journey   from two guys staying
+    up until 3:00 am fourteen years ago   to write lessons on Perl for scientists
+    at Los Alamos   to a mature open project run by the volunteers it belongs to.
+    </p> <p>   If you are a qualified instructor who has taught at least twice in
+    the past two years,   or have done a significant chunk of non-teaching work for
+    Software Carpentry,   you can both stand for election and vote.   We strongly
+    urge you to consider standing:   if you''re willing and able to commit to giving
+    the Foundation 3 hours a week,   you''ll help thousands of scientists get more
+    done in less time and with less pain.   It''ll be fun, too:   few things in life
+    are as rewarding as building something,   and our members are building something
+    extraordinary. </p> <p>   In order to stand for election,   you must write a blog
+    post to introduce yourself to the community   by Friday, January 16   (i.e., a
+    full week before the start of the election).   This post: </p> <ul>   <li>     <p>       must
+    be around 500 words long,     </p>   </li>   <li>     <p>       can be written
+    in any format (e.g. question and answer, paragraph text),       and     </p>   </li>   <li>     <p>       must
+    be titled, "2015 Election: Your Name"     </p>   </li> </ul> <p>   You can submit
+    your post as a pull request   to <a href="{{site.github_url}}/site">this website''s
+    repository</a>   or <a href="mailto:{{site.contact}}">by email</a>.   It should
+    explain: </p> <ul>   <li>     <p>       what your background is,     </p>   </li>   <li>     <p>       what
+    your previous involvement with Software Carpentry has been,       and most importantly     </p>   </li>   <li>     <p>       what
+    you will do as a member of the Steering Committee       to contribute to the growth
+    and success of Software Carpentry.     </p>   </li> </ul> <p>   The last point
+    is the most important.   If you have experience managing money,   we need a Treasurer;   if
+    your passion is helping new instructors or figuring out how well we''re doing,   we
+    need people to lead   <a href="{{page.root}}/blog/2014/12/plans-for-2015-mentorship-and-assessment.html">mentorship
+    and assessment</a>,   while if you come from a part of the world that hasn''t
+    seen much Software Carpentry activity yet,   you might want to take the lead in
+    getting us going there. </p> <p>   (Actually,   the point that''s <em>really</em>
+    most important is that   everyone will still be very welcome to volunteer in other
+    ways,   and that doing so will be as valuable as ever.   We will still need topic
+    maintainers,   help with the website,   and many other things,   and I hope that
+    having more people coordinating things   will actually make it easier for you
+    all to lend a hand.) </p> <p>   If seven or fewer nominations are received,   those
+    people who nominated will be automatically appointed to the Steering Committee   and
+    no formal election will be held.   Vacancies on the Steering Committee can be
+    filled at any time at the Committee''s discretion.   The regular positions on
+    the Steering Committee   (Chair, Vice-Chair, Secretary, Treasurer and then any
+    others the Committee feels it needs)   will be decided by a vote at the Committee''s
+    first meeting. </p>'
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/standing-for-election.html
+  root: ../../..
+  time: 07:00:00
+  title: Standing for Election
+- &id1301
+  author: Greg Wilson
+  category: [Governance]
+  date: 2014-12-19
+  excerpt: '<p>Software Carpentry Foundation Interim Board Meeting: Dec 2, 2014</p>'
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/minutes-2014-dec-02.html
+  root: ../../..
+  time: 07:30:00
+  title: 'Interim Steering Committee Meeting: Dec 2, 2014'
+- &id1302
+  author: Greg Wilson
+  category: [Teaching, Community]
+  date: 2014-12-23
+  excerpt: <p>   A lot of people qualified as instructors this fall and winter,   thanks
+    in part to the live sessions we ran in Charlottesville, Norwich, and Seattle.   They
+    join the 86 other people who received their badge this year;   we look forward
+    to seeing them all run workshops before 2015 is over. </p>
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/welcome-aboard.html
+  root: ../../..
+  time: '16:00:00'
+  title: Welcome Aboard
+- &id1303
+  author: Greg Wilson
+  category: [Community]
+  date: 2014-12-28
+  excerpt: '<p>   We have updated our <a href="{{page.root}}/pages/projects.html">projects
+    page</a> with links to: </p> <ol>   <li>     things we''re building ourselves,
+    and   </li>   <li>     things that our members are building.   </li> </ol> <p>   The
+    first list includes the templates for   <a href="https://github.com/swcarpentry/lesson-template">lessons</a>   and
+    <a href="https://github.com/swcarpentry/workshop-template">workshop websites</a>,   a
+    <a href="https://github.com/swcarpentry/amy">a tool for managing workshops</a>   (for
+    which we''re using Django),   the <a href="https://github.com/twitwi/deck.browsercast.js/">latest
+    version</a> of   <a href="http://third-bit.com/browsercast/">Browsercast</a>,   and
+    more.   The second list has everything from   <a href="http://www.activepapers.org/"
+    class="project">active papers</a>   to <a href="http://jrsmith3.github.io/tec/">utilities
+    for simulating vacuum thermionic energy conversion devices</a>.   If you''d like
+    to help with the first,   or if you''re a <a href="{{page.root}}/blog/2014/12/standing-for-election.html#members">member</a>   and
+    would like your project listed in the second,   please <a href="mailto:{{site.contact}}">get
+    in touch</a>. </p>'
+  favorite: null
+  folder: blog/2014/12
+  layout: blog
+  path: blog/2014/12/projects-projects-projects.html
+  root: ../../..
+  time: '16:00:00'
+  title: Projects, Projects, Projects
+- &id1304
+  author: Greg Wilson
+  category: [Opinion]
+  date: 2015-01-04
+  excerpt: <p>   I was talking with friends over the holiday about the future of science   and
+    how it might one day be funded.   Since it'll be ten years before I'm proven wrong,   it
+    seems like a good topic with which to start the new year. </p>
+  favorite: null
+  folder: blog/2015/01
+  layout: blog
+  path: blog/2015/01/future-and-funding-of-science.html
+  root: ../../..
+  time: 05:30:00
+  title: The Future and Funding of Science
+blog_count:
+  '2004': {'01': 0, '02': 0, '03': 0, '04': 0, '05': 0, '06': 0, '07': 0, 08: 0, 09: 0,
+    '10': 0, '11': 0, '12': 1}
+  '2005': {'01': 0, '02': 0, '03': 0, '04': 0, '05': 0, '06': 0, '07': 2, 08: 1, 09: 3,
+    '10': 0, '11': 1, '12': 6}
+  '2006': {'01': 10, '02': 11, '03': 4, '04': 5, '05': 2, '06': 1, '07': 3, 08: 4,
+    09: 0, '10': 2, '11': 2, '12': 1}
+  '2007': {'01': 1, '02': 1, '03': 3, '04': 1, '05': 1, '06': 6, '07': 4, 08: 2, 09: 2,
+    '10': 2, '11': 0, '12': 1}
+  '2008': {'01': 0, '02': 4, '03': 4, '04': 4, '05': 7, '06': 3, '07': 6, 08: 4, 09: 2,
+    '10': 2, '11': 7, '12': 6}
+  '2009': {'01': 4, '02': 9, '03': 5, '04': 8, '05': 6, '06': 13, '07': 20, 08: 16,
+    09: 9, '10': 8, '11': 9, '12': 5}
+  '2010': {'01': 7, '02': 4, '03': 10, '04': 11, '05': 24, '06': 41, '07': 32, 08: 12,
+    09: 17, '10': 24, '11': 15, '12': 23}
+  '2011': {'01': 24, '02': 19, '03': 24, '04': 5, '05': 6, '06': 11, '07': 9, 08: 3,
+    09: 8, '10': 8, '11': 12, '12': 10}
+  '2012': {'01': 15, '02': 37, '03': 28, '04': 26, '05': 31, '06': 21, '07': 9, 08: 13,
+    09: 18, '10': 30, '11': 25, '12': 22}
+  '2013': {'01': 14, '02': 18, '03': 12, '04': 16, '05': 19, '06': 15, '07': 14, 08: 13,
+    09: 16, '10': 9, '11': 21, '12': 15}
+  '2014': {'01': 20, '02': 10, '03': 25, '04': 18, '05': 19, '06': 23, '07': 11, 08: 15,
+    09: 19, '10': 25, '11': 26, '12': 32}
+  '2015': {'01': 1, '02': 0, '03': 0, '04': 0, '05': 0, '06': 0, '07': 0, 08: 0, 09: 0,
+    '10': 0, '11': 0, '12': 0}
+blog_favorites:
+- *id001
+- *id002
+- *id003
+- *id004
+- *id005
+- *id006
+- *id007
+- *id008
+- *id009
+- *id010
+- *id011
+- *id012
+- *id013
+- *id014
+- *id015
+- *id016
+- *id017
+- *id018
+- *id019
+- *id020
+- *id021
+- *id022
+blog_lookup:
+  '2004':
+    '01': []
+    '02': []
+    '03': []
+    '04': []
+    '05': []
+    '06': []
+    '07': []
+    08: []
+    09: []
+    '10': []
+    '11': []
+    '12':
+    - *id023
+  '2005':
+    '01': []
+    '02': []
+    '03': []
+    '04': []
+    '05': []
+    '06': []
+    '07':
+    - *id024
+    - *id025
+    08:
+    - *id026
+    09:
+    - *id027
+    - *id028
+    - *id029
+    '10': []
+    '11':
+    - *id030
+    '12':
+    - *id031
+    - *id032
+    - *id033
+    - *id034
+    - *id035
+    - *id036
+  '2006':
+    '01':
+    - *id037
+    - *id038
+    - *id039
+    - *id040
+    - *id041
+    - *id042
+    - *id043
+    - *id044
+    - *id045
+    - *id046
+    '02':
+    - *id047
+    - *id048
+    - *id049
+    - *id050
+    - *id051
+    - *id052
+    - *id053
+    - *id054
+    - *id055
+    - *id056
+    - *id057
+    '03':
+    - *id058
+    - *id059
+    - *id060
+    - *id061
+    '04':
+    - *id062
+    - *id063
+    - *id064
+    - *id065
+    - *id066
+    '05':
+    - *id067
+    - *id068
+    '06':
+    - *id069
+    '07':
+    - *id070
+    - *id071
+    - *id072
+    08:
+    - *id073
+    - *id074
+    - *id075
+    - *id076
+    09: []
+    '10':
+    - *id077
+    - *id078
+    '11':
+    - *id079
+    - *id080
+    '12':
+    - *id081
+  '2007':
+    '01':
+    - *id082
+    '02':
+    - *id083
+    '03':
+    - *id084
+    - *id085
+    - *id086
+    '04':
+    - *id087
+    '05':
+    - *id088
+    '06':
+    - *id089
+    - *id090
+    - *id091
+    - *id092
+    - *id093
+    - *id094
+    '07':
+    - *id095
+    - *id096
+    - *id097
+    - *id098
+    08:
+    - *id099
+    - *id100
+    09:
+    - *id101
+    - *id102
+    '10':
+    - *id103
+    - *id104
+    '11': []
+    '12':
+    - *id105
+  '2008':
+    '01': []
+    '02':
+    - *id106
+    - *id107
+    - *id108
+    - *id109
+    '03':
+    - *id110
+    - *id111
+    - *id112
+    - *id113
+    '04':
+    - *id114
+    - *id115
+    - *id116
+    - *id117
+    '05':
+    - *id118
+    - *id119
+    - *id120
+    - *id121
+    - *id122
+    - *id123
+    - *id124
+    '06':
+    - *id125
+    - *id126
+    - *id127
+    '07':
+    - *id128
+    - *id129
+    - *id130
+    - *id131
+    - *id132
+    - *id133
+    08:
+    - *id134
+    - *id135
+    - *id136
+    - *id137
+    09:
+    - *id138
+    - *id139
+    '10':
+    - *id140
+    - *id141
+    '11':
+    - *id142
+    - *id143
+    - *id144
+    - *id145
+    - *id146
+    - *id147
+    - *id148
+    '12':
+    - *id149
+    - *id150
+    - *id151
+    - *id152
+    - *id153
+    - *id154
+  '2009':
+    '01':
+    - *id155
+    - *id156
+    - *id157
+    - *id158
+    '02':
+    - *id159
+    - *id160
+    - *id161
+    - *id162
+    - *id163
+    - *id164
+    - *id165
+    - *id166
+    - *id167
+    '03':
+    - *id168
+    - *id169
+    - *id170
+    - *id171
+    - *id172
+    '04':
+    - *id173
+    - *id174
+    - *id175
+    - *id176
+    - *id177
+    - *id178
+    - *id179
+    - *id180
+    '05':
+    - *id181
+    - *id182
+    - *id183
+    - *id184
+    - *id185
+    - *id186
+    '06':
+    - *id187
+    - *id188
+    - *id189
+    - *id190
+    - *id191
+    - *id192
+    - *id193
+    - *id194
+    - *id195
+    - *id196
+    - *id197
+    - *id198
+    - *id199
+    '07':
+    - *id200
+    - *id201
+    - *id202
+    - *id203
+    - *id204
+    - *id205
+    - *id206
+    - *id207
+    - *id208
+    - *id209
+    - *id210
+    - *id211
+    - *id212
+    - *id213
+    - *id214
+    - *id215
+    - *id216
+    - *id217
+    - *id218
+    - *id219
+    08:
+    - *id220
+    - *id221
+    - *id222
+    - *id223
+    - *id224
+    - *id225
+    - *id226
+    - *id227
+    - *id228
+    - *id229
+    - *id230
+    - *id231
+    - *id232
+    - *id233
+    - *id234
+    - *id235
+    09:
+    - *id236
+    - *id237
+    - *id238
+    - *id239
+    - *id240
+    - *id241
+    - *id242
+    - *id243
+    - *id244
+    '10':
+    - *id245
+    - *id246
+    - *id247
+    - *id248
+    - *id249
+    - *id250
+    - *id251
+    - *id252
+    '11':
+    - *id253
+    - *id254
+    - *id255
+    - *id256
+    - *id257
+    - *id258
+    - *id259
+    - *id260
+    - *id261
+    '12':
+    - *id262
+    - *id263
+    - *id264
+    - *id265
+    - *id266
+  '2010':
+    '01':
+    - *id267
+    - *id268
+    - *id269
+    - *id270
+    - *id271
+    - *id272
+    - *id273
+    '02':
+    - *id274
+    - *id275
+    - *id276
+    - *id277
+    '03':
+    - *id278
+    - *id279
+    - *id280
+    - *id281
+    - *id282
+    - *id283
+    - *id284
+    - *id285
+    - *id286
+    - *id287
+    '04':
+    - *id288
+    - *id289
+    - *id290
+    - *id291
+    - *id292
+    - *id293
+    - *id294
+    - *id295
+    - *id296
+    - *id297
+    - *id298
+    '05':
+    - *id299
+    - *id300
+    - *id301
+    - *id302
+    - *id303
+    - *id304
+    - *id305
+    - *id306
+    - *id307
+    - *id308
+    - *id309
+    - *id310
+    - *id311
+    - *id312
+    - *id313
+    - *id314
+    - *id315
+    - *id316
+    - *id317
+    - *id318
+    - *id319
+    - *id320
+    - *id321
+    - *id322
+    '06':
+    - *id323
+    - *id324
+    - *id325
+    - *id326
+    - *id327
+    - *id328
+    - *id329
+    - *id330
+    - *id331
+    - *id332
+    - *id333
+    - *id334
+    - *id335
+    - *id336
+    - *id337
+    - *id338
+    - *id339
+    - *id340
+    - *id341
+    - *id342
+    - *id343
+    - *id344
+    - *id345
+    - *id346
+    - *id347
+    - *id348
+    - *id349
+    - *id350
+    - *id351
+    - *id352
+    - *id353
+    - *id354
+    - *id355
+    - *id356
+    - *id357
+    - *id358
+    - *id359
+    - *id360
+    - *id361
+    - *id362
+    - *id363
+    '07':
+    - *id364
+    - *id365
+    - *id366
+    - *id367
+    - *id368
+    - *id369
+    - *id370
+    - *id371
+    - *id372
+    - *id373
+    - *id374
+    - *id375
+    - *id376
+    - *id377
+    - *id378
+    - *id379
+    - *id380
+    - *id381
+    - *id382
+    - *id383
+    - *id384
+    - *id385
+    - *id386
+    - *id387
+    - *id388
+    - *id389
+    - *id390
+    - *id391
+    - *id392
+    - *id393
+    - *id394
+    - *id395
+    08:
+    - *id396
+    - *id397
+    - *id398
+    - *id399
+    - *id400
+    - *id401
+    - *id402
+    - *id403
+    - *id404
+    - *id405
+    - *id406
+    - *id407
+    09:
+    - *id408
+    - *id409
+    - *id410
+    - *id411
+    - *id412
+    - *id413
+    - *id414
+    - *id415
+    - *id416
+    - *id417
+    - *id418
+    - *id419
+    - *id420
+    - *id421
+    - *id422
+    - *id423
+    - *id424
+    '10':
+    - *id425
+    - *id426
+    - *id427
+    - *id428
+    - *id429
+    - *id430
+    - *id431
+    - *id432
+    - *id433
+    - *id434
+    - *id435
+    - *id436
+    - *id437
+    - *id438
+    - *id439
+    - *id440
+    - *id441
+    - *id442
+    - *id443
+    - *id444
+    - *id445
+    - *id446
+    - *id447
+    - *id448
+    '11':
+    - *id449
+    - *id450
+    - *id451
+    - *id452
+    - *id453
+    - *id454
+    - *id455
+    - *id456
+    - *id457
+    - *id458
+    - *id459
+    - *id460
+    - *id461
+    - *id462
+    - *id463
+    '12':
+    - *id464
+    - *id465
+    - *id466
+    - *id467
+    - *id468
+    - *id469
+    - *id470
+    - *id471
+    - *id472
+    - *id473
+    - *id474
+    - *id475
+    - *id476
+    - *id477
+    - *id478
+    - *id479
+    - *id480
+    - *id481
+    - *id482
+    - *id483
+    - *id484
+    - *id485
+    - *id486
+  '2011':
+    '01':
+    - *id487
+    - *id488
+    - *id489
+    - *id490
+    - *id491
+    - *id492
+    - *id493
+    - *id494
+    - *id495
+    - *id496
+    - *id497
+    - *id498
+    - *id499
+    - *id500
+    - *id501
+    - *id502
+    - *id503
+    - *id504
+    - *id505
+    - *id506
+    - *id507
+    - *id508
+    - *id509
+    - *id510
+    '02':
+    - *id511
+    - *id512
+    - *id513
+    - *id514
+    - *id515
+    - *id516
+    - *id517
+    - *id518
+    - *id519
+    - *id520
+    - *id521
+    - *id522
+    - *id523
+    - *id524
+    - *id525
+    - *id526
+    - *id527
+    - *id528
+    - *id529
+    '03':
+    - *id530
+    - *id531
+    - *id532
+    - *id533
+    - *id534
+    - *id535
+    - *id536
+    - *id537
+    - *id538
+    - *id539
+    - *id540
+    - *id541
+    - *id542
+    - *id543
+    - *id544
+    - *id545
+    - *id546
+    - *id547
+    - *id548
+    - *id549
+    - *id550
+    - *id551
+    - *id552
+    - *id553
+    '04':
+    - *id554
+    - *id555
+    - *id556
+    - *id557
+    - *id558
+    '05':
+    - *id559
+    - *id560
+    - *id561
+    - *id562
+    - *id563
+    - *id564
+    '06':
+    - *id565
+    - *id566
+    - *id567
+    - *id568
+    - *id569
+    - *id570
+    - *id571
+    - *id572
+    - *id573
+    - *id574
+    - *id575
+    '07':
+    - *id576
+    - *id577
+    - *id578
+    - *id579
+    - *id580
+    - *id581
+    - *id582
+    - *id583
+    - *id584
+    08:
+    - *id585
+    - *id586
+    - *id587
+    09:
+    - *id588
+    - *id589
+    - *id590
+    - *id591
+    - *id592
+    - *id593
+    - *id594
+    - *id595
+    '10':
+    - *id596
+    - *id597
+    - *id598
+    - *id599
+    - *id600
+    - *id601
+    - *id602
+    - *id603
+    '11':
+    - *id604
+    - *id605
+    - *id606
+    - *id607
+    - *id608
+    - *id609
+    - *id610
+    - *id611
+    - *id612
+    - *id613
+    - *id614
+    - *id615
+    '12':
+    - *id616
+    - *id617
+    - *id618
+    - *id619
+    - *id620
+    - *id621
+    - *id622
+    - *id022
+    - *id623
+    - *id624
+  '2012':
+    '01':
+    - *id625
+    - *id626
+    - *id627
+    - *id628
+    - *id629
+    - *id630
+    - *id631
+    - *id632
+    - *id633
+    - *id634
+    - *id635
+    - *id636
+    - *id637
+    - *id638
+    - *id639
+    '02':
+    - *id640
+    - *id641
+    - *id642
+    - *id643
+    - *id644
+    - *id645
+    - *id646
+    - *id647
+    - *id648
+    - *id649
+    - *id650
+    - *id651
+    - *id652
+    - *id653
+    - *id654
+    - *id655
+    - *id656
+    - *id657
+    - *id658
+    - *id659
+    - *id660
+    - *id661
+    - *id662
+    - *id663
+    - *id664
+    - *id665
+    - *id666
+    - *id667
+    - *id668
+    - *id669
+    - *id670
+    - *id671
+    - *id672
+    - *id673
+    - *id674
+    - *id675
+    - *id676
+    '03':
+    - *id677
+    - *id678
+    - *id679
+    - *id680
+    - *id681
+    - *id682
+    - *id021
+    - *id683
+    - *id684
+    - *id685
+    - *id686
+    - *id687
+    - *id688
+    - *id689
+    - *id690
+    - *id691
+    - *id692
+    - *id693
+    - *id694
+    - *id695
+    - *id696
+    - *id697
+    - *id698
+    - *id699
+    - *id700
+    - *id701
+    - *id702
+    - *id703
+    '04':
+    - *id704
+    - *id705
+    - *id706
+    - *id707
+    - *id708
+    - *id709
+    - *id710
+    - *id711
+    - *id712
+    - *id713
+    - *id714
+    - *id715
+    - *id716
+    - *id717
+    - *id718
+    - *id719
+    - *id720
+    - *id721
+    - *id722
+    - *id723
+    - *id724
+    - *id725
+    - *id726
+    - *id727
+    - *id728
+    - *id729
+    '05':
+    - *id730
+    - *id731
+    - *id732
+    - *id733
+    - *id734
+    - *id735
+    - *id736
+    - *id737
+    - *id738
+    - *id739
+    - *id740
+    - *id741
+    - *id742
+    - *id743
+    - *id020
+    - *id744
+    - *id745
+    - *id746
+    - *id747
+    - *id748
+    - *id749
+    - *id750
+    - *id751
+    - *id752
+    - *id753
+    - *id754
+    - *id019
+    - *id755
+    - *id756
+    - *id757
+    - *id758
+    '06':
+    - *id759
+    - *id760
+    - *id761
+    - *id762
+    - *id763
+    - *id764
+    - *id765
+    - *id766
+    - *id767
+    - *id768
+    - *id769
+    - *id770
+    - *id771
+    - *id772
+    - *id773
+    - *id774
+    - *id775
+    - *id776
+    - *id777
+    - *id778
+    - *id779
+    '07':
+    - *id780
+    - *id781
+    - *id782
+    - *id783
+    - *id784
+    - *id785
+    - *id786
+    - *id787
+    - *id788
+    08:
+    - *id789
+    - *id790
+    - *id791
+    - *id792
+    - *id793
+    - *id794
+    - *id795
+    - *id796
+    - *id797
+    - *id798
+    - *id799
+    - *id800
+    - *id801
+    09:
+    - *id802
+    - *id803
+    - *id804
+    - *id805
+    - *id806
+    - *id807
+    - *id808
+    - *id809
+    - *id810
+    - *id811
+    - *id812
+    - *id813
+    - *id814
+    - *id815
+    - *id816
+    - *id817
+    - *id018
+    - *id818
+    '10':
+    - *id819
+    - *id820
+    - *id821
+    - *id822
+    - *id823
+    - *id824
+    - *id825
+    - *id826
+    - *id017
+    - *id827
+    - *id828
+    - *id829
+    - *id830
+    - *id831
+    - *id832
+    - *id833
+    - *id834
+    - *id835
+    - *id016
+    - *id836
+    - *id837
+    - *id838
+    - *id839
+    - *id840
+    - *id841
+    - *id842
+    - *id843
+    - *id844
+    - *id845
+    - *id846
+    '11':
+    - *id847
+    - *id848
+    - *id849
+    - *id850
+    - *id851
+    - *id852
+    - *id853
+    - *id854
+    - *id855
+    - *id856
+    - *id857
+    - *id858
+    - *id859
+    - *id860
+    - *id861
+    - *id862
+    - *id863
+    - *id864
+    - *id865
+    - *id866
+    - *id867
+    - *id868
+    - *id869
+    - *id870
+    - *id871
+    '12':
+    - *id872
+    - *id873
+    - *id874
+    - *id875
+    - *id876
+    - *id877
+    - *id878
+    - *id879
+    - *id880
+    - *id881
+    - *id882
+    - *id883
+    - *id884
+    - *id885
+    - *id886
+    - *id887
+    - *id888
+    - *id889
+    - *id890
+    - *id891
+    - *id892
+    - *id893
+  '2013':
+    '01':
+    - *id015
+    - *id894
+    - *id895
+    - *id896
+    - *id014
+    - *id897
+    - *id898
+    - *id899
+    - *id900
+    - *id901
+    - *id902
+    - *id903
+    - *id904
+    - *id905
+    '02':
+    - *id906
+    - *id907
+    - *id908
+    - *id909
+    - *id910
+    - *id911
+    - *id912
+    - *id913
+    - *id914
+    - *id013
+    - *id915
+    - *id916
+    - *id917
+    - *id918
+    - *id919
+    - *id920
+    - *id921
+    - *id922
+    '03':
+    - *id923
+    - *id924
+    - *id925
+    - *id926
+    - *id927
+    - *id928
+    - *id929
+    - *id930
+    - *id931
+    - *id932
+    - *id933
+    - *id934
+    '04':
+    - *id935
+    - *id936
+    - *id937
+    - *id938
+    - *id939
+    - *id940
+    - *id941
+    - *id942
+    - *id943
+    - *id944
+    - *id945
+    - *id946
+    - *id947
+    - *id948
+    - *id949
+    - *id950
+    '05':
+    - *id951
+    - *id952
+    - *id953
+    - *id954
+    - *id955
+    - *id956
+    - *id957
+    - *id958
+    - *id959
+    - *id960
+    - *id961
+    - *id962
+    - *id963
+    - *id964
+    - *id965
+    - *id012
+    - *id011
+    - *id966
+    - *id967
+    '06':
+    - *id968
+    - *id969
+    - *id970
+    - *id971
+    - *id972
+    - *id973
+    - *id974
+    - *id975
+    - *id976
+    - *id977
+    - *id978
+    - *id979
+    - *id980
+    - *id981
+    - *id982
+    '07':
+    - *id983
+    - *id984
+    - *id985
+    - *id986
+    - *id987
+    - *id988
+    - *id989
+    - *id990
+    - *id991
+    - *id992
+    - *id993
+    - *id994
+    - *id995
+    - *id996
+    08:
+    - *id997
+    - *id998
+    - *id999
+    - *id1000
+    - *id1001
+    - *id1002
+    - *id1003
+    - *id1004
+    - *id1005
+    - *id1006
+    - *id1007
+    - *id1008
+    - *id1009
+    09:
+    - *id1010
+    - *id1011
+    - *id1012
+    - *id1013
+    - *id1014
+    - *id1015
+    - *id1016
+    - *id1017
+    - *id1018
+    - *id1019
+    - *id1020
+    - *id1021
+    - *id1022
+    - *id1023
+    - *id1024
+    - *id1025
+    '10':
+    - *id1026
+    - *id1027
+    - *id1028
+    - *id1029
+    - *id1030
+    - *id1031
+    - *id1032
+    - *id1033
+    - *id010
+    '11':
+    - *id1034
+    - *id1035
+    - *id1036
+    - *id1037
+    - *id1038
+    - *id1039
+    - *id1040
+    - *id1041
+    - *id1042
+    - *id1043
+    - *id1044
+    - *id1045
+    - *id1046
+    - *id009
+    - *id1047
+    - *id008
+    - *id1048
+    - *id1049
+    - *id1050
+    - *id1051
+    - *id1052
+    '12':
+    - *id1053
+    - *id1054
+    - *id1055
+    - *id1056
+    - *id1057
+    - *id1058
+    - *id1059
+    - *id1060
+    - *id1061
+    - *id1062
+    - *id1063
+    - *id1064
+    - *id1065
+    - *id007
+    - *id1066
+  '2014':
+    '01':
+    - *id1067
+    - *id1068
+    - *id1069
+    - *id1070
+    - *id1071
+    - *id1072
+    - *id1073
+    - *id1074
+    - *id006
+    - *id1075
+    - *id1076
+    - *id1077
+    - *id1078
+    - *id1079
+    - *id1080
+    - *id1081
+    - *id1082
+    - *id1083
+    - *id1084
+    - *id1085
+    '02':
+    - *id1086
+    - *id1087
+    - *id1088
+    - *id1089
+    - *id1090
+    - *id1091
+    - *id1092
+    - *id1093
+    - *id1094
+    - *id1095
+    '03':
+    - *id1096
+    - *id1097
+    - *id1098
+    - *id1099
+    - *id1100
+    - *id1101
+    - *id1102
+    - *id1103
+    - *id1104
+    - *id1105
+    - *id1106
+    - *id1107
+    - *id1108
+    - *id1109
+    - *id1110
+    - *id1111
+    - *id1112
+    - *id1113
+    - *id1114
+    - *id1115
+    - *id1116
+    - *id1117
+    - *id1118
+    - *id1119
+    - *id1120
+    '04':
+    - *id1121
+    - *id1122
+    - *id1123
+    - *id1124
+    - *id1125
+    - *id1126
+    - *id1127
+    - *id1128
+    - *id1129
+    - *id1130
+    - *id1131
+    - *id1132
+    - *id1133
+    - *id1134
+    - *id1135
+    - *id1136
+    - *id1137
+    - *id1138
+    '05':
+    - *id1139
+    - *id1140
+    - *id1141
+    - *id1142
+    - *id1143
+    - *id1144
+    - *id1145
+    - *id1146
+    - *id1147
+    - *id1148
+    - *id1149
+    - *id1150
+    - *id1151
+    - *id1152
+    - *id1153
+    - *id1154
+    - *id1155
+    - *id1156
+    - *id1157
+    '06':
+    - *id1158
+    - *id1159
+    - *id1160
+    - *id1161
+    - *id1162
+    - *id1163
+    - *id1164
+    - *id1165
+    - *id1166
+    - *id1167
+    - *id1168
+    - *id1169
+    - *id1170
+    - *id1171
+    - *id1172
+    - *id1173
+    - *id1174
+    - *id1175
+    - *id1176
+    - *id1177
+    - *id1178
+    - *id1179
+    - *id1180
+    '07':
+    - *id1181
+    - *id1182
+    - *id1183
+    - *id1184
+    - *id1185
+    - *id1186
+    - *id1187
+    - *id1188
+    - *id1189
+    - *id1190
+    - *id1191
+    08:
+    - *id1192
+    - *id1193
+    - *id1194
+    - *id1195
+    - *id1196
+    - *id1197
+    - *id1198
+    - *id1199
+    - *id1200
+    - *id1201
+    - *id1202
+    - *id1203
+    - *id1204
+    - *id1205
+    - *id1206
+    09:
+    - *id1207
+    - *id1208
+    - *id1209
+    - *id005
+    - *id1210
+    - *id1211
+    - *id1212
+    - *id1213
+    - *id1214
+    - *id1215
+    - *id1216
+    - *id1217
+    - *id1218
+    - *id1219
+    - *id1220
+    - *id1221
+    - *id1222
+    - *id1223
+    - *id1224
+    '10':
+    - *id1225
+    - *id1226
+    - *id1227
+    - *id1228
+    - *id1229
+    - *id1230
+    - *id1231
+    - *id1232
+    - *id004
+    - *id1233
+    - *id1234
+    - *id1235
+    - *id1236
+    - *id1237
+    - *id1238
+    - *id1239
+    - *id1240
+    - *id1241
+    - *id1242
+    - *id1243
+    - *id1244
+    - *id1245
+    - *id1246
+    - *id1247
+    - *id1248
+    '11':
+    - *id1249
+    - *id1250
+    - *id1251
+    - *id1252
+    - *id1253
+    - *id1254
+    - *id1255
+    - *id1256
+    - *id1257
+    - *id1258
+    - *id1259
+    - *id1260
+    - *id1261
+    - *id1262
+    - *id1263
+    - *id1264
+    - *id1265
+    - *id1266
+    - *id1267
+    - *id1268
+    - *id1269
+    - *id1270
+    - *id1271
+    - *id1272
+    - *id1273
+    - *id1274
+    '12':
+    - *id1275
+    - *id1276
+    - *id1277
+    - *id003
+    - *id002
+    - *id001
+    - *id1278
+    - *id1279
+    - *id1280
+    - *id1281
+    - *id1282
+    - *id1283
+    - *id1284
+    - *id1285
+    - *id1286
+    - *id1287
+    - *id1288
+    - *id1289
+    - *id1290
+    - *id1291
+    - *id1292
+    - *id1293
+    - *id1294
+    - *id1295
+    - *id1296
+    - *id1297
+    - *id1298
+    - *id1299
+    - *id1300
+    - *id1301
+    - *id1302
+    - *id1303
+  '2015':
+    '01':
+    - *id1304
+    '02': []
+    '03': []
+    '04': []
+    '05': []
+    '06': []
+    '07': []
+    08: []
+    09: []
+    '10': []
+    '11': []
+    '12': []
+blog_recent:
+- *id1304
+- *id1303
+- *id1302
+- *id1301
+- *id1300
+- *id1299
+blog_subtitle: Helping scientists make better software since 1998
+blog_title: Software Carpentry
+blog_years: ['2015', '2014', '2013', '2012', '2011', '2010', '2009', '2008', '2007',
+  '2006', '2005', '2004']
+board_inquiries: board-inquiries@software-carpentry.org
+contact: admin@software-carpentry.org
+dashboard:
+  num_issues: 99
+  num_repos: 13
+  records:
+  - description: Introduction to the Unix shell
+    ident: swcarpentry/shell-novice
+    issues:
+    - {number: 37, title: copied references from glossary, updated: '2014-12-29',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/37'}
+    - {number: 36, title: 'index.md: Fill in the Prerequisites FIXME', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/36'}
+    - {number: 35, title: '06-find.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/35'}
+    - {number: 34, title: '05-script.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/34'}
+    - {number: 33, title: '04-loop.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/33'}
+    - {number: 32, title: '03-pipefilter.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/32'}
+    - {number: 31, title: '02-filedir.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/31'}
+    - {number: 30, title: '01-filedir.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/30'}
+    - {number: 29, title: Dead link to discussion.html, updated: '2014-12-18', url: 'https://github.com/swcarpentry/shell-novice/issues/29'}
+    - {number: 28, title: 'Suggested small fixes for the Unix Shell Loops lesson ',
+      updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/28'}
+    - {number: 25, title: removed empty spaces in 02-create.md, updated: '2014-12-17',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/25'}
+    - {number: 24, title: Add man page nav instructions & word boundary info, updated: '2014-12-17',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/24'}
+    - {number: 23, title: Small changes in shell course for an assignment of the instructor's
+        training, updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/23'}
+    - {number: 22, title: 'Minor edit: Spell out significance of the trash bin.',
+      updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/22'}
+    - {number: 21, title: ' Correcting images to match text description in 01-filedir.md
+        file #873 ', updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/21'}
+    - {number: 20, title: Update 02-create.md, updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/20'}
+    - {number: 18, title: Csh and its incompatibility with bash mentioned, updated: '2014-12-17',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/18'}
+    - {number: 16, title: Csh and its incompatibility with bash mentioned, updated: '2014-12-17',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/16'}
+    - {number: 12, title: Proposed changes to the shell directories lesson (assignment),
+      updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/12'}
+    - {number: 8, title: Turn the 1st shell 02-create challenge into MCQ, updated: '2014-12-17',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/8'}
+    - {number: 7, title: added div statements to 01-filedir lesson that center images
+        (refactor t..., updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/7'}
+    - {number: 5, title: Add in a diagram showing redirects and pipes, updated: '2014-12-17',
+      url: 'https://github.com/swcarpentry/shell-novice/pull/5'}
+    - {number: 26, title: Remove mentions of man pages, updated: '2014-12-16', url: 'https://github.com/swcarpentry/shell-novice/issues/26'}
+    - {number: 14, title: Remove auto-generated files from version control and find
+        sources for downloaded data., updated: '2014-11-09', url: 'https://github.com/swcarpentry/shell-novice/issues/14'}
+    url: https://github.com/swcarpentry/shell-novice
+  - description: Introduction to Git
+    ident: swcarpentry/git-novice
+    issues:
+    - {number: 6, title: reference updates, updated: '2015-01-02', url: 'https://github.com/swcarpentry/git-novice/pull/6'}
+    - {number: 4, title: minor revisions to open science lessons for clarity, updated: '2014-12-16',
+      url: 'https://github.com/swcarpentry/git-novice/pull/4'}
+    - {number: 1, title: Remove data/data.csv, updated: '2014-12-05', url: 'https://github.com/swcarpentry/git-novice/issues/1'}
+    url: https://github.com/swcarpentry/git-novice
+  - description: Introduction to Mercurial
+    ident: swcarpentry/hg-novice
+    issues:
+    - {number: 1, title: ' update reference', updated: '2014-12-29', url: 'https://github.com/swcarpentry/hg-novice/pull/1'}
+    url: https://github.com/swcarpentry/hg-novice
+  - description: Introduction to SQL
+    ident: swcarpentry/sql-novice-survey
+    issues:
+    - {number: 14, title: Shift some focus from complex query construction to schema
+        design, updated: '2015-01-03', url: 'https://github.com/swcarpentry/sql-novice-survey/issues/14'}
+    - {number: 13, title: '  instr function not available in SQLite 3.7.13 and older',
+      updated: '2015-01-03', url: 'https://github.com/swcarpentry/sql-novice-survey/issues/13'}
+    - {number: 12, title: Database reconstruction, updated: '2014-12-31', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/12'}
+    - {number: 11, title: SQLite & Python working together on OSX, updated: '2014-12-31',
+      url: 'https://github.com/swcarpentry/sql-novice-survey/issues/11'}
+    - {number: 10, title: Glossary entries, updated: '2014-12-29', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/10'}
+    - {number: 9, title: Edit text since there is no longer any red formatting in
+        table., updated: '2014-12-20', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/9'}
+    - {number: 8, title: 01-select.md talks about three entries in tables being red,
+      updated: '2014-12-20', url: 'https://github.com/swcarpentry/sql-novice-survey/issues/8'}
+    - {number: 4, title: add section on LIKE keyword, updated: '2014-12-16', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/4'}
+    - {number: 6, title: Fix glossary indentation, updated: '2014-12-14', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/6'}
+    - {number: 5, title: Remove HTML tags and others small fixes, updated: '2014-12-14',
+      url: 'https://github.com/swcarpentry/sql-novice-survey/pull/5'}
+    url: https://github.com/swcarpentry/sql-novice-survey
+  - description: Python for non-programmers
+    ident: swcarpentry/python-novice-inflammation
+    issues:
+    - {number: 1, title: Unescape the less than and greater than inequalities, updated: '2015-01-02',
+      url: 'https://github.com/swcarpentry/python-novice-inflammation/pull/1'}
+    - {number: 3, title: 'challenge titles, glossary entries, grid images', updated: '2014-12-31',
+      url: 'https://github.com/swcarpentry/python-novice-inflammation/pull/3'}
+    - {number: 2, title: 'Seaborn comment as stated on issue #907 for bc repo', updated: '2014-12-27',
+      url: 'https://github.com/swcarpentry/python-novice-inflammation/pull/2'}
+    url: https://github.com/swcarpentry/python-novice-inflammation
+  - description: R for non-programmers
+    ident: swcarpentry/r-novice-inflammation
+    issues: []
+    url: https://github.com/swcarpentry/r-novice-inflammation
+  - description: MATLAB for non-programmers
+    ident: swcarpentry/matlab-novice-inflammation
+    issues:
+    - {number: 5, title: Matlab novice material review, updated: '2014-12-28', url: 'https://github.com/swcarpentry/matlab-novice-inflammation/pull/5'}
+    - {number: 6, title: '01-intro: conform to template', updated: '2014-12-21', url: 'https://github.com/swcarpentry/matlab-novice-inflammation/pull/6'}
+    - {number: 4, title: Conform to lesson template, updated: '2014-12-21', url: 'https://github.com/swcarpentry/matlab-novice-inflammation/issues/4'}
+    - {number: 3, title: Getting the MATLAB materials up on the SWC website, updated: '2014-12-14',
+      url: 'https://github.com/swcarpentry/matlab-novice-inflammation/issues/3'}
+    url: https://github.com/swcarpentry/matlab-novice-inflammation
+  - description: Software Carpentry presentations
+    ident: swcarpentry/slideshows
+    issues:
+    - {number: 2, title: Cite statistics, updated: '2015-01-03', url: 'https://github.com/swcarpentry/slideshows/issues/2'}
+    url: https://github.com/swcarpentry/slideshows
+  - description: From Excel to a database via Python
+    ident: swcarpentry/capstone-novice-spreadsheet-biblio
+    issues: []
+    url: https://github.com/swcarpentry/capstone-novice-spreadsheet-biblio
+  - description: What instructors need to know
+    ident: swcarpentry/instructor-training
+    issues: []
+    url: https://github.com/swcarpentry/instructor-training
+  - description: Python for non-programmers using Turtles
+    ident: swcarpentry/python-novice-turtles
+    issues: []
+    url: https://github.com/swcarpentry/python-novice-turtles
+  - description: Workshop administration tool
+    ident: swcarpentry/amy
+    issues:
+    - {number: 121, title: Supporting notes about events under negotiation, updated: '2015-01-04',
+      url: 'https://github.com/swcarpentry/amy/pull/121'}
+    - {number: 2, title: Add list of provisional events to home page, updated: '2015-01-04',
+      url: 'https://github.com/swcarpentry/amy/issues/2'}
+    - {number: 120, title: 'WIP: workshops/models.py: Add Host and EventHost models',
+      updated: '2015-01-03', url: 'https://github.com/swcarpentry/amy/pull/120'}
+    - {number: 106, title: Add bulk person ingest from CSV, updated: '2015-01-03',
+      url: 'https://github.com/swcarpentry/amy/pull/106'}
+    - {number: 110, title: Add per-person award administration and per-event "Assign
+        awards" button, updated: '2015-01-02', url: 'https://github.com/swcarpentry/amy/pull/110'}
+    - {number: 101, title: 'basic search for event, site, person, work in progress',
+      updated: '2015-01-02', url: 'https://github.com/swcarpentry/amy/pull/101'}
+    - {number: 37, title: Allow award of new badges, updated: '2014-12-29', url: 'https://github.com/swcarpentry/amy/issues/37'}
+    - {number: 108, title: Developer guidelines, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/108'}
+    - {number: 70, title: 'Replace Django''s auth.User with our workshops.Person?',
+      updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/70'}
+    - {number: 61, title: 'Use person.name instead of personal, middle, and family
+        names', updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/61'}
+    - {number: 28, title: Allow addition of new skills, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/28'}
+    - {number: 22, title: Page displaying all person should have expand/contract to
+        show details, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/22'}
+    - {number: 19, title: Event details page should allow validation of Eventbrite
+        link, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/19'}
+    - {number: 12, title: Distinguish lead instructor from other instructors in all
+        displays, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/12'}
+    - {number: 89, title: Use Python's logging module for debugging, updated: '2014-12-23',
+      url: 'https://github.com/swcarpentry/amy/issues/89'}
+    - {number: 64, title: 'Additional event attendance information (slots and applicants)?',
+      updated: '2014-12-23', url: 'https://github.com/swcarpentry/amy/issues/64'}
+    - {number: 27, title: Add form for bulk addition of new persons, updated: '2014-12-23',
+      url: 'https://github.com/swcarpentry/amy/issues/27'}
+    - {number: 99, title: Headings hierarchy, updated: '2014-12-22', url: 'https://github.com/swcarpentry/amy/issues/99'}
+    - {number: 82, title: Display map of known airports, updated: '2014-12-18', url: 'https://github.com/swcarpentry/amy/issues/82'}
+    - {number: 10, title: Add CSS to make display less ugly, updated: '2014-12-16',
+      url: 'https://github.com/swcarpentry/amy/issues/10'}
+    - {number: 74, title: 'Event_sponsor table ', updated: '2014-12-15', url: 'https://github.com/swcarpentry/amy/issues/74'}
+    - {number: 62, title: Separate country table, updated: '2014-12-15', url: 'https://github.com/swcarpentry/amy/issues/62'}
+    - {number: 6, title: Rename 'site' to 'host', updated: '2014-12-15', url: 'https://github.com/swcarpentry/amy/issues/6'}
+    - {number: 63, title: 'Do we need a cohort table?', updated: '2014-12-14', url: 'https://github.com/swcarpentry/amy/issues/63'}
+    - {number: 18, title: Use calendar pop-up for picking dates for workshops, updated: '2014-12-14',
+      url: 'https://github.com/swcarpentry/amy/issues/18'}
+    - {number: 52, title: Forms should also display original data when invalid data
+        entered, updated: '2014-12-11', url: 'https://github.com/swcarpentry/amy/issues/52'}
+    - {number: 51, title: Automatic email reminders about upcoming workshops to admins,
+      updated: '2014-12-10', url: 'https://github.com/swcarpentry/amy/issues/51'}
+    - {number: 44, title: Spatial Data, updated: '2014-12-07', url: 'https://github.com/swcarpentry/amy/issues/44'}
+    - {number: 42, title: Email list co-management with hosts, updated: '2014-12-07',
+      url: 'https://github.com/swcarpentry/amy/issues/42'}
+    - {number: 41, title: Add administrative page, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/41'}
+    - {number: 36, title: Display details of a single badge, updated: '2014-12-02',
+      url: 'https://github.com/swcarpentry/amy/issues/36'}
+    - {number: 33, title: Show whether an instructor training class counts toward
+        a badge, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/33'}
+    - {number: 32, title: Training cohort display should show completion rates, updated: '2014-12-02',
+      url: 'https://github.com/swcarpentry/amy/issues/32'}
+    - {number: 31, title: 'Record training cohorts as workshops?', updated: '2014-12-02',
+      url: 'https://github.com/swcarpentry/amy/issues/31'}
+    - {number: 29, title: The database should record the instructors for every instructor
+        training workshop, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/29'}
+    - {number: 21, title: Create checklist for event, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/21'}
+    - {number: 20, title: Event details page should include links to assessment forms,
+      updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/20'}
+    - {number: 16, title: 'Allow hosts, instructors, and helpers to be selected on
+        event details page', updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/16'}
+    - {number: 5, title: Add location information to sites, updated: '2014-12-02',
+      url: 'https://github.com/swcarpentry/amy/issues/5'}
+    url: https://github.com/swcarpentry/amy
+  - description: Software Carpentry website
+    ident: swcarpentry/site
+    issues:
+    - {number: 719, title: Partial support for interactive construction of dashboard,
+      updated: '2015-01-04', url: 'https://github.com/swcarpentry/site/pull/719'}
+    - {number: 717, title: 'IOError: [Errno 2] No such file or directory: ''./git-token.txt''',
+      updated: '2015-01-04', url: 'https://github.com/swcarpentry/site/issues/717'}
+    - {number: 715, title: Future Workshops not sorted, updated: '2015-01-04', url: 'https://github.com/swcarpentry/site/issues/715'}
+    - {number: 711, title: Update FAQ to reflect latest SCF documents, updated: '2014-12-20',
+      url: 'https://github.com/swcarpentry/site/issues/711'}
+    - {number: 509, title: Invalid HTTPS certs for software-carpentry.org and files.software-carpentry.org,
+      updated: '2014-12-20', url: 'https://github.com/swcarpentry/site/issues/509'}
+    - {number: 672, title: Remove instruction to send notices about workshops to announcements
+        list, updated: '2014-11-20', url: 'https://github.com/swcarpentry/site/issues/672'}
+    - {number: 655, title: 'Suggestion: Have an ''I want this workshop in <country>''
+        button', updated: '2014-10-30', url: 'https://github.com/swcarpentry/site/issues/655'}
+    - {number: 618, title: Update post-assessment survey for workshop instructors,
+      updated: '2014-10-09', url: 'https://github.com/swcarpentry/site/issues/618'}
+    - {number: 629, title: Filter site posts by author, updated: '2014-10-08', url: 'https://github.com/swcarpentry/site/issues/629'}
+    - {number: 617, title: Update pre-assessment survey for workshop attendees, updated: '2014-10-02',
+      url: 'https://github.com/swcarpentry/site/issues/617'}
+    - {number: 620, title: Remove the "registration" field from workshops, updated: '2014-10-01',
+      url: 'https://github.com/swcarpentry/site/issues/620'}
+    - {number: 619, title: 'Add and display a flag for workshops to show kind (SWC,
+        DC, etc.)', updated: '2014-10-01', url: 'https://github.com/swcarpentry/site/issues/619'}
+    - {number: 580, title: Menu iconification in small browser windows, updated: '2014-10-01',
+      url: 'https://github.com/swcarpentry/site/issues/580'}
+    - {number: 32, title: Add a "show your support" page to the site for buying swag,
+      updated: '2013-12-26', url: 'https://github.com/swcarpentry/site/issues/32'}
+    url: https://github.com/swcarpentry/site
+exclude: [standard_config.yml, badges_config.yml, bootcamp_cache.yml, talks]
+facebook_url: https://www.facebook.com/SoftwareCarpentry
+flag_size: 16
+github_io_url: http://swcarpentry.github.io
+github_url: https://github.com/swcarpentry
+google_plus_url: https://plus.google.com/+Software-carpentryOrg
+mailing_lists: http://lists.software-carpentry.org
+month_names: {'01': Jan, '02': Feb, '03': Mar, '04': Apr, '05': May, '06': Jun, '07': Jul,
+  08: Aug, 09: Sep, '10': Oct, '11': Nov, '12': Dec}
+months: ['01', '02', '03', '04', '05', '06', '07', 08, 09, '10', '11', '12']
+msl_url: http://mozillascience.org
+paypal_url: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MYSDWRR8HWFR6
+people: [people/adelman.joshua.html, people/ahmadia.a.html, people/aiello-lammens.matthew.html,
+  people/ainsley.joshua.html, people/alleen-willems.russell.html, people/allen.james.html,
+  people/alonzi.pete.html, people/anderson.c.html, people/anghel.catalina.html, people/antonioletti.mario.html,
+  people/aranda.j.html, people/aruliah.d.html, people/avestruz.camille.html, people/bahlai.christie.html,
+  people/barmby.pauline.html, people/barneche.diego.html, people/bauer.dana.html,
+  people/bayer.p.html, people/beagrie.r.html, people/bekolay.trevor.html, people/bennett.n.html,
+  people/blakk.lukas.html, people/blischak.j.html, people/boettiger.carl.html, people/bonnie.jessica.html,
+  people/bostroem.a.html, people/bray.e.html, people/brown.amy.html, people/brown.ct.html,
+  people/bryan.j.html, people/cabunoc.abigail.html, people/camins-esakov.jared.html,
+  people/canino-koning.r.html, people/cannam.c.html, people/cerino.t.html, people/chamberlain.s.html,
+  people/chan.cliburn.html, people/chen.daniel.html, people/chisholm.chelsea.html,
+  people/cholia.s.html, people/chuang-howe.a.html, people/chue-hong.n.html, people/coelho.luis.html,
+  people/collings.ruth.html, people/collins.arliss.html, people/corless.john.html,
+  people/corvellec.marianne.html, people/cox.logan.html, people/cozzini.s.html, people/cranston.k.html,
+  people/crouch.s.html, people/davenport.e.html, people/davey.rob.html, people/davis.m.html,
+  people/davis.neal.html, people/devenyi.gabriel.html, people/dickson.r.html, people/duckles.jonah.html,
+  people/ely.j.html, people/emonet.remi.html, people/erlich.aaron.html, people/falster.daniel.html,
+  people/fei.xu.html, people/figueira.l.html, people/fitzjohn.rich.html, people/fowler.p.html,
+  people/friedline.chris.html, people/fu.zhuo.html, people/garcia-gutierrez.leonor.html,
+  people/garcia.julian.html, people/garoutte.aaron.html, people/gates.chris.html,
+  people/gatto.laurent.html, people/gibson.molly.html, people/goble.c.html, people/gonzalez.ivan.html,
+  people/gross.jonathan.html, people/guignard.thomas.html, people/gustavsen.j.html,
+  people/guy.t.html, people/haddock.s.html, people/haine.denis.html, people/hamrick.jessica.html,
+  people/hansen.m.html, people/harrison.anthony.html, people/hart.t.html, people/henry.ian.html,
+  people/herr.joshua.html, people/hertweck.kate.html, people/hetherington.james.html,
+  people/hiebert.james.html, people/hinsen.k.html, people/hocking.daniel.html, people/holdgraf.c.html,
+  people/hollister.jeff.html, people/huang.daisie.html, people/huff.k.html, people/irving.d.html,
+  people/ivanov.p.html, people/jackson.m.html, people/jacobs.christian.html, people/jones.dm.html,
+  people/kerr.j.html, people/king.wt.html, people/kiral-kornek.isabell.html, people/kitzes.j.html,
+  people/koch.christina.html, people/koenig.steven.html, people/koeppel.alexander.html,
+  people/konrad.b.html, people/lafleur.olivier.html, people/laforest-lapointe.isabelle.html,
+  people/lagesen.k.html, people/lasher.c.html, people/latornell.d.html, people/lee.luke.html,
+  people/levernier.jacob.html, people/leyder.jean-christophe.html, people/lightman.matthew.html,
+  people/lin.johnny.html, people/lowe.elijah.html, people/luo.yuxi.html, people/macdonell.cam.html,
+  people/macindoe.gary.html, people/maclean.dan.html, people/madison.cindee.html,
+  people/mcgough.s.html, people/mckay.sheldon.html, people/mckellar.j.html, people/mctavish.ej.html,
+  people/michael.lauren.html, people/michnowicz.s.html, people/michonneau.francois.html,
+  people/miles.brian.html, people/mills.b.html, people/mitchell.i.html, people/morris.b.html,
+  people/mudrak.erika.html, people/munoz.ian.html, people/nederbragt.l.html, people/nenadic.aleksandra.html,
+  people/ocais.alan.html, people/olson.r.html, people/ory.j.html, people/pawlik.a.html,
+  people/pearson.john.html, people/pell.j.html, people/perez-suarez.david.html, people/perez.f.html,
+  people/peru.giacomo.html, people/petre.m.html, people/pfenninger.s.html, people/pipitone.j.html,
+  people/plumbley.m.html, people/pollard.tom.html, people/preeyanon.likit.html, people/provencher.francoise.html,
+  people/ram.k.html, people/ramalingam.saravanan.html, people/rio.david.html, people/ritchie.scott.html,
+  people/robinson.james.html, people/rokem.a.html, people/rowell.bill.html, people/schossau.j.html,
+  people/scopatz.a.html, people/selik.m.html, people/serra.neem.html, people/shelton.j.html,
+  people/shih.yu-ching.html, people/silva.raniere.html, people/slaybaugh.rachel.html,
+  people/sloggett.clare.html, people/smith.daniel.html, people/smith.j.html, people/smorul.mike.html,
+  people/srinath.ashwin.html, people/staton.margaret.html, people/steinbach.peter.html,
+  people/supp.s.html, people/svaksha.html, people/swaminathan.gayathri.html, people/taber-thomas.bradley.html,
+  people/tarkowski.leszek.html, people/teal.t.html, people/teucher.andrew.html, people/thaney.kaitlin.html,
+  people/trimble.will.html, people/turner.s.html, people/vahtras.olav.html, people/vaidyanathan.ramnath.html,
+  people/varga.vicky.html, people/varoquaux.n.html, people/vera.b.html, people/viana.a.html,
+  people/vonderlinden.jens.html, people/walker.andrew.html, people/warren.dan.html,
+  people/wasser.leah.html, people/waugh.b.html, people/white.e.html, people/white.easton.html,
+  people/wilber.mark.html, people/williams.jason.html, people/williams.l.html, people/williams.ryan.html,
+  people/wilson.g.html, people/wilson.p.html, people/woo.kara.html, people/woods.c.html,
+  people/yang.fan.html, people/zhang.qp.html, people/zimmerman.naupaka.html, people/zito.t.html,
+  people/zonca.andrea.html]
+projects: [projects/active-papers.html, projects/archer.html, projects/astropy.html,
+  projects/cyclus.html, projects/ecodata-retriever.html, projects/genomics-virtual-lab.html,
+  projects/iplant.html, projects/jors.html, projects/macroeco.html, projects/magetbrain.html,
+  projects/mahotas.html, projects/math-education-resources.html, projects/msl.html,
+  projects/nipy.html, projects/open-tree-of-life.html, projects/practical-computing-for-biologists.html,
+  projects/pyne.html, projects/ropensci.html, projects/sharelatex.html, projects/stat-545.html,
+  projects/tec.html]
+recent_length: 6
+rss_url: http://software-carpentry.org/feed.xml
+site: /Users/gvwilson/s/site/_site
+site_url: http://software-carpentry.org
+store_url: http://www.cafepress.com/swcarpentry
+timestamp: '2015-01-04T20:12:30Z'
+today: 2015-01-04
+training_url: http://teaching.software-carpentry.org
+twitter_name: '@swcarpentry'
+twitter_url: https://twitter.com/swcarpentry
+upcoming_length: 10
+workshops:
+- address: 3rd floor Training Room, 7 Sir Winston Churchill Square
+  contact: vvarga@epl.ca
+  country: Canada
+  enddate: 2014-12-16
+  helper: [Cody Moorhouse, Katie Thompson]
+  humandate: Dec 15 & 16 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Cam MacDonell, Vicky Varga]
+  latlng: 53.5430628,-113.4897479
+  layout: workshop
+  lessons: [Python, SQL, Bash]
+  registration: restricted
+  root: .
+  slug: 12-14-epl
+  startdate: 2014-12-15
+  url: http://vixvarga.github.io/12-14-epl/
+  user: vixvarga
+  venue: Edmonton Public Library
+- country: Canada
+  enddate: 2011-11-08
+  humandate: Nov 7-8, 2011
+  instructor: [Jonathan Dursi, Tommy Guy, Katy Huff, Dominique Vuvan]
+  latlng: 43.661476,-79.395189
+  layout: bootcamp
+  registration: open
+  slug: 2011-11-07-toronto
+  startdate: 2011-11-07
+  url: http://swcarpentry.github.io/2011-11-07-toronto/
+  user: swcarpentry
+  venue: University of Toronto
+- country: United-States
+  enddate: 2012-01-19
+  humandate: Jan 18-19, 2012
+  instructor: [Greg Wilson]
+  latlng: 39.332604,-76.62319
+  layout: bootcamp
+  registration: open
+  slug: 2012-01-18-stsci
+  startdate: 2012-01-18
+  url: http://swcarpentry.github.io/2012-01-18-stsci/
+  user: swcarpentry
+  venue: Space Telescope Science Institute
+- country: Italy
+  enddate: 2012-03-02
+  humandate: Feb 20 - March 2, 2012
+  instructor: [Stephen Crouch, Tommy Guy, Katy Huff]
+  latlng: 45.703255,13.718013
+  layout: bootcamp
+  registration: open
+  slug: 2012-02-20-itcp
+  startdate: 2012-02-20
+  url: http://swcarpentry.github.io/2012-02-20-itcp/
+  user: swcarpentry
+  venue: International Centre for Theoretical Physics
+- address: Bahen Centre for Information Technology, 40 St. George Street, Toronto,
+    ON
+  country: Canada
+  enddate: 2012-02-24
+  humandate: February 23-24, 2012
+  instructor: [Matt Davis, Jonathan Dursi, Mike Fletcher, Greg Wilson]
+  latlng: 43.661476,-79.395189
+  layout: bootcamp
+  registration: open
+  slug: 2012-02-23-toronto
+  startdate: 2012-02-23
+  url: http://swcarpentry.github.io/2012-02-23-toronto/
+  user: swcarpentry
+  venue: University of Toronto
+- country: United-States
+  enddate: 2012-03-08
+  humandate: March 7-8, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Greg Wilson]
+  latlng: 39.1663815,-86.526621
+  layout: bootcamp
+  registration: open
+  slug: 2012-03-07-indiana
+  startdate: 2012-03-07
+  url: http://swcarpentry.github.io/2012-03-07-indiana/
+  user: swcarpentry
+  venue: Indiana University
+- country: United-States
+  enddate: 2012-03-27
+  humandate: March 26-27, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Steve Haddock, Greg Wilson]
+  latlng: 36.802151,-121.788163
+  layout: bootcamp
+  registration: open
+  slug: 2012-03-26-mbari
+  startdate: 2012-03-26
+  url: http://swcarpentry.github.io/2012-03-26-mbari/
+  user: swcarpentry
+  venue: Monterey Bay Aquarium Research Institute
+- address: Conference Room 238, Oakland Scientific Facility (OSF), 415 20th Street
+    ("Thomas L Berkley Way") at Franklin Street, Oakland, CA
+  country: United-States
+  enddate: 2012-03-29
+  humandate: March 28-29, 2012
+  instructor: [Michelle Levesque, Greg Wilson]
+  latlng: 37.8083814,-122.2675787
+  layout: bootcamp
+  registration: open
+  slug: 2012-03-28-nersc
+  startdate: 2012-03-28
+  url: http://swcarpentry.github.io/2012-03-28-nersc/
+  user: swcarpentry
+  venue: NERSC
+- country: United-States
+  enddate: 2012-04-03
+  humandate: April 2-3, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Milad Fatenejad, Katy Huff, Anthony Scopatz, Joshua Smith]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: open
+  slug: 2012-04-02-chicago
+  startdate: 2012-04-02
+  url: http://swcarpentry.github.io/2012-04-02-chicago/
+  user: swcarpentry
+  venue: University of Chicago
+- address: Room 314, Biology and Natural Resources Building, Utah State University,
+    5305 Old Main Hill, Logan, UT
+  country: United-States
+  enddate: 2012-04-15
+  humandate: April 14-15, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Curtis Dyreson, Jason Pell, Greg Wilson]
+  latlng: 41.7449488,-111.8042944
+  layout: bootcamp
+  registration: open
+  slug: 2012-04-14-utahstate
+  startdate: 2012-04-14
+  url: http://swcarpentry.github.io/2012-04-14-utahstate/
+  user: swcarpentry
+  venue: Utah State University
+- country: United-Kingdom
+  enddate: 2012-05-01
+  humandate: April 30 - May 1, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Cannam, Greg Wilson]
+  latlng: 51.5598815,-0.1334579
+  layout: bootcamp
+  registration: open
+  slug: 2012-04-30-ucl
+  startdate: 2012-04-30
+  url: http://swcarpentry.github.io/2012-04-30-ucl/
+  user: swcarpentry
+  venue: University College London
+- country: United-States
+  enddate: 2012-05-08
+  humandate: May 7-8, 2012
+  instructor: [C. Titus Brown, Greg Wilson]
+  latlng: 42.7272884,-84.482106
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-07-michiganstate
+  startdate: 2012-05-07
+  url: http://swcarpentry.github.io/2012-05-07-michiganstate/
+  user: swcarpentry
+  venue: Michigan State University
+- contact: swc2012@ncl.ac.uk
+  country: United-Kingdom
+  enddate: 2012-05-15
+  humandate: May 14-15, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Chris Cannam, Neil Chue Hong, Stephen Crouch, Mike Jackson, Steve McGough]
+  latlng: 54.980095,-1.6146142
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-14-newcastle
+  startdate: 2012-05-14
+  url: http://swcarpentry.github.io/2012-05-14-newcastle/
+  user: swcarpentry
+  venue: Newcastle University
+- address: Computing Sciences Centre (CSC) 1-59, University of Alberta, Edmonton,
+    AB
+  country: Canada
+  enddate: 2012-05-17
+  humandate: May 16-17, 2012
+  instructor: [Rosangela Canino-Koning, Greg Wilson]
+  latlng: 53.5234543,-113.5259951
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-16-alberta
+  startdate: 2012-05-16
+  url: http://swcarpentry.github.io/2012-05-16-alberta/
+  user: swcarpentry
+  venue: University of Alberta
+- address: Room DMP 201, 6245 Agronomy Road
+  country: Canada
+  enddate: 2012-05-23
+  humandate: May 22-23, 2012
+  instructor: [Adina Chuang Howe, Greg Wilson]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-22-ubc
+  startdate: 2012-05-22
+  url: http://swcarpentry.github.io/2012-05-22-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Room 475, Bloomberg Center for Physics &amp; Astronomy
+  country: United-States
+  enddate: 2012-06-19
+  humandate: June 18-19, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Joshua Smith, Sasha Wood]
+  latlng: 39.3275798,-76.6207579
+  layout: bootcamp
+  registration: open
+  slug: 2012-06-18-jhu
+  startdate: 2012-06-18
+  url: http://swcarpentry.github.io/2012-06-18-jhu/
+  user: swcarpentry
+  venue: Johns Hopkins University
+- address: Place d'Italie
+  country: France
+  enddate: 2012-06-29
+  humandate: June 28-29, 2012
+  instructor: [Feth Arezki, Christophe Combelles, Alexandre Gramfort, Konrad Hinsen,
+    Nelle Varoquaux]
+  latlng: 48.831673,2.355623
+  layout: bootcamp
+  registration: open
+  slug: 2012-06-28-inria
+  startdate: 2012-06-28
+  url: http://swcarpentry.github.io/2012-06-28-inria/
+  user: swcarpentry
+  venue: INRIA Paris
+- address: Room 32-141, CSAIL, MIT, 32 Vassar Street, Cambridge, MA
+  country: United-States
+  enddate: 2012-07-10
+  humandate: July 9-10, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jessica McKellar, Greg Wilson]
+  latlng: 42.3591326,-71.093201
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-09-mit
+  startdate: 2012-07-09
+  url: http://swcarpentry.github.io/2012-07-09-mit/
+  user: swcarpentry
+  venue: MIT
+- address: Davis Centre DC 1568, University of Waterloo, 200 University Avenue West,
+    Waterloo, ON
+  country: Canada
+  enddate: 2012-07-13
+  eventbrite: 3558725243
+  humandate: July 12-13, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Greg Wilson]
+  latlng: 43.4701302,-80.5357712
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-12-waterloo
+  startdate: 2012-07-12
+  url: http://swcarpentry.github.io/2012-07-12-waterloo/
+  user: swcarpentry
+  venue: University of Waterloo
+- address: Rm 255, Sobey Building, Saint Mary's University, Halifax, Nova Scotia
+  country: Canada
+  enddate: 2012-07-17
+  humandate: July 16-17, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Ely, Greg Wilson]
+  latlng: 44.6322608,-63.5802627
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-16-halifax
+  startdate: 2012-07-16
+  url: http://swcarpentry.github.io/2012-07-16-halifax/
+  user: swcarpentry
+  venue: Halifax
+- country: Canada
+  enddate: 2012-07-20
+  humandate: July 19-20, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Jonathan Dursi, Greg Wilson]
+  latlng: 43.7835514,-79.1863972
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-19-utsc
+  startdate: 2012-07-19
+  url: http://swcarpentry.github.io/2012-07-19-utsc/
+  user: swcarpentry
+  venue: University of Toronto (Scarborough)
+- address: University of York
+  country: United-Kingdom
+  enddate: 2012-09-14
+  humandate: Sept 13-14, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Cannam, Adam Stark, Becky Stewart, Greg Wilson]
+  latlng: 53.9481933,-1.0529144
+  layout: bootcamp
+  registration: open
+  slug: 2012-09-13-dafx
+  startdate: 2012-09-13
+  url: http://swcarpentry.github.io/2012-09-13-dafx/
+  user: swcarpentry
+  venue: DAFx Conference
+- address: Room 3213, Kristine Bonnevies hus, Blindernveien 31, University of Oslo
+  country: Norway
+  enddate: 2012-09-18
+  humandate: Sept 17-18, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Hans Petter Langtangen, Greg Wilson]
+  latlng: 59.9399586,10.7217496
+  layout: bootcamp
+  registration: open
+  slug: 2012-09-17-oslo
+  startdate: 2012-09-17
+  url: http://swcarpentry.github.io/2012-09-17-oslo/
+  user: swcarpentry
+  venue: University of Oslo
+- country: United-States
+  enddate: 2012-09-29
+  humandate: Sept 28-29, 2012
+  instructor: [Erik Bray, Chang She, Eric Weinstein, Greg Wilson]
+  latlng: 40.8080777,-73.9635678
+  layout: bootcamp
+  registration: open
+  slug: 2012-09-28-columbia
+  startdate: 2012-09-28
+  url: http://swcarpentry.github.io/2012-09-28-columbia/
+  user: swcarpentry
+  venue: Columbia University
+- address: Stewart Center, Room 318
+  country: United-States
+  enddate: 2012-10-09
+  humandate: Oct 8-9, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Hansen, Anthony Scopatz]
+  latlng: 40.4282668,-86.9143245
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-08-purdue
+  startdate: 2012-10-08
+  url: http://swcarpentry.github.io/2012-10-08-purdue/
+  user: swcarpentry
+  venue: Purdue University
+- address: Building 50A, Room 5132
+  country: United-States
+  enddate: 2012-10-18
+  humandate: Oct 17-18, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Katy Huff, Justin Kitzes]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-17-lbl
+  startdate: 2012-10-17
+  url: http://swcarpentry.github.io/2012-10-17-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley National Laboratory
+- country: Canada
+  enddate: 2012-10-19
+  eventbrite: 3869257052
+  humandate: Oct 18-19, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Davor Cubranic, Ted Hart, Laura Tremblay-Boyer, Greg Wilson]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-18-ubc
+  startdate: 2012-10-18
+  url: http://swcarpentry.github.io/2012-10-18-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Goldman School of Public Policy, Room 150
+  country: United-States
+  enddate: 2012-10-21
+  eventbrite: 3942004642
+  humandate: Oct 20-21, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Katy Huff, Justin Kitzes]
+  latlng: 37.8695,-122.258949
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-20-ucb
+  startdate: 2012-10-20
+  url: http://swcarpentry.github.io/2012-10-20-ucb/
+  user: swcarpentry
+  venue: University of California Berkeley
+- country: United-Kingdom
+  enddate: 2012-10-23
+  humandate: Oct 22-23, 2012
+  instructor: [Mike Jackson, Steve McGough]
+  latlng: 54.980095,-1.6146142
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-22-newcastle
+  startdate: 2012-10-22
+  url: http://swcarpentry.github.io/2012-10-22-newcastle/
+  user: swcarpentry
+  venue: University of Newcastle
+- address: 383 Hill Annex, Caltech Campus, Pasadena, CA 91125
+  country: United-States
+  enddate: 2012-10-24
+  humandate: Oct 23-24, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis]
+  latlng: 34.141411,-118.1249
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-23-caltech
+  startdate: 2012-10-23
+  url: http://swcarpentry.github.io/2012-10-23-caltech/
+  user: swcarpentry
+  venue: Caltech
+- country: United-States
+  enddate: 2012-10-26
+  eventbrite: 4647209930
+  humandate: Oct 25-26, 2012
+  instructor: [Azalee Bostroem, Erik Bray]
+  latlng: 38.831513,-77.308746
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-25-gmu
+  startdate: 2012-10-25
+  url: http://swcarpentry.github.io/2012-10-25-gmu/
+  user: swcarpentry
+  venue: George Mason University
+- address: New Biochemistry
+  contact: philip.fowler@bioch.ox.ac.uk
+  country: United-Kingdom
+  enddate: 2012-10-31
+  humandate: Oct 30-31, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Stephen Crouch, Mike Jackson]
+  latlng: 51.7571373,-1.2569052
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-30-oxford
+  startdate: 2012-10-30
+  url: http://swcarpentry.github.io/2012-10-30-oxford/
+  user: swcarpentry
+  venue: Oxford University
+- address: Information Technology Building, Room A113
+  country: Canada
+  enddate: 2012-11-09
+  eventbrite: 4522284274
+  humandate: Nov 8-9, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Lynne Williams, Greg Wilson]
+  latlng: 43.2613285,-79.9202476
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-08-mcmaster
+  startdate: 2012-11-08
+  url: http://swcarpentry.github.io/2012-11-08-mcmaster/
+  user: swcarpentry
+  venue: McMaster University
+- address: Life Sciences Building
+  country: United-States
+  enddate: 2012-11-11
+  eventbrite: 4262808174
+  humandate: Nov 10-11, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Ely, Jessica Kerr, Sarah Supp]
+  latlng: 38.6480562,-90.3050959
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-10-wustl
+  startdate: 2012-11-10
+  url: http://swcarpentry.github.io/2012-11-10-wustl/
+  user: swcarpentry
+  venue: Washington University in St. Louis
+- address: La Jolla, CA
+  country: United-States
+  enddate: 2012-11-16
+  eventbrite: 3869222950
+  humandate: Nov 15-16, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [C. Titus Brown, Justin Kitzes, Caitlyn Pickens, Tracy Teal]
+  latlng: 32.8953297,-117.2421882
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-15-scripps
+  startdate: 2012-11-15
+  url: http://swcarpentry.github.io/2012-11-15-scripps/
+  user: swcarpentry
+  venue: Scripps Research Institute
+- country: United-States
+  enddate: 2012-11-29
+  eventbrite: 4224585850
+  humandate: Nov 28-29, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ethan White, Greg Wilson]
+  latlng: 34.2274248,-77.8791793
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-28-unc
+  startdate: 2012-11-28
+  url: http://swcarpentry.github.io/2012-11-28-unc/
+  user: swcarpentry
+  venue: University of North Carolina
+- address: Hawaii Institute of Marine Biology
+  country: United-States
+  enddate: 2012-12-01
+  eventbrite: 4314420548
+  humandate: Nov 30 - Dec 1, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Erik Bray, Fernando Perez]
+  latlng: 21.3006615,-157.8191655
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-30-hawaii
+  startdate: 2012-11-30
+  url: http://swcarpentry.github.io/2012-11-30-hawaii/
+  user: swcarpentry
+  venue: University of Hawaii
+- contact: michaelj@epcc.ed.ac.uk
+  country: United-Kingdom
+  enddate: 2012-12-05
+  humandate: Dec 4-5, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Mike Jackson]
+  latlng: 55.9453279,-3.1911838
+  layout: bootcamp
+  registration: open
+  slug: 2012-12-04-edinburgh
+  startdate: 2012-12-04
+  url: http://swcarpentry.github.io/2012-12-04-edinburgh/
+  user: swcarpentry
+  venue: University of Edinburgh
+- country: United-States
+  enddate: 2012-12-11
+  eventbrite: 3666777430
+  humandate: Dec 10-11, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Rosangela Canino-Koning, Emily Jane McTavish, Jason Pell, Andy Terrel]
+  latlng: 30.2835989,-97.7344283
+  layout: bootcamp
+  registration: open
+  slug: 2012-12-10-uta
+  startdate: 2012-12-10
+  url: http://swcarpentry.github.io/2012-12-10-uta/
+  user: swcarpentry
+  venue: University of Texas (Austin)
+- address: MSL 101
+  country: Canada
+  enddate: 2013-01-12
+  humandate: Jan 11 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jennifer Bryan, Davor Cubranic, Ted Hart, Bernhard Konrad, Rick White]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-11-ubc
+  startdate: 2013-01-11
+  url: http://swcarpentry.github.io/2013-01-11-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Kent Hall, Room 120, 1020 East 58th Street Chicago, IL 60637
+  country: United-States
+  enddate: 2013-01-13
+  eventbrite: 4044017766
+  humandate: Jan 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Katy Huff, Anthony Scopatz]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-12-chicago
+  startdate: 2013-01-12
+  url: http://swcarpentry.github.io/2013-01-12-chicago/
+  user: swcarpentry
+  venue: University of Chicago
+- country: Canada
+  enddate: 2013-01-13
+  eventbrite: 4859419655
+  humandate: Jan 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ross Dickson, Jessica McKellar]
+  latlng: 45.4174172,-73.9489284
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-12-mcgill
+  startdate: 2013-01-12
+  url: http://swcarpentry.github.io/2013-01-12-mcgill/
+  user: swcarpentry
+  venue: McGill University
+- address: Engineering 6 Building, Room 4022
+  country: Canada
+  enddate: 2013-01-13
+  eventbrite: 4455642948
+  humandate: Jan 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Nasser Mohieddin Abukhdeir, Greg Wilson]
+  latlng: 43.4691285,-80.5398649
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-12-waterloo
+  startdate: 2013-01-12
+  url: http://swcarpentry.github.io/2013-01-12-waterloo/
+  user: swcarpentry
+  venue: University of Waterloo
+- address: 1 Maximus-von-Imhof-Forum, 85354 Freising, Germany
+  country: Germany
+  enddate: 2013-01-23
+  eventbrite: 4602466100
+  humandate: Jan 22-23, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stephen Crouch, Konrad Hinsen]
+  latlng: 48.264934,11.669121
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-22-tum
+  startdate: 2013-01-22
+  url: http://swcarpentry.github.io/2013-01-22-tum/
+  user: swcarpentry
+  venue: Technische Universitat Munchen
+- address: Suite 500, 366 Adelaide St West, Toronto, ON
+  country: Canada
+  enddate: 2013-01-25
+  eventbrite: 5086301264
+  humandate: Jan 24-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson]
+  latlng: 43.6471184,-79.3942998
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-24-camh
+  startdate: 2013-01-24
+  url: http://swcarpentry.github.io/2013-01-24-camh/
+  user: swcarpentry
+  venue: Mozilla Foundation
+- address: 41 Spemannstrasse, 72076 Tuebingen, Germany
+  country: Germany
+  enddate: 2013-01-26
+  eventbrite: 5014203618
+  humandate: Jan 25-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stephen Crouch, Luis Figueira]
+  latlng: 48.5369804,9.058935
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-25-tuebingen
+  startdate: 2013-01-25
+  url: http://swcarpentry.github.io/2013-01-25-tuebingen/
+  user: swcarpentry
+  venue: Max Planck Institute Tuebingen
+- country: United-States
+  enddate: 2013-02-02
+  humandate: Jan 30 - Feb 2, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Adina Chuang Howe, Justin Ely, Daniel Krasner, Jared Lander, Ian Langmore,
+    Chang She, Alex Viana, David Warde-Farley]
+  latlng: 40.8080777,-73.9635678
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-01-30-columbia
+  startdate: 2013-01-30
+  url: http://swcarpentry.github.io/2013-01-30-columbia/
+  user: swcarpentry
+  venue: Columbia University
+- country: United-States
+  enddate: 2013-02-01
+  humandate: Jan 31 - Feb 1, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tommy Guy, Chris Lasher]
+  latlng: 37.2283843,-80.4234167
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-31-vt
+  startdate: 2013-01-31
+  url: http://swcarpentry.github.io/2013-01-31-vt/
+  user: swcarpentry
+  venue: Virginia Tech
+- country: Canada
+  enddate: 2013-02-06
+  eventbrite: 5227315040
+  humandate: Feb 5-6, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ted Hart, Ethan White]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-05-ubc
+  startdate: 2013-02-05
+  url: http://swcarpentry.github.io/2013-02-05-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Room E8A 341, Macquarie University, Sydney
+  country: Australia
+  enddate: 2013-02-08
+  eventbrite: 4114901782
+  humandate: Feb 7-8, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Eli Bressert, Greg Wilson]
+  latlng: -33.773636,151.112005
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-07-macquarie
+  startdate: 2013-02-07
+  url: http://swcarpentry.github.io/2013-02-07-macquarie/
+  user: swcarpentry
+  venue: Macquarie University
+- address: Theatre 2 (room 109), Alan Gilbert Building, University of Melbourne
+  country: Australia
+  enddate: 2013-02-15
+  humandate: Feb 14-15, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson]
+  latlng: -37.8253285,144.9516212
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-14-amos
+  startdate: 2013-02-14
+  url: http://swcarpentry.github.io/2013-02-14-amos/
+  user: swcarpentry
+  venue: AMOS Conference (Melbourne)
+- country: United-States
+  enddate: 2013-02-26
+  eventbrite: 4309568034
+  humandate: Feb 25-26, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [C. Titus Brown, Matt Davis, Julia Gustavsen, Bernhard Konrad, Doug
+      Latornell, Greg Wilson]
+  latlng: 47.655965,-122.309377
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-25-uwash
+  startdate: 2013-02-25
+  url: http://swcarpentry.github.io/2013-02-25-uwash/
+  user: swcarpentry
+  venue: University of Washington
+- country: United-States
+  enddate: 2013-03-07
+  humandate: March 4-5 and March 6-7, 2013
+  instructor: [Geoff Oxberry, Greg Wilson]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-03-04-lbl
+  startdate: 2013-03-04
+  url: http://swcarpentry.github.io/2013-03-04-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley National Laboratory
+- country: United-States
+  enddate: 2013-03-08
+  humandate: March 7-8, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Carlos Anderson, Stephen Crouch, Ben Morris]
+  latlng: 38.031441,-78.499356
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-03-07-virginia
+  startdate: 2013-03-07
+  url: http://swcarpentry.github.io/2013-03-07-virginia/
+  user: swcarpentry
+  venue: University of Virginia
+- country: Lebanon
+  enddate: 2013-03-21
+  humandate: March 20-21, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia]
+  latlng: 33.900058,35.482727
+  layout: bootcamp
+  registration: open
+  slug: 2013-03-20-aub
+  startdate: 2013-03-20
+  url: http://swcarpentry.github.io/2013-03-20-aub/
+  user: swcarpentry
+  venue: American University of Beirut
+- address: Room 314, Biology and Natural Resources Building, Utah State University,
+    5305 Old Main Hill, Logan, UT
+  country: United-States
+  enddate: 2013-03-24
+  eventbrite: 5398228246
+  humandate: March 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dan McGlinn, Ethan White]
+  latlng: 41.7449488,-111.8042944
+  layout: bootcamp
+  registration: open
+  slug: 2013-03-23-utahstate
+  startdate: 2013-03-23
+  url: http://swcarpentry.github.io/2013-03-23-utahstate/
+  user: swcarpentry
+  venue: Utah State University
+- address: Library Computer Laboratory
+  country: Saudi-Arabia
+  enddate: 2013-03-25
+  eventbrite: 5790053205
+  humandate: March 24-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, David Ketcheson, Enas Yunis]
+  latlng: 22.3101,39.1259
+  layout: bootcamp
+  registration: full
+  slug: 2013-03-24-kaust
+  startdate: 2013-03-24
+  url: http://swcarpentry.github.io/2013-03-24-kaust/
+  user: swcarpentry
+  venue: King Abdullah University of Science and Technology
+- country: United-States
+  enddate: 2013-04-05
+  eventbrite: 5396735782
+  humandate: April 4-5, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [C. Titus Brown, Karen Cranston, Rich Enbody, David Koop]
+  latlng: 32.2363584,-110.9495396
+  layout: bootcamp
+  registration: full
+  slug: 2013-04-04-arizona
+  startdate: 2013-04-04
+  url: http://swcarpentry.github.io/2013-04-04-arizona/
+  user: swcarpentry
+  venue: University of Arizona
+- contact: host-ucl@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-04-08
+  eventbrite: 5396735782
+  humandate: April 4 and 8, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ben Waugh, James Hetherington, Miguel Bernabeu, Andrew Smith]
+  latlng: 51.524789,-0.133578
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-04-04-ucl
+  startdate: 2013-04-04
+  url: http://swcarpentry.github.io/2013-04-04-ucl/
+  user: swcarpentry
+  venue: University College London
+- address: Room A306, Engineering Building
+  country: South-Africa
+  enddate: 2013-04-09
+  eventbrite: 6014414275
+  humandate: April 8-9, 2013
+  humantime: 1:00 pm - 6:00 pm on day one, noon - 4:00 pm on day two
+  instructor: [Aron Ahmadia]
+  latlng: -33.929492,18.865391
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-08-stellenbosch
+  startdate: 2013-04-08
+  url: http://swcarpentry.github.io/2013-04-08-stellenbosch/
+  user: swcarpentry
+  venue: Stellenbosch University
+- contact: michaelj@epcc.ed.ac.uk
+  country: United-Kingdom
+  enddate: 2013-04-12
+  humandate: April 11, 2013
+  humantime: 10:00 - 17:30
+  instructor: [Mike Jackson]
+  latlng: 53.467102,-2.233958
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-11-egi
+  startdate: 2013-04-11
+  url: http://swcarpentry.github.io/2013-04-11-egi/
+  user: swcarpentry
+  venue: EGI Forum, Manchester
+- country: United-States
+  enddate: 2013-04-14
+  humandate: April 13-14, 2013
+  instructor: [Justin Kitzes, Karthik Ram]
+  latlng: 37.8695,-122.258949
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-04-13-ucb
+  startdate: 2013-04-13
+  url: http://swcarpentry.github.io/2013-04-13-ucb/
+  user: swcarpentry
+  venue: University of California Berkeley
+- contact: host-manchester@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-04-19
+  eventbrite: 5397207192
+  humandate: April 18-19, 2013
+  instructor: [Mike Jackson, David Jones, Aleksandra Pawlik]
+  latlng: 53.4783491,-2.2416052
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-18-manchester
+  startdate: 2013-04-18
+  url: http://swcarpentry.github.io/2013-04-18-manchester/
+  user: swcarpentry
+  venue: University of Manchester
+- address: 46 Rue Barrault, 75013 Paris
+  country: France
+  enddate: 2013-04-21
+  eventbrite: 5232959924
+  humandate: April 20-21, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sergi Blanco-Cuaresma, Christophe Cossou, Alexandre Gramfort, Konrad
+      Hinsen, Nicolas Limare, Gael Varoquaux, Nelle Varoquaux]
+  latlng: 48.82629,2.34642
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-20-paris
+  startdate: 2013-04-20
+  url: http://swcarpentry.github.io/2013-04-20-paris/
+  user: swcarpentry
+  venue: Telecom ParisTech
+- address: N111, Pharmacy Hall
+  country: United-States
+  enddate: 2013-04-28
+  eventbrite: 5919069095
+  humandate: April 27-28, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Alex Viana]
+  latlng: 39.291389,-76.625
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-27-umaryland
+  startdate: 2013-04-27
+  url: http://swcarpentry.github.io/2013-04-27-umaryland/
+  user: swcarpentry
+  venue: University of Maryland, Baltimore
+- address: Union South "Fifth Quarter" room
+  country: United-States
+  enddate: 2013-04-30
+  eventbrite: 5915929705
+  humandate: April 29-30, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Gidden, Steve Mcgough, Aronne Merrelli, Paul Wilson]
+  latlng: 43.07718,-89.40399
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-29-wisc
+  startdate: 2013-04-29
+  url: http://swcarpentry.github.io/2013-04-29-wisc/
+  user: swcarpentry
+  venue: University of Wisconsin - Madison
+- address: Faculty of Sciences, Vrije Universiteit, De Boelelaan 1081, 1081 HV Amsterdam
+  country: Netherlands
+  enddate: 2013-05-03
+  humandate: May 2-3, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stefano Cozzini, Justin Ely]
+  latlng: 52.33399,4.86305
+  layout: bootcamp
+  registration: open
+  slug: 2013-05-02-vu
+  startdate: 2013-05-02
+  url: http://swcarpentry.github.io/2013-05-02-vu/
+  user: swcarpentry
+  venue: Vrije Universiteit, Amsterdam
+- address: Christian-Albrechts-Universit&auml;t zu Kiel, Christian-Albrechts-Platz
+    4, 24118 Kiel, Germany
+  country: Germany
+  enddate: 2013-05-07
+  humandate: May 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stefano Cozzini, Justin Ely]
+  latlng: 54.32707,10.18265
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-06-geomar
+  startdate: 2013-05-06
+  url: http://swcarpentry.github.io/2013-05-06-geomar/
+  user: swcarpentry
+  venue: GEOMAR (Kiel)
+- address: Axon/Dendrite Room, Landscape Building, Howard Hughes Medical Institute,
+    Janelia Farm Research Campus, 19700 Helix Drive, Ashburn, VA 20147
+  country: United-States
+  enddate: 2013-05-07
+  humandate: May 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Adina Chuang-Howe, Michael Hansen]
+  latlng: 39.07141,-77.46427
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-06-hhmi
+  startdate: 2013-05-06
+  url: http://swcarpentry.github.io/2013-05-06-hhmi/
+  user: swcarpentry
+  venue: Howard Hughes Medical Institute
+- address: Room B005, Li Ka Shing Center for Learning and Knowledge, Stanford University
+  country: United-States
+  enddate: 2013-05-07
+  humandate: May 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Paul Ivanov, Bernhard Konrad, Ariel Rokem]
+  latlng: 37.42949,-122.17186
+  layout: bootcamp
+  registration: full
+  slug: 2013-05-06-stanford
+  startdate: 2013-05-06
+  url: http://swcarpentry.github.io/2013-05-06-stanford/
+  user: swcarpentry
+  venue: Stanford University
+- country: United-States
+  enddate: 2013-05-10
+  humandate: May 9-10, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Matt Davis, Tracy Teal]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-09-lbl
+  startdate: 2013-05-09
+  url: http://swcarpentry.github.io/2013-05-09-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley National Laboratory
+- address: 366 Adelaide Street West, Suite 500, Toronto, ON
+  country: Canada
+  enddate: 2013-05-10
+  eventbrite: 6181024611
+  humandate: May 9-10, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Gabriel Devenyi, Caitlyn Pickens, Victor Ng, Greg Wilson]
+  latlng: 43.64712,-79.39430
+  layout: bootcamp
+  registration: open
+  slug: 2013-05-09-mozilla
+  startdate: 2013-05-09
+  url: http://swcarpentry.github.io/2013-05-09-mozilla/
+  user: swcarpentry
+  venue: Mozilla Foundation (Toronto)
+- contact: host-oxford-dtc@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-05-10
+  eventbrite: 5656292122
+  humandate: May 9-10, 2013
+  instructor: [Mario Antonioletti, Shoaib Sufi]
+  latlng: 51.759865,-1.258648
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-09-oxford
+  startdate: 2013-05-09
+  url: http://swcarpentry.github.io/2013-05-09-oxford/
+  user: swcarpentry
+  venue: University of Oxford
+- address: King Lounge (Room 245), Memorial Union
+  country: United-States
+  enddate: 2013-05-14
+  eventbrite: 5553687228
+  humandate: May 13-14, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Matt Davis, Chloe Lewis, Tracy Teal]
+  latlng: 38.54926,-121.76709
+  layout: bootcamp
+  registration: full
+  slug: 2013-05-13-ucdavis
+  startdate: 2013-05-13
+  url: http://swcarpentry.github.io/2013-05-13-ucdavis/
+  user: swcarpentry
+  venue: University of California Davis
+- country: United-States
+  enddate: 2013-05-17
+  eventbrite: 5899249815
+  humandate: May 16-17, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jennifer Bryan, Karen Cranston, Ben Morris]
+  latlng: 36.00803,-78.92323
+  layout: bootcamp
+  registration: open
+  slug: 2013-05-16-nescent
+  startdate: 2013-05-16
+  url: http://swcarpentry.github.io/2013-05-16-nescent/
+  user: swcarpentry
+  venue: NESCent
+- address: Krakow, Poland
+  country: Poland
+  enddate: 2013-05-19
+  humandate: May 18-19, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aleksandra Pawlik, Karin Lagesen]
+  latlng: 50.060833,19.932778
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-18-krakow
+  startdate: 2013-05-18
+  url: http://swcarpentry.github.io/2013-05-18-krakow/
+  user: swcarpentry
+  venue: Jagiellonian University
+- country: United-States
+  enddate: 2013-05-21
+  humandate: May 20-21, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jennifer Bryan, Ben Morris]
+  latlng: 36.00283,-78.93827
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-20-duke
+  startdate: 2013-05-20
+  url: http://swcarpentry.github.io/2013-05-20-duke/
+  user: swcarpentry
+  venue: Duke University
+- address: National Center for Atmospheric Research, Boulder, CO
+  country: United-States
+  enddate: 2013-05-24
+  humandate: May 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ted Hart, Alex Viana]
+  latlng: 40.03131,-105.2459
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-23-ucar
+  startdate: 2013-05-23
+  url: http://swcarpentry.github.io/2013-05-23-ucar/
+  user: swcarpentry
+  venue: NCAR
+- address: Skinner 112, UMass Amherst
+  country: United-States
+  enddate: 2013-05-24
+  humandate: May 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tracy Teal, Erik Bray]
+  latlng: 42.388889,-72.527778
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-23-umass
+  startdate: 2013-05-23
+  url: http://swcarpentry.github.io/2013-05-23-umass/
+  user: swcarpentry
+  venue: University of Massachusetts Amherst
+- address: Biological Sciences Building, Central Wing 410 (CW410), University of Alberta
+  country: Canada
+  enddate: 2013-05-31
+  eventbrite: 5824534339
+  humandate: May 30-31, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Charlene Nielsen, Greg Wilson]
+  latlng: 53.52345,-113.52600
+  layout: bootcamp
+  registration: full
+  slug: 2013-05-30-alberta
+  startdate: 2013-05-30
+  url: http://swcarpentry.github.io/2013-05-30-alberta/
+  user: swcarpentry
+  venue: University of Alberta
+- contact: host-soton@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-06-04
+  humandate: June 3-4, 2013
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Nelle Varoquaux, James Morrison]
+  latlng: 50.937716,-1.395599
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-03-southampton
+  startdate: 2013-06-03
+  url: http://swcarpentry.github.io/2013-06-03-southampton/
+  user: swcarpentry
+  venue: University of Southampton
+- country: United-States
+  enddate: 2013-06-04
+  humandate: June 3-4, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Jessica Mckellar, Michael Selik, Will Trimble]
+  latlng: 42.35076,-71.06274
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-03-tufts
+  startdate: 2013-06-03
+  url: http://swcarpentry.github.io/2013-06-03-tufts/
+  user: swcarpentry
+  venue: Tufts University
+- address: University of Chicago
+  country: United-States
+  enddate: 2013-06-05
+  humandate: June 4-5 and June 17-18, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Elliott Hauser, Fernanda Foertter, John Blischak]
+  latlng: 41.789722,-87.599722
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-04-dssg
+  startdate: 2013-06-04
+  url: http://swcarpentry.github.io/2013-06-04-dssg/
+  user: swcarpentry
+  venue: Data Science for Social Good
+- address: Blusson Hall Room 10011, Simon Fraser University, Burnaby BC.
+  country: Canada
+  enddate: 2013-06-07
+  eventbrite: 6744439801
+  humandate: June 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Lynne Williams, Ted Hart, Bernhard Konrad, Julia Gustavsen]
+  latlng: 49.276765,-122.917957
+  layout: bootcamp
+  registration: open
+  slug: 2013-06-06-sfu
+  startdate: 2013-06-06
+  url: http://swcarpentry.github.io/2013-06-06-sfu/
+  user: swcarpentry
+  venue: Simon Fraser University
+- address: La Jolla, CA
+  country: United-States
+  enddate: 2013-06-11
+  humandate: June 10-11, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jessica Kerr, Dhavide Aruliah, Bill Punch]
+  latlng: 32.887151,-117.246212
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-10-salk
+  startdate: 2013-06-10
+  url: http://swcarpentry.github.io/2013-06-10-salk/
+  user: swcarpentry
+  venue: Salk Institute
+- country: United-States
+  enddate: 2013-06-18
+  humandate: June 17-18, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [John Blischak, Will Trimble, Randy Olson, Emily Davenport]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-17-chicago
+  startdate: 2013-06-17
+  url: http://swcarpentry.github.io/2013-06-17-chicago/
+  user: swcarpentry
+  venue: University of Chicago
+- address: One Cambridge Center, Cambridge, MA 02142
+  country: United-States
+  enddate: 2013-06-25
+  eventbrite: 6181177067
+  humandate: June 24-25, 2013
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Tracy Teal, Sheeri Cabral, Adina Chuang-Howe, Jessica Mckellar, Aleksandra
+      Pawlik, Sarah Supp, Nelle Varoquaux]
+  latlng: 42.3625,-71.085
+  layout: bootcamp
+  registration: open
+  root: ../..
+  slug: 2013-06-24-wise
+  startdate: 2013-06-24
+  url: http://swcarpentry.github.io/2013-06-24-wise/
+  user: swcarpentry
+  venue: Women in Science and Engineering (Boston)
+- country: United-States
+  enddate: 2013-05-26
+  humandate: June 25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Katy Huff]
+  latlng: 30.2835989,-97.7344283
+  layout: bootcamp
+  registration: open
+  slug: 2013-06-25-scipy
+  startdate: 2013-05-25
+  url: http://swcarpentry.github.io/2013-06-25-scipy/
+  user: swcarpentry
+  venue: SciPy 2013
+- address: Undercroft Room, University of Canterbury, Christchurch
+  country: New-Zealand
+  enddate: 2013-07-04
+  humandate: July 1-4, 2013
+  humantime: 1:00 pm - 5:00 pm
+  instructor: [Shreyas Cholia, Ariel Rokem, Tim McNamara, Nick Jones]
+  latlng: -43.523333,172.581944
+  layout: bootcamp
+  registration: closed
+  slug: 2013-07-01-christchurch
+  startdate: 2013-07-01
+  url: http://swcarpentry.github.io/2013-07-01-christchurch/
+  user: swcarpentry
+  venue: eResearch New Zealand
+- address: The Core, Stephenson Research and Technology Center, University of Oklahoma
+  country: United-States
+  enddate: 2013-07-02
+  humandate: July 1-2, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Paul Ivanov, Aleksandra Pawlik]
+  latlng: 35.20859,-97.44566
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-07-01-oklahoma
+  startdate: 2013-07-01
+  url: http://swcarpentry.github.io/2013-07-01-oklahoma/
+  user: swcarpentry
+  venue: University of Oklahoma
+- address: Auditorium 2, Georg Sverdrups hus, Moltke Moes vei 39, Oslo
+  country: Norway
+  enddate: 2013-07-04
+  eventbrite: 5398444894
+  humandate: July 3-4, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Karin Lagesen, Lex Nederbragt]
+  latlng: 59.9399586,10.7217496
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-03-oslo
+  startdate: 2013-07-03
+  url: http://swcarpentry.github.io/2013-07-03-oslo/
+  user: swcarpentry
+  venue: University of Oslo
+- address: Xiao Hong Shan No.44, Wuhan
+  country: China
+  enddate: 2013-07-09
+  humandate: July 8-9, 2013
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Karen Cranston, Qingpeng Zhang]
+  latlng: 30.538977502418366,114.32192802429199
+  layout: bootcamp
+  registration: closed
+  slug: 2013-07-08-wuhan
+  startdate: 2013-07-08
+  url: http://swcarpentry.github.io/2013-07-08-wuhan/
+  user: swcarpentry
+  venue: Wuhan Institute of Virology
+- country: United-States
+  enddate: 2013-07-12
+  eventbrite: 6106951055
+  humandate: July 11-12, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Hansen, Jeff Shelton]
+  latlng: 39.1663815,-86.526621
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-11-indiana
+  startdate: 2013-07-11
+  url: http://swcarpentry.github.io/2013-07-11-indiana/
+  user: swcarpentry
+  venue: Indiana University
+- contact: host-bath@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-07-16
+  eventbrite: 6059565323
+  humandate: July 15-16, 2013
+  humantime: 9:00 - 17:00
+  instructor: [Mike Jackson, Christopher Woods]
+  latlng: 51.3777431,-2.3263779
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-15-bath
+  startdate: 2013-07-15
+  url: http://swcarpentry.github.io/2013-07-15-bath/
+  user: swcarpentry
+  venue: University of Bath
+- address: Sustainable Software for Chemistry and Materials Software Summer School
+  country: United-States
+  enddate: 2013-07-16
+  humandate: July 15-16, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tommy Guy, Ross Dickson]
+  latlng: 37.2283843,-80.4234167
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-07-15-vt
+  startdate: 2013-07-15
+  url: http://swcarpentry.github.io/2013-07-15-vt/
+  user: swcarpentry
+  venue: Virginia Tech
+- address: Utah State University Engineering Building (ENGR) Room 302
+  country: United-States
+  enddate: 2013-07-17
+  eventbrite: 6309398581
+  humandate: July 16-17, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ben Morris, Ethan White]
+  latlng: 41.74080,-111.81416
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-16-cuahsi
+  startdate: 2013-07-16
+  url: http://swcarpentry.github.io/2013-07-16-cuahsi/
+  user: swcarpentry
+  venue: CUAHSI Water Data Center
+- address: 140 DeBartolo Hall
+  country: United-States
+  enddate: 2013-07-19
+  eventbrite: 7012698169
+  humandate: July 18-19, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Randy Olson, Will Trimble]
+  latlng: 41.70522,-86.23531
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-18-notredame
+  startdate: 2013-07-18
+  url: http://swcarpentry.github.io/2013-07-18-notredame/
+  user: swcarpentry
+  venue: University of Notre Dame
+- country: United-States
+  enddate: 2013-07-19
+  humandate: July 18-19, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Jacob Vanderplas, Kyle Mandli]
+  latlng: 47.655,-122.303333
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-18-washington
+  startdate: 2013-07-18
+  url: http://swcarpentry.github.io/2013-07-18-washington/
+  user: swcarpentry
+  venue: University of Washington
+- address: Pittsburgh, PA
+  country: United-States
+  enddate: 2013-07-28
+  humandate: July 27-28, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Erik Bray, Josh Smith]
+  latlng: 40.443322,-79.943583
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-27-cmu
+  startdate: 2013-07-27
+  url: http://swcarpentry.github.io/2013-07-27-cmu/
+  user: swcarpentry
+  venue: Carnegie Mellon University
+- address: Minneapolis Convention Center
+  country: United-States
+  enddate: 2013-08-04
+  humandate: Aug 4, 2013
+  humantime: 8:00 a.m. - 5:00 p.m.
+  instructor: [Ted Hart, Ben Morris, Ethan White]
+  latlng: 44.968657,-93.27457
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-04-esa
+  startdate: 2013-08-04
+  url: http://swcarpentry.github.io/2013-08-04-esa/
+  user: swcarpentry
+  venue: Ecological Society of America Annual Meeting
+- address: The Commons, University of Kansas
+  contact: ejm@ku.edu
+  country: United-States
+  enddate: 2013-08-23
+  humandate: Aug 22-23, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Darren Boss, Karen Cranston, Mark Holder, Emily Jane McTavish]
+  latlng: 38.9584551,-95.2432842
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-22-ku
+  startdate: 2013-08-22
+  url: http://swcarpentry.github.io/2013-08-22-ku/
+  user: swcarpentry
+  venue: University of Kansas
+- address: Phillips Auditorium at the Center for Astrophysics, 60 Garden Street
+  contact: harvard@lists.software-carpentry.org
+  country: United-States
+  enddate: 2013-08-24
+  humandate: August 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Erik Bray, Jessica McKellar, R. David Murray, Mike Selik]
+  latlng: 42.381705,-71.127904
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-08-23-harvard
+  startdate: 2013-08-23
+  url: http://swcarpentry.github.io/2013-08-23-harvard/
+  user: swcarpentry
+  venue: Harvard University
+- address: Vicksburg, MS
+  country: United-States
+  enddate: 2013-08-29
+  humandate: Aug 27-29, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Andy Terrel]
+  latlng: 32.3019199,-90.8733522
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-27-erdc
+  startdate: 2013-08-27
+  url: http://swcarpentry.github.io/2013-08-27-erdc/
+  user: swcarpentry
+  venue: US Army Engineer Research and Development Center
+- address: Wisconsin Institutes for Discovery, 3rd Floor Teaching Lab
+  country: United-States
+  enddate: 2013-08-29
+  eventbrite: 7317971249
+  humandate: Aug 28-29, 2013
+  humantime: 8:30 a.m. - 4:30 p.m.
+  instructor: [Matt Gidden, Jens von der Linden, Lauren Michael, Paul Wilson, Anthony
+      Scopatz]
+  latlng: 43.07718,-89.40399
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-28-wisc
+  startdate: 2013-08-28
+  url: http://swcarpentry.github.io/2013-08-28-wisc/
+  user: swcarpentry
+  venue: University of Wisconsin - Madison
+- country: United-States
+  enddate: 2013-09-06
+  eventbrite: 7583026035
+  humandate: Sept 5-6, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Adina Chuang Howe, Jory Schossau]
+  latlng: 41.66293,-91.56203
+  layout: bootcamp
+  registration: open
+  slug: 2013-09-05-iowa
+  startdate: 2013-09-05
+  url: http://swcarpentry.github.io/2013-09-05-iowa/
+  user: swcarpentry
+  venue: University of Iowa
+- contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-09-13
+  humandate: Sept 12-13, 2013
+  humantime: 9:00 a.m. - 5:00 p.m.
+  instructor: [Karthik Ram, Christopher Woods]
+  latlng: 51.457971,-2.601474
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-09-12-bristol
+  startdate: 2013-09-12
+  url: http://swcarpentry.github.io/2013-09-12-bristol/
+  user: swcarpentry
+  venue: University of Bristol
+- address: Davidson Continuing Education Conference Center, 3415 S Figueroa St., Los
+    Angeles
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2013-09-17
+  humandate: Sept 16-17, 2013
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Ariel Rokem, Matt Terry, John Mehringer, Karan Vahi]
+  latlng: 34.020493, -118.281233
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-09-16-ISI
+  startdate: 2013-09-16
+  url: http://arokem.github.io/2013-09-16-ISI/
+  user: arokem
+  venue: University of Southern California
+- address: 3700 San Martin Drive, Baltimore, MD 21218
+  contact: gvwilson@software-carpentry.org
+  country: United-States
+  enddate: 2013-09-17
+  humandate: Sept 16-17, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Erik Bray, Justin Ely, Greg Wilson]
+  latlng: 39.33272,-76.62327
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-09-16-stsci
+  startdate: 2013-09-16
+  url: http://swcarpentry.github.io/2013-09-16-stsci/
+  user: swcarpentry
+  venue: Space Telescope Science Institute
+- address: BSLC 115, 924 East 57th Street
+  contact: jdblischak@uchicago.edu
+  country: United-States
+  enddate: 2013-09-20
+  humandate: Sept 19-20, 2013
+  humantime: 8:30 am - 4:30 pm
+  instructor: [John Blischak, Will Trimble, Emily Davenport]
+  latlng: 41.79149, -87.60270
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-09-19-chicago
+  startdate: 2013-09-19
+  url: http://jdblischak.github.io/2013-09-19-chicago/
+  user: jdblischak
+  venue: University of Chicago
+- country: Canada
+  enddate: 2013-09-22
+  humandate: Sept 21-22, 2013
+  instructor: [Gabriel Devenyi, Tommy Guy]
+  latlng: 43.468889,-80.54
+  layout: bootcamp
+  registration: open
+  slug: 2013-09-21-uwaterloo
+  startdate: 2013-09-21
+  url: http://swcarpentry.github.io/2013-09-21-uwaterloo/
+  user: swcarpentry
+  venue: University of Waterloo
+- country: United-States
+  enddate: 2013-09-26
+  eventbrite: 7723648641
+  humandate: Sept 23-26, 2013
+  humantime: 8:00 am - 11:30 am
+  instructor: [Randy Olson, Jory Schossau, Tracy Teal, Jordan Fish, Michael Crusoe]
+  latlng: 42.724085,-84.476265
+  layout: bootcamp
+  registration: open
+  slug: 2013-09-23-msu
+  startdate: 2013-09-23
+  url: http://swcarpentry.github.io/2013-09-23-msu/
+  user: swcarpentry
+  venue: Michigan State University
+- address: Ingkarni Wardli, Room 218
+  country: Australia
+  enddate: 2013-09-26
+  humandate: Sep 24-26, 2013
+  humantime: 9:00 - 17:00
+  instructor: [Ben Morris, Diego Barneche, Philipp Bayer]
+  latlng: -34.919159,138.60414
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-09-24-acpfgA
+  startdate: 2013-09-24
+  url: http://swcarpentry.github.io/2013-09-24-acpfgA/
+  user: swcarpentry
+  venue: 'Australian Bioinformatics Network: Adelaide'
+- address: ESB-5108
+  country: Canada
+  enddate: 2013-09-27
+  eventbrite: 7405051709
+  humandate: Sept 26-27, 2013
+  instructor: [Julia Gustavsen, Doug Latornell]
+  latlng: 49.261111,-123.253056
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-09-26-ubc
+  startdate: 2013-09-26
+  url: http://swcarpentry.github.io/2013-09-26-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Building 60, Monash University Clayton campus
+  country: Australia
+  enddate: 2013-10-03
+  humandate: Oct 1-3, 2013
+  humantime: 9:00 - 17:00
+  instructor: [Ben Morris, Philipp Bayer]
+  latlng: -37.9083,145.138
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-10-01-acpfgM
+  startdate: 2013-10-01
+  url: http://swcarpentry.github.io/2013-10-01-acpfgM/
+  user: swcarpentry
+  venue: 'Australian Bioinformatics Network: Melbourne'
+- address: Centre Fran&ccedilois Jacob, room 28_01_01C
+  contact: jdblischak@uchicago.edu
+  country: France
+  enddate: 2013-10-04
+  humandate: Oct 03-04, 2013
+  humantime: 13:30 - 18:30, 9:00 - 17:30
+  instructor: [John Blischak, Diego Barneche]
+  latlng: 48.84042, 2.31068
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-10-03-pasteur
+  startdate: 2013-10-03
+  url: http://jdblischak.github.io/2013-10-03-pasteur/
+  user: jdblischak
+  venue: Institut Pasteur
+- address: Canberra
+  contact: karthik.ram@berkeley.edu
+  country: Australia
+  enddate: 2013-10-10
+  humandate: October 9-10, 2013
+  humantime: 8:30 am - 5 pm
+  instructor: [Karthik Ram]
+  latlng: -35.27770,149.11853
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2013-10-09-canberra
+  startdate: 2013-10-09
+  url: http://swcarpentry.github.io/2013-10-09-canberra/
+  user: swcarpentry
+  venue: CSIRO/ANU
+- address: MRMB 1152, 900 S. Ashland, Chicago, IL 60607
+  contact: microbe@uic.edu
+  country: United-States
+  enddate: 2013-10-18
+  humandate: Oct 17-18, 2013
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Rachel Poretsky, Neal Davis, Will Trimble, John Blischak]
+  latlng: 41.870206, -87.666934
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-10-17-uic
+  startdate: 2013-10-17
+  url: http://jdblischak.github.io/2013-10-17-uic/
+  user: jdblischak
+  venue: University of Illinois at Chicago
+- address: 11th Floor, Greenwich Digital Enterprise Centre, 6 Mitre Passage, London
+    SE10 0ER
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-10-25
+  eventbrite: 7995483707
+  humandate: Oct 24-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson, James Hetherington, Karthik Ram]
+  latlng: 51.50066,0.00663
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2013-10-24-greenwich
+  startdate: 2013-10-24
+  url: http://swcarpentry.github.io/2013-10-24-greenwich/
+  user: swcarpentry
+  venue: Greenwich, England
+- address: NYC
+  contact: ely@stsci.edu
+  country: United-States
+  enddate: 2013-10-26
+  humandate: October 25-26, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Ely, David Koop, Ivan Gonzalez, David Warde-Farley]
+  latlng: 40.8080777,-73.9635678
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-10-25-columbia
+  startdate: 2013-10-25
+  url: http://justincely.github.io/2013-10-25-columbia/
+  user: justincely
+  venue: Columbia University and CUSP
+- address: The Westin Bonaventure Hotel, Los Angeles
+  country: United-States
+  enddate: 2013-10-29
+  humandate: Oct 29, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [April Wright]
+  latlng: 34.052778,-118.255833
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-10-29-vertpaleo
+  startdate: 2013-10-29
+  url: http://swcarpentry.github.io/2013-10-29-vertpaleo/
+  user: swcarpentry
+  venue: Society of Vertebrate Paleontology Annual Meeting
+- address: Reed Hall, Streatham Drive, Exeter, Devon EX4 4QR
+  contact: host-exeter@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-11-15
+  humandate: November 14-15, 2013
+  humantime: 9:00 am - 5.00 pm
+  instructor: [David Martin, Christopher Woods]
+  latlng: 50.735788,-3.535033
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-11-14-exeter
+  startdate: 2013-11-14
+  url: http://chryswoods.github.io/2013-11-14-exeter/
+  user: chryswoods
+  venue: Exeter University
+- address: Aquarium Conference Room, NOAA National Marine Fisheries Service, Woods
+    Hole
+  contact: james.maning@noaa.gov
+  country: United-States
+  enddate: 2013-11-15
+  humandate: Nov 14-15, 2013
+  humantime: 9:00 - 16:30
+  instructor: [Ross Dickson, Will Trimble]
+  latlng: 41.526667,-70.663056
+  layout: bootcamp
+  registration: open
+  slug: 2013-11-14-whoi
+  startdate: 2013-11-14
+  url: http://swcarpentry.github.io/2013-11-14-whoi/
+  user: swcarpentry
+  venue: Woods Hole Scientific Community
+- address: Old Arts, Second Floor, Collaborative Learning Space 2 (room 257)
+  contact: karenl@unimelb.edu.au
+  country: Australia
+  enddate: 2013-12-04
+  humandate: Nov 25 & 27/Dec 2 & 4, 2013
+  humantime: 3:00 pm - 6:00 pm
+  instructor: [Damien Irving]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-11-25-unimelb
+  startdate: 2013-11-25
+  url: http://damienirving.github.io/2013-11-25-unimelb/
+  user: damienirving
+  venue: University of Melbourne
+- address: Room 3217, James Clark Maxwell Building, Kings Buildings, Mayfield Road,
+    Edinburgh, EH9 3JZ
+  contact: host-edinburgh@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-12-04
+  humandate: Dec 3-4, 2013
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Mike Jackson, Mario Antonioletti]
+  latlng: 55.921628,-3.174155
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2013-12-03-edinburgh
+  startdate: 2013-12-03
+  url: http://mikej888.github.io/2013-12-03-edinburgh/
+  user: mikej888
+  venue: The University of Edinburgh
+- address: SESYNC, Annapolis, MD
+  contact: mshelley@sesync.org
+  country: United-States
+  enddate: 2013-12-06
+  humandate: Dec 3-6, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Will Trimble, Amanda Whitlock, Bernhard Konrad, Aron Ahmadia, R. David
+      Murray]
+  latlng: 38.976734, -76.503296
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-12-03-sesync
+  startdate: 2013-12-03
+  url: http://wltrimbl.github.io/2013-12-03-sesync/
+  user: wltrimbl
+  venue: National Socio-Environmental Synthesis Center (SESYNC)
+- address: Room 320, Kelvin Building
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-12-13
+  humandate: Dec 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ben Morris, James Morrison]
+  latlng: 55.87185,-4.29155
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-12-12-glasgow
+  startdate: 2013-12-12
+  url: http://bendmorris.github.io/2013-12-12-glasgow/
+  user: bendmorris
+  venue: Glasgow University
+- address: College of Life Sciences, University of Dundee, Dundee DD1 5EH
+  contact: d.m.a.martin@dundee.ac.uk
+  country: United-Kingdom
+  enddate: 2013-12-16
+  humandate: December 16-17, 2013
+  humantime: 9:00 am - 5.00 pm
+  instructor: [David Martin, Martin Jones]
+  latlng: 56.464,-2.97
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-12-16-dundee
+  startdate: 2013-12-16
+  url: http://davidmam.github.io/2013-12-16-dundee/
+  user: davidmam
+  venue: Dundee University
+- address: Bailey Hall 214-216, 10 Bailey Drive, Fredericton, New Brunswick
+  contact: jgustavsen@eos.ubc.ca
+  country: Canada
+  enddate: 2014-01-07
+  humandate: Jan 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Julia Gustavsen, Ross Dickson]
+  latlng: 45.947214,-66.640325
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-06-unb
+  startdate: 2014-01-06
+  url: http://jooolia.github.io/2014-01-06-unb/
+  user: jooolia
+  venue: University of New Brunswick
+- address: Wilberforce Road, Cambridge
+  contact: r.cam.bootcamp@gmail.com
+  country: United-Kingdom
+  enddate: 2014-01-08
+  humandate: Jan 7-8, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stephen Eglen, Laurent Gatto, Aleksandra Pawlik]
+  latlng: 52.209868,0.102439
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-07-cam
+  startdate: 2014-01-07
+  url: http://sje30.github.io/2014-01-07-cam/
+  user: sje30
+  venue: Centre for Mathematical Sciences, University of Cambridge
+- address: ISU Memorial Union (1/8/14 - Oak and South Ballroom, 1/9/14 - Oak and Sun
+    Room)
+  contact: howead@msu.edu
+  country: United-States
+  enddate: 2014-01-09
+  humandate: Jan 8-9, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jonah Duckles, Molly Gibson, Adina Howe, William Trimble]
+  latlng: 42.02662,-93.64647
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-08-iastate
+  startdate: 2014-01-08
+  url: http://adina.github.io/2014-01-08-iastate/
+  user: adina
+  venue: Iowa State University
+- &id1305
+  address: Avery Hall, room 119
+  contact: sheldon.mckay@gmail.com
+  country: United-States
+  enddate: 2015-01-09
+  etherpad: https://etherpad.mozilla.org/2015-01-08-unl
+  helper: [Derek Weitzel, Emelie Harstad, Jingchao Zhang, Adam Caprez, Natasha Pavlovijk,
+    O. William McClung]
+  humandate: Jan 8-9, 2015
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Sheldon McKay, Daniel Smith]
+  latlng: 40.819348, -96.704387
+  layout: workshop
+  root: .
+  slug: 2014-01-08-unl
+  startdate: 2015-01-08
+  url: http://mckays630.github.io/2014-01-08-unl/
+  user: mckays630
+  venue: University of Nebraska-Lincoln
+- address: 366 Adelaide Street West, Toronto
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-01-14
+  humandate: Jan 13-14, 2014
+  humantime: 8:45 am - 4:30 pm
+  instructor: [Andromeda Yelton, Chris Gray, Victor Ng, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-01-13-toronto
+  startdate: 2014-01-13
+  url: http://swcarpentry.github.io/2014-01-13-toronto/
+  user: swcarpentry
+  venue: Mozilla Toronto
+- address: Hazard Conference Room, 215 South Ferry Road, Narragansett, RI 02882
+  contact: igonzalez@mailaps.org
+  country: United-States
+  enddate: 2014-01-14
+  humandate: Jan 13-14, 2014
+  humantime: 8:00 am - 4:00 pm
+  instructor: [Patrick Fuller, Ivan Gonzalez]
+  latlng: 41.492635,-71.422294
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-13-uri
+  startdate: 2014-01-13
+  url: http://iglpdc.github.io/2014-01-13-uri/
+  user: iglpdc
+  venue: Coastal Institute, University of Rhode Island
+- address: Researcher's Link, Wisconsin Institutes for Discovery
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-01-14
+  eventbrite: 9770502837
+  humandate: Jan 13-14, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Paul Wilson, Matt Gidden, Lauren Michael, Cliff Davis, Danielle Nielsen,
+    Aronne Merrelli]
+  latlng: 43.07718,-89.40399
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-13-wisc
+  startdate: 2014-01-13
+  url: http://uw-madison-aci.github.io/2014-01-13-wisc/
+  user: uw-madison-aci
+  venue: University of Wisconsin-Madison
+- address: Room IT407, Information Technology Building, University of Manchester,
+    Oxford Road, M13 9PL
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-01-15
+  humandate: Jan 14-15, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Michael Croucher, Jos Martin, Shoaib Sufi, Aleksandra Pawlik]
+  latlng: 53.467972,-2.233154
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-14-manchester
+  startdate: 2014-01-14
+  url: http://apawlik.github.io/2014-01-14-manchester/
+  user: apawlik
+  venue: University of Manchester
+- address: Moffitt 103
+  contact: jkitzes@berkeley.edu
+  country: United-States
+  enddate: 2014-01-19
+  humandate: Jan 18-19, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Justin Kitzes, Chris Holdgraf, Mark Wilber]
+  latlng: 34.413963,-119.848947
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-18-ucb
+  startdate: 2014-01-18
+  url: http://swcarpentry.github.io/2014-01-18-ucb/
+  user: swcarpentry
+  venue: University of California Berkeley
+- address: '405 Avenue Ogilvy #101, Montreal'
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-01-21
+  eventbrite: 9698535581
+  humandate: Jan 20-21, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson, Julia Evans]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-01-20-montreal
+  startdate: 2014-01-20
+  url: http://gvwilson.github.io/2014-01-20-montreal/
+  user: gvwilson
+  venue: CRIM (Montreal)
+- address: 3909 Halls Ferry Rd Vicksburg, MS 39180
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-01-22
+  humandate: January 21-22, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Randal Olson]
+  latlng: 32.301199,-90.871617
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-21-erdc
+  startdate: 2014-01-21
+  url: http://geocarpentry.github.io/2014-01-21-erdc/
+  user: geocarpentry
+  venue: US Army Engineer Research and Development Center
+- address: Hartley Conference Center, Mitchell Earth Sciences bldg., Stanford, CA
+  contact: arokem@gmail.com
+  country: United-States
+  enddate: 2014-01-28
+  humandate: Jan 27-28, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ariel Rokem, Justin Kitzes]
+  latlng: 37.4225, -122.1653
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-27-Stanford
+  startdate: 2014-01-27
+  url: http://arokem.github.io/2014-01-27-Stanford/
+  user: arokem
+  venue: Stanford University
+- address: Newman Alumni Center (tentative)
+  contact: SKhuri@med.miami.edu
+  country: United-States
+  enddate: 2014-01-28
+  humandate: Jan 27-28, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Jenny Bryan, Carlos Anderson, Bernhard Konrad, Justin Ely, Victor Ng,
+    Jonah Duckles]
+  latlng: 25.7174346,-80.2781389
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-27-miami
+  startdate: 2014-01-27
+  url: http://jennybc.github.io/2014-01-27-miami/
+  user: jennybc
+  venue: University of Miami
+- address: Alma Mater Room, I Hotel and Conference Center, 1900 South 1st Street,
+    Champaign, IL 61820
+  contact: davis68@illinois.edu
+  country: United-States
+  enddate: 2014-01-31
+  humandate: Jan 30-31, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Selik, Neal Davis]
+  latlng: 40.093692, -88.237606
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-01-30-cse
+  startdate: 2014-01-30
+  url: http://uiuc-cse.github.io/2014-01-30-cse/
+  user: uiuc-cse
+  venue: University of Illinois, Computational Science and Engineering
+- address: 15 Vassar Street, 48-316
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-02-01
+  humandate: Jan 30 - Feb 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Randy Olson]
+  latlng: 42.361947,-71.090936
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-30-mit
+  startdate: 2014-01-30
+  url: http://geocarpentry.github.io/2014-01-30-mit/
+  user: geocarpentry
+  venue: Massachusetts Institute of Technology
+- address: 1424 Bren Hall, University of California, Santa Barbara
+  contact: jkitzes@berkeley.edu
+  country: United-States
+  enddate: 2014-02-01
+  humandate: Jan 31-Feb 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Kitzes, Shane Grigsby, Mark Wilber]
+  latlng: 34.412114,-119.842014
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-31-ucsb
+  startdate: 2014-01-31
+  url: http://swcarpentry.github.io/2014-01-31-ucsb/
+  user: swcarpentry
+  venue: University of California Santa Barbara
+- address: Norwich Research Park, Norwich
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-02-04
+  humandate: Feb 3-4, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aleksandra Pawlik, Rob Davey]
+  latlng: 52.6217629,-1.2409930
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-03-TGAC
+  startdate: 2014-02-03
+  url: http://apawlik.github.io/2014-02-03-TGAC/
+  user: apawlik
+  venue: The Genome Analysis Centre (TGAC)
+- address: Institute for Marine and Antarctic Studies, <a href="http://www.utas.edu.au/commercial-services-development/building-works/current-projects/institute-for-marine-and-antarctic-studies-imas">Castray
+    Esplanade, Battery Point</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-02-11
+  humandate: Feb 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Damien Irving]
+  latlng: -42.8806,147.3250
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-10-hobart
+  startdate: 2014-02-10
+  url: http://damienirving.github.io/2014-02-10-hobart/
+  user: damienirving
+  venue: AMOS conference
+- address: 366 Adelaide Street West, Toronto
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-02-12
+  eventbrite: 9459779455
+  humandate: Feb 11-12, 2014
+  humantime: 8:45 am - 4:30 pm
+  instructor: [Trevor Bekolay, Bonny Biswas, Abigail Cabunoc, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-11-toronto
+  startdate: 2014-02-11
+  url: http://swcarpentry.github.io/2014-02-11-toronto/
+  user: swcarpentry
+  venue: Mozilla Toronto
+- address: High St, Kensington NSW 2052 (Boral Theatre in the AGSM)
+  contact: a.letten@unsw.edu.au
+  country: Australia
+  enddate: 2014-02-14
+  humandate: Feb 13-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Daniel Falster, Rich FitzJohn, Diego Barneche]
+  latlng: -33.917410,151.231307
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-13-UNSW
+  startdate: 2014-02-13
+  url: http://nicercode.github.io/2014-02-13-UNSW/
+  user: nicercode
+  venue: University of New South Wales
+- address: TBD
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-02-16
+  humandate: Feb 15-16, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Emily Jane McTavish, Jonah Duckles]
+  latlng: 39.091816,-94.550378
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-15-umkc
+  startdate: 2014-02-15
+  url: http://swcarpentry.github.io/2014-02-15-umkc/
+  user: swcarpentry
+  venue: University of Missouri - Kansas City
+- address: London
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-02-19
+  humandate: Feb 18-19, 2014
+  humantime: 10:00 am - 5:00 pm
+  instructor: [James Hetherington, Owain Kenway, Miguel Bernabeu Llinares, Mayeul
+      d'Avezac]
+  latlng: 51.5243625,-0.1344750
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-18-UCL
+  startdate: 2014-02-18
+  url: http://apawlik.github.io/2014-02-18-UCL/
+  user: apawlik
+  venue: University College London
+- address: CB06.06.103 (Bld 6, level 6, Rm 103)<br> 15 Broadway, Ultimo NSW 2007,
+    Australia <a href ="http://maps.uts.edu.au/map.cfm">map</a>
+  contact: daniel.falster@mq.edu.au
+  country: Australia
+  enddate: 2014-02-19
+  humandate: Feb 18-19, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Daniel Falster, Rich FitzJohn, Diego Barneche]
+  latlng: -33.883898,151.201013
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-18-UTS
+  startdate: 2014-02-18
+  url: http://nicercode.github.io/2014-02-18-UTS/
+  user: nicercode
+  venue: University of Technology, Sydney
+- address: Accra - Cape Coast Rd, Biriwa, Central, Biriwa
+  contact: admin@software-carpentry.org
+  country: Ghana
+  enddate: 2014-02-20
+  humandate: Feb 18-20, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stefano Cozzini, Kwasi Kwakwa]
+  latlng: 5.161988,-1.165945
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-18-aims
+  startdate: 2014-02-18
+  url: http://swcarpentry.github.io/2014-02-18-aims/
+  user: swcarpentry
+  venue: African Institute for Mathematical Sciences
+- address: 8888 University Drive, Burnaby
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-03-01
+  eventbrite: 8883102599
+  humandate: Feb 22 and Mar 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Bernhard Konrad, Scott Chamberlain, Christina Koch, Lynne Williams]
+  latlng: 49.276765,-122.917957
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-22-SFU
+  startdate: 2014-02-22
+  url: http://bernhardkonrad.github.io/2014-02-22-SFU/
+  user: bernhardkonrad
+  venue: Simon Fraser University
+- address: Madrid
+  contact: abostroem@stsci.edu
+  country: Spain
+  enddate: 2014-02-24
+  humandate: Feb 24-25, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Justin Ely]
+  latlng: 40.46871,-3.94383
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-24-esac
+  startdate: 2014-02-25
+  url: http://justincely.github.io/2014-02-24-esac/
+  user: justincely
+  venue: ESAC
+- address: ETH Hoenggerberg, HIT E51, Zurich
+  contact: admin@software-carpentry.org
+  country: Switzerland
+  enddate: 2014-03-01
+  humandate: Feb 28-Mar 1, 2014
+  humantime: 9:00 am - 5:30 pm
+  instructor: [Stefano Cozzini, Sam Thomson]
+  latlng: 47.4103, 8.508272
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-28-ethz
+  startdate: 2014-02-28
+  url: http://swcarpentry.github.io/2014-02-28-ethz/
+  user: swcarpentry
+  venue: ETH Zurich
+- address: Brown Science and Engineering Library Electronic Classroom, Clark Hall
+    (Room 133)
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-11
+  humandate: Mar 10-11 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Hansen, Stephen Turner, Erik Bray]
+  latlng: 38.033553,-78.507977
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-10-uva
+  startdate: 2014-03-10
+  url: http://synesthesiam.github.io/2014-03-10-uva/
+  user: synesthesiam
+  venue: University of Virginia
+- address: 4 Washington Place, 2nd Floor, Manhattan (for Python) and<br/> 1 MetroTech
+    Center, 19th Floor, Brooklyn (for R)
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-18
+  eventbrite: 10435144799
+  humandate: Mar 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Elena Glassman, Matthew Lightman, Michael Selik, Sarah Supp, Tracy
+      Teal, Alex Viana, David Warde-Farley]
+  ipythonnotebook: http://nbviewer.ipython.org/urls
+  latlng: 40.729513,-73.996461
+  layout: bootcamp
+  raw: raw.github.com/swcarpentry/bc/gh-pages
+  registration: open
+  root: .
+  slug: 2014-03-17-nyu
+  startdate: 2014-03-17
+  url: http://swcarpentry.github.io/2014-03-17-nyu/
+  user: swcarpentry
+  venue: New York University
+- address: 100 S. Grant Street, West Lafayette, IN
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-18
+  humandate: March 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Neal Davis, Joshua Herr, Jeff Shelton]
+  latlng: 40.423784,-86.909696
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-17-purdue
+  startdate: 2014-03-17
+  url: http://swcarpentry.github.io/2014-03-17-purdue/
+  user: swcarpentry
+  venue: Purdue University
+- address: Kinzie and Tamalpais Rooms, David Brower Center, 2150 Alliston Way, Berkeley
+    CA
+  contact: davclark@berkeley.edu
+  country: United-States
+  enddate: 2014-03-18
+  humandate: Mar 17-18, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Justin Kitzes, Matt Davis, Chang She, Cindee Madison, Chris Holdgraf,
+    Thomas Kluyver, Dav Clark, Anna Schneider]
+  latlng: 37.873913,-122.250563
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-03-17-ucb
+  startdate: 2014-03-17
+  url: http://swcarpentry.github.io/2014-03-17-ucb/
+  user: swcarpentry
+  venue: University of California - Berkeley
+- address: HUB 145, 4001 Stevens Way NE and OUG 220, 4060 George Washington Ln NE,
+    Seattle
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-18
+  eventbrite: 10299635487
+  humandate: Mar 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Bernhard Konrad, Jenny Bryan, Tommy Guy, Christina Koch, Lynne Williams,
+    Trevor King]
+  latlng: 47.655335,-122.303519
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-17-uw
+  startdate: 2014-03-17
+  url: http://ljwilliams.github.io/2014-03-17-uw/
+  user: ljwilliams
+  venue: University of Washington
+- address: <a href="http://maps.unimelb.edu.au/parkville/building/104#.Uw0fhPiLelM">Alan
+    Gilbert Building</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-03-28
+  humandate: Mar 18, 21, 26 & 28, 2014
+  humantime: 9:00 am - 12:30 pm
+  instructor: [Damien Irving]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-18-combine
+  startdate: 2014-03-18
+  url: http://resbaz.github.io/2014-03-18-combine/
+  user: resbaz
+  venue: University of Melbourne
+- address: Room 110, Petch Building
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-04-03
+  eventbrite: 10138651981
+  humandate: Apr 2-3, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ethan White, Greg Wilson, Bill Mills]
+  latlng: 48.461821,-123.310443
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-02-uvic
+  startdate: 2014-04-02
+  url: http://swcarpentry.github.io/2014-04-02-uvic/
+  user: swcarpentry
+  venue: University of Victoria
+- address: <a href="http://vejviser.sdu.dk/opslag?lid=1082">Room U24</a> on day 1,
+    <a href="http://vejviser.sdu.dk/opslag?lid=1799">room U30A</a> on day 2
+  contact: admin@software-carpentry.org
+  country: Denmark
+  enddate: 2014-04-04
+  humandate: Apr 3-4, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Luis Pedro Coelho, Steven Koenig]
+  latlng: 55.368735,10.426408
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-03-sdu
+  startdate: 2014-04-03
+  url: http://luispedro.github.io/2014-04-03-sdu/
+  user: luispedro
+  venue: University of Southern Denmark
+- address: 101 David L. Boren Blvd, Norman OK 73019
+  contact: jduckles@ou.edu
+  country: United-States
+  enddate: 2014-04-05
+  helpers: [Mark Stacy, Mark Laufersweiler]
+  humandate: April 4-5, 2014
+  instructor: [Jonah Duckles, Emily Jane McTavish]
+  latlng: 35.183121,-97.441238
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-04-ou
+  startdate: 2014-04-04
+  url: http://jduckles.github.io/2014-04-04-ou/
+  user: jduckles
+  venue: University of Oklahoma
+- address: School of Life Sciences on Gibbet Hill Campus, Coventry
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-04-10
+  humandate: Apr 09-10, 2014
+  humantime: 9:45 am - 4:00 pm
+  instructor: [Aleksandra Pawlik, Christina Koch]
+  latlng: 52.3802961,-1.5639370
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-09-GARNET
+  startdate: 2014-04-09
+  url: http://apawlik.github.io/2014-04-09-GARNET/
+  user: apawlik
+  venue: GARNet, Warwick University
+- address: 3080 Center Green Drive, Boulder, CO
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-04-10
+  humandate: Apr 09-10, 2014
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Edmund Hart, Camille Avestruz]
+  latlng: 40.031528, -105.245847
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-09-ucar
+  startdate: 2014-04-09
+  url: http://emhart.github.io/2014-04-09-ucar/
+  user: emhart
+  venue: University Corporation for Atmospheric Research
+- address: Room 523, Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-04-15
+  eventbrite: 10151376039
+  humandate: Apr 14-15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Anthony Scopatz, Ivan Gonzalez, Marcello Barisonzi, Marianne Corvellec,
+    Denis Haine]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon
+  startdate: 2014-04-14
+  url: http://swcarpentry.github.io/2014-04-14-pycon/
+  user: swcarpentry
+  venue: Software Skills for Scientists and Engineers
+- address: Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-04-15
+  eventbrite: 10812972893
+  humandate: Apr 14-15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Luke Lee, Jessica Hamrick]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon-lib
+  startdate: 2014-04-14
+  url: http://dhavide.github.io/2014-04-14-pycon-lib/
+  user: dhavide
+  venue: Software Skills for Librarians
+- address: Room 525, Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  eventbrite: 10151618765
+  humandate: Apr 14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Titus Brown]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon-ngs
+  startdate: 2014-04-14
+  url: http://swcarpentry.github.io/2014-04-14-pycon-ngs/
+  user: swcarpentry
+  venue: Next-Generation Sequencing
+- address: Room 525, Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  eventbrite: 10319320365
+  helper: [Denis Haine, John Blischak]
+  humandate: Apr 15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ramnath Vaidyanathan]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon-r
+  startdate: 2014-04-15
+  url: http://swcarpentry.github.io/2014-04-14-pycon-r/
+  user: swcarpentry
+  venue: R for Python Programmers
+- address: Lawrence Berkeley National Laboratory, Berkeley, California
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-04-15
+  humandate: Apr 14-15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Katy Huff, Rachel Slaybaugh, Azalee Bostroem, Cindee Madison, Jessica
+      Kerr, Molly Gibson, and Suzanne Kiihne]
+  latlng: 37.8734481,-122.2563972
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-wise
+  startdate: 2014-04-14
+  url: http://swcarpentry.github.io/2014-04-14-wise/
+  user: swcarpentry
+  venue: Women in Science and Engineering
+- address: Vilvite, Thorm&oslash;hlensgate 51, 5006 Bergen
+  contact: david.fredman@uib.no
+  country: Norway
+  enddate: 2014-04-24
+  humandate: April 23-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Lex Nederbragt, Karin Lagesen, David Fredman]
+  latlng: 60.3812811,5.3291539
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-23-uib
+  startdate: 2014-04-23
+  url: http://elixirno.github.io/2014-04-23-uib/
+  user: elixirno
+  venue: University of Bergen
+- address: Virginia Science and Technology Campus, Ashburn, VA
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-04-30
+  humandate: Apr 29-30, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Joshua R. Herr, William Rowell]
+  latlng: 39.059322,-77.445661
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-29-gwu
+  startdate: 2014-04-29
+  url: http://jrherr.github.io/2014-04-29-gwu/
+  user: jrherr
+  venue: George Washington University
+- address: Mills Library L107, 1280 Main St. W. Hamilton, Ontario
+  contact: devenyga@mcmaster.ca
+  country: Canada
+  enddate: 2014-05-06
+  eventbrite: 11361824523
+  humandate: May 5-6, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson, Gabriel Devenyi]
+  latlng: 43.2627392,-79.9175982
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-05-05-mcmaster
+  startdate: 2014-05-05
+  url: http://gdevenyi.github.io/2014-05-05-mcmaster/
+  user: gdevenyi
+  venue: McMaster University Wong e-Classroom
+- address: Waterfront Campus, European Way, Southampton, Hampshire, SO14 3ZH
+  country: United-Kingdom
+  enddate: 2014-05-09
+  humandate: May 08-09, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Bogdan Vera, Devasena Inupakutika]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  organizer: Maike Sonnewald
+  registration: restricted
+  root: .
+  slug: 2014-05-08-soton
+  startdate: 2014-05-08
+  url: http://DevasenaInupakutika.github.io/2014-05-08-soton/
+  user: DevasenaInupakutika
+  venue: National Oceanography Centre
+- address: One Bungtown Road, Cold Spring Harbor, NY
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-05-13
+  humandate: May 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Will Trimble, Sheldon McKay]
+  latlng: 40.859197,-73.468704
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-05-12-cshl
+  startdate: 2014-05-12
+  url: http://wltrimbl.github.io/2014-05-12-cshl/
+  user: wltrimbl
+  venue: Cold Spring Harbor Laboratory, Hershey Building, east conference room
+- address: Av. Italia, km 8, sala 2106 no pavilhao 2.
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-05-13
+  eventbrite: 11429715587
+  helper: [Marcus Vinicius Freire Guimaraes]
+  humandate: 12 e 13 de Maio, 2014
+  humantime: 8:00 - 17:30
+  instructor: [Raniere Silva, Fernando Mayer]
+  latlng: -32.06811,-52.16238
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-05-12-furg
+  startdate: 2014-05-12
+  url: http://r-gaia-cs.github.io/2014-05-12-furg/
+  user: r-gaia-cs
+  venue: Universidade Federal do Rio Grande
+- address: Mozilla, 366 Adelaide Street West, Toronto
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-05-13
+  humandate: May 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua Ainsley, Abigail Cabunoc, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-12-oicr-toronto
+  startdate: 2014-05-12
+  url: http://swcarpentry.github.io/2014-05-12-oicr-toronto/
+  user: swcarpentry
+  venue: Ontario Institute for Cancer Research
+- address: University of British Columbia, Vancouver, BC
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-05-13
+  humandate: May 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jenny Bryan, Shaun Jackman, Andy Leung]
+  latlng: 49.26508,-123.25378
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-12-ubc
+  startdate: 2014-05-12
+  url: http://jennybc.github.io/2014-05-12-ubc/
+  user: jennybc
+  venue: bioinformatics.ca
+- address: Karolinska Institutet Science Park, Stockholm
+  contact: admin@software-carpentry.org
+  country: Sweden
+  enddate: 2014-05-20
+  humandate: May 19-20, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Konrad Hinsen, Nelle Varoquaux, Karin Lagesen, Lex Nederbragt]
+  latlng: 59.329323,18.068581
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-19-scilifelab
+  startdate: 2014-05-19
+  url: http://gvwilson.github.io/2014-05-19-scilifelab/
+  user: gvwilson
+  venue: Science Life Lab
+- address: Room 620, Administrative and Research Center, 3100 Marine St. Boulder,
+    CO 80309
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-05-23
+  humandate: May 23, 2014
+  humantime: 8:00 am - 5:00 pm
+  instructor: [Aron Ahmadia, Ted Hart]
+  latlng: 40.013187,-105.253465
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-23-csdms
+  startdate: 2014-05-23
+  url: http://geocarpentry.github.io/2014-05-23-csdms/
+  user: geocarpentry
+  venue: Community Surface Dynamics Modeling System Meeting
+- address: SeaCave in the Eckart Bldg, La Jolla, CA
+  contact: ntpierce@ucsd.edu
+  country: United-States
+  enddate: 2014-05-30
+  humandate: May 29-30, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Lasher, Will Trimble, Andrea Zonca]
+  latlng: 32.867307,-117.252586
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-29-ucsd
+  startdate: 2014-05-29
+  url: http://gotgenes.github.io/2014-05-29-ucsd/
+  user: gotgenes
+  venue: Scripps Institution of Oceanography, UC San Diego
+- address: Faculty of Medicine, Nursing and Health Sciences (Krongold Centre (Building
+    5) / Room G19), Wellington Road, Clayton, Victoria 3800
+  contact: Matthew.Dimmock@monash.edu
+  country: Australia
+  enddate: 2014-06-04
+  humandate: Jun 02-04, 2014
+  humantime: 1:00 pm - 5:00 pm
+  instructor: [Matthew Dimmock, Damien Irving]
+  latlng: -37.915211,145.134682
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-02-monash
+  startdate: 2014-06-02
+  url: http://badger-d.github.io/2014-06-02-monash/
+  user: badger-d
+  venue: Monash University
+- address: Pisa
+  contact: admin@software-carpentry.org
+  country: Italy
+  enddate: 2014-06-06
+  humandate: Jun 04-06, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aleksandra Pawlik, Rémi Emonet]
+  latlng: 43.720699,10.408022
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-03-cern
+  startdate: 2014-06-05
+  url: http://apawlik.github.io/2014-06-03-cern/
+  user: apawlik
+  venue: Italian National Institute for Nuclear Physics, Department of Physics, Università
+    di Pisa
+- address: Mann Library, Room B30A<br>237 Mann Drive<br>Ithaca, NY 14853
+  contact: mudrak@cornell.edu
+  country: United-States
+  enddate: 2014-06-05
+  eventbrite: 11562775573
+  humandate: Jun 4-5, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Gabriel A. Devenyi, Jeramia Ory]
+  latlng: 42.449286,-76.476284
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-04-cornell
+  startdate: 2014-06-04
+  url: http://gdevenyi.github.io/2014-06-04-cornell/
+  user: gdevenyi
+  venue: Cornell University
+- address: 20 Konstantinou Kavafi Street, 2121 Aglantzia, Nicosia
+  contact: admin@software-carpentry.org
+  country: Cyprus
+  enddate: 2014-06-11
+  humandate: Jun 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Luis Pedro Coelho, Marios Isaakidis]
+  latlng: 35.164972,33.361289
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-10-cyi
+  startdate: 2014-06-10
+  url: http://luispedro.github.io/2014-06-10-cyi/
+  user: luispedro
+  venue: Cyprus Institute
+- address: Albro-Falconer-Manely Science Center, Room 232, 440 Westview Dr. S.W.,
+    Atlanta, GA 30354
+  contact: hqin@spelman.edu
+  country: United-States
+  enddate: 2014-06-11
+  humandate: Jun 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Will Trimble, Elijah Lowe]
+  latlng: 33.745,-84.409
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-10-spelman
+  startdate: 2014-06-10
+  url: http://wltrimbl.github.io/2014-06-10-spelman/
+  user: wltrimbl
+  venue: Spelman College
+- address: Amman
+  contact: admin@software-carpentry.org
+  country: Jordan
+  enddate: 2014-06-17
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Luis Pedro Coelho, Marios Isaakidis]
+  latlng: 31.956578,35.945695
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-15-khbp
+  startdate: 2014-06-16
+  url: http://luispedro.github.io/2014-06-15-khbp/
+  user: luispedro
+  venue: Ibis Hotel (Open One Meeting Room)
+- address: 888 Columbia Ave, Claremont, CA 91711; Kravis Center, room LC62 (Freeberg
+    Forum)
+  contact: psn@kecksci.claremont.edu
+  country: United-States
+  enddate: 2014-06-17
+  eventbrite: 11558171803
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Preston Holmes, Bill Mills]
+  latlng: 34.102082,-117.711183
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-16-claremont
+  startdate: 2014-06-16
+  url: http://ptone.github.io/2014-06-16-claremont/
+  user: ptone
+  venue: Claremont Colleges
+- address: UCDavis Shields Library
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-17
+  eventbrite: '11471139487'
+  humandate: Jun 16-17, 2014
+  humantime: 8:30 am - 5:00 pm
+  instructor: [Naupaka Zimmerman, Bernhard Konrad, Dav Clark, Andrea Zonca]
+  latlng: 38.5397144,-121.7490892
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-16-davis
+  startdate: 2014-06-16
+  url: http://BernhardKonrad.github.io/2014-06-16-davis/
+  user: BernhardKonrad
+  venue: UC Davis
+- address: CRTP Classroom, 2nd Floor, Hock Plaza, 2424 Erwin Road
+  contact: cliburn.chan@duke.edu
+  country: United-States
+  enddate: 2014-06-17
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Cliburn Chan, Karen Cranston, Joshua Granek]
+  latlng: 36.009706, -78.941628
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-16-duke
+  startdate: 2014-06-16
+  url: http://cliburn.github.io/2014-06-16-duke/
+  user: cliburn
+  venue: Duke University
+- address: 366 Adelaide Street West, Toronto, Ontario
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-06-17
+  eventbrite: 11526822035
+  helper: [Catalina Anghel]
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Pauline Barmby, Jennifer Campbell, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-06-16-toronto
+  startdate: 2014-06-16
+  url: http://swcarpentry.github.io/2014-06-16-toronto/
+  user: swcarpentry
+  venue: Mozilla Toronto
+- address: Bowers Auditorium, Sage Hall, 205 Prospect, New Haven, CT 06511
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-21
+  eventbrite: 11719002853
+  humandate: June 20-21, 2014
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Camille Avestruz, Matthew Lightman]
+  ipythonnotebook: http://nbviewer.ipython.org/urls
+  latlng: 41.317165,-72.923847
+  layout: bootcamp
+  raw: raw.github.com/swcarpentry/bc/gh-pages
+  registration: restricted
+  root: .
+  slug: 2014-06-20-yale
+  startdate: 2014-06-20
+  url: http://cavestruz.github.io/2014-06-20-yale/
+  user: cavestruz
+  venue: Yale University
+- address: Delta Bessborough Hotel, 601 Spadina Crescent East, Saskatoon, SK
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-06-24
+  humandate: Jun 22-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Ian Mitchell]
+  latlng: 52.127165, -106.658892
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-06-22-caims
+  startdate: 2014-06-22
+  url: http://dhavide.github.io/2014-06-22-caims/
+  user: dhavide
+  venue: Canadian Applied and Industrial Mathematics Society
+- address: 1230 York Ave, New York, NY 10065
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-25
+  humandate: June 24-25, 2014
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Camille Avestruz, Tim Cerino, Dan Chen, Ivan Gonzalez]
+  ipythonnotebook: http://nbviewer.ipython.org/urls
+  latlng: 40.76332, -73.955464
+  layout: bootcamp
+  raw: raw.github.com/swcarpentry/bc/gh-pages
+  registration: restricted
+  root: .
+  slug: 2014-06-24-ru
+  startdate: 2014-06-24
+  url: http://cavestruz.github.io/2014-06-24-ru/
+  user: cavestruz
+  venue: Rockefeller University
+- address: Room 08-146AB, Smilow Center for Translational Research, 3400 Civic Center
+    Blvd., Philadelphia
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-25
+  helper: [Alyssa Batula, Maneesha Sane]
+  humandate: Jun 24-25, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dana Bauer, Adina Howe]
+  latlng: 39.94733,-75.193134
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-06-24-wise-penn
+  startdate: 2014-06-24
+  url: http://swcarpentry.github.io/2014-06-24-wise-penn/
+  user: swcarpentry
+  venue: Women in Science and Engineering (Philadelphia)
+- address: Department of Meteorology, Whiteknights, Earley Gate,Reading, RG6 7BE,
+    Berkshire
+  contact: admin@software-carpentry.org, Kathie Bowden (k.e.bowden@reading.ac.uk),
+    <a href="http://www.met.reading.ac.uk/contact.html">Meteorology Dept.</a>
+  country: United-Kingdom
+  enddate: 2014-06-26
+  humandate: June 25-26, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Christina Koch, Devasena Inupakutika]
+  latlng: 51.4419,0.9456
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-25-Reading
+  startdate: 2014-06-25
+  url: http://DevasenaInupakutika.github.io/2014-06-25-Reading/
+  user: DevasenaInupakutika
+  venue: University of Reading
+- address: South bend, IN
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-06-27
+  helper: []
+  humandate: Jun 26-27, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua R. Herr, Sheldon McKay]
+  latlng: 41.705467, -86.235296
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-26-nd
+  startdate: 2014-06-26
+  url: http://jrherr.github.io/2014-06-26-nd/
+  user: jrherr
+  venue: University of Notre Dame
+- address: Li Ka Shing Center at Stanford's Medical School, room LK130
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-07-01
+  humandate: Jun 30-Jul 1, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Paul Ivanov, Naupaka Zimmerman]
+  latlng: 37.431904,-122.175787
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-30-stanford
+  startdate: 2014-06-30
+  url: http://ivanov.github.io/2014-06-30-stanford/
+  user: ivanov
+  venue: Stanford University
+- address: Sobey School of Business, 4th floor, 923 Robie Street, Halifax, NS
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-07-03
+  humandate: Jul 2-3, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Stephanie Gagne]
+  latlng: 44.631627,-63.580168
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-02-smu
+  startdate: 2014-07-02
+  url: http://dhavide.github.io/2014-07-02-smu/
+  user: dhavide
+  venue: Saint Mary's University
+- address: Hilton Garden Inn conference room, 1 Circle Rd, Stony Brook, NY 11794
+  contact: olsonran@msu.edu
+  country: United-States
+  enddate: 2014-07-09
+  humandate: Jul 08-09, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tommy Guy, Randy Olson]
+  latlng: 40.918188, -73.122074
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-08-stonybrook
+  startdate: 2014-07-08
+  url: http://guyrt.github.io/2014-07-08-stonybrook/
+  user: guyrt
+  venue: Stony Brook University
+- address: Rm 3200, 40 St. George Street, University of Toronto
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-07-09
+  eventbrite: 11725123159
+  helper: [Elizabeth Patitsas, Catalina Anghel]
+  humandate: Jul 8-9, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Emily Davenport, Erika Mudrak, Dana Bauer, Camille Avestruz]
+  latlng: 43.659641,-79.396792
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-08-wise-toronto
+  startdate: 2014-07-08
+  url: http://erdavenport.github.io/2014-07-08-wise-toronto/
+  user: erdavenport
+  venue: Women in Science and Engineering (Toronto)
+- address: University Park, NG7 2RD, Nottingham
+  contact: gavin.thomas@sheffield.ac.uk
+  country: United-Kingdom
+  enddate: 2014-07-11
+  helper: []
+  humandate: Jul 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aur Saraf, Devasena Inupakutika]
+  latlng: 52.938636,-1.195158
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-10-Nottingham
+  startdate: 2014-07-10
+  url: http://DevasenaInupakutika.github.io/2014-07-10-Nottingham/
+  user: DevasenaInupakutika
+  venue: The University of Nottingham
+- address: Stanley Milner Library, 7 Sir Winston Churchill Square, Edmonton, AB
+  contact: macdonellc4@macewan.ca
+  country: Canada
+  enddate: 2014-07-11
+  eventbrite: '11668602103'
+  humandate: Jul 10-11, 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Cam Macdonell, Sam Popowich, Dana Ouellette, Vicky Varga]
+  latlng: 53.542948,-113.489552
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-10-epl
+  startdate: 2014-07-10
+  url: http://cmacdonell.github.io/2014-07-10-epl/
+  user: cmacdonell
+  venue: Software Skills for Librarians at EPL
+- address: Frisco, CO, USA
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-07-11
+  helper: []
+  humandate: Jul 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua R. Herr, Fan Yang, Ted M. Hart]
+  latlng: 39.582399, -106.098913
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-10-esip
+  startdate: 2014-07-10
+  url: http://jrherr.github.io/2014-07-10-esip/
+  user: jrherr
+  venue: Federation of Earth Science Information Partners (ESIP) Summer Meeting
+- address: Kenneth C. Rowe Management Building, Room 1014
+  contact: diego.barneche@mq.edu.au
+  country: Canada
+  enddate: 2014-07-15
+  helper: [Daniel Morrison]
+  humandate: Jul 14-15, 2014
+  humantime: 8:00/9:00 am - 6:00/5:00 pm
+  instructor: [Diego Barneche, Gavin Simpson, Ross Dickson]
+  latlng: 44.6372747,-63.5889263
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-14-Dalhousie
+  startdate: 2014-07-14
+  url: http://dbarneche.github.io/2014-07-14-Dalhousie/
+  user: dbarneche
+  venue: Dalhousie University
+- address: Mozilla Toronto, 366 Adelaide Street West, Toronto, Ontario
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-07-16
+  eventbrite: 11727066973
+  helper: [Ruth Collings, Thomas Guignard, Alif Zaman, Orion Buske, Dale Russell]
+  humandate: Jul 15-16, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Abigail Cabunoc, Cam Macdonell, Jennifer Campbell, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-15-toronto
+  startdate: 2014-07-15
+  url: http://swcarpentry.github.io/2014-07-15-toronto/
+  user: swcarpentry
+  venue: Librarians in Toronto
+- address: Portland Hilton, Broadway I and II rooms, 921 SW 6th Ave, Portland, OR
+    97204
+  contact: olsonran@msu.edu
+  country: United-States
+  enddate: 2014-07-18
+  humandate: July 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sheldon McKay, Randy Olson]
+  latlng: 45.5175515,-122.6799365
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-17-aspb
+  startdate: 2014-07-17
+  url: http://swcarpentry.github.io/2014-07-17-aspb/
+  user: swcarpentry
+  venue: American Society of Plant Biologists
+- address: North Campus Research Complex (NCRC)<br/>Building 18, South Atrium<br/>2800
+    Plymouth Rd.
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-07-20
+  humandate: July 19-20, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Carlos Anderson, Leigh Sheneman, Elijah Lowe]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-19-umich
+  startdate: 2014-07-19
+  url: http://redcurry.github.io/2014-07-19-umich/
+  user: redcurry
+  venue: University of Michigan
+- address: Computer Teaching Suite (room 252), Whittle Building (building 52), College
+    Road, Cranfield, MK43 0AL
+  contact: support@archer.ac.uk
+  country: United-Kingdom
+  enddate: 2014-07-23
+  humandate: Jul 21-23, 2014
+  humantime: 9:30 am - 5:00 pm
+  instructor: [Mike Jackson, Andrew Turner, Arno Proeme]
+  latlng: 52.074389,-0.629225
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-21-cranfield
+  startdate: 2014-07-21
+  url: http://hpcarcher.github.io/2014-07-21-cranfield/
+  user: hpcarcher
+  venue: Cranfield University
+- address: 19700 Helix Drive, Ashburn, VA 20147
+  contact: sheldon.mckay@gmail.com
+  country: United-States
+  helper: [Anitha Parvatham, Rob Svirskas, Ben Arthur, Christopher Bruns, Don Olbris,
+    Greg Pinero, Peter Bukowinski]
+  humandate: July 23-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sheldon McKay, William Rowell]
+  latlng: 39.0714096,-77.46427019999999
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-23-jfrc
+  startdate: 2014-07-23
+  url: http://mckays630.github.io/2014-07-23-jfrc/
+  user: mckays630
+  venue: Janelia Farm Research Campus
+- address1: 567 Wilson Road, BPS Room 1441, East Lansing, MI
+  address2: UT Austin, GDC 7.808
+  contact: tkteal@msu.edu
+  country: United-States
+  enddate: 2014-07-25
+  eventbrite1: 11953052903
+  eventbrite2: 11953089011
+  helper: [Alexis Black Pyrkosz, Kevin Hall, Qingpeng Zhang, Ben Johnson, Josh Nahum,
+    April Wright, Nichole Bennett, Kelly Pierce, Jiarong Guo]
+  humandate: July 24-25, 2014
+  humantime: 9:30 am - 5 pm MSU and 8:30 am - 4 pm UT Austin
+  instructor: [Tracy Teal, Christie Bahlai, Josh Herr, Elijah Lowe]
+  latlng: 42.723303,-84.479780
+  layout: bootcamp2
+  raw: raw.github.com/datacarpentry/2014-07-24-beacon/gh-pages
+  registration: open
+  root: .
+  slug: 2014-07-24-beacon
+  startdate: 2014-07-24
+  url: http://datacarpentry.github.io/2014-07-24-beacon/
+  user: datacarpentry
+  venue: MSU BEACON
+  venue1: MSU BEACON
+  venue2: UT Austin BEACON (via teleconference)
+- address: Li Ka Shing Center at Stanford's Medical School, room LK120
+  contact: amyhodge@stanford.edu
+  country: United-States
+  enddate: 2014-07-29
+  eventbrite: '12096909181'
+  helper: [Christian Battista, Chris Beitel, Louise Giam, Amy Hodge, Jillynne Quinn,
+    Kelly Zalocusky]
+  humandate: Jul 28-29, 2014
+  humantime: Jul 28 9:00 am - 5:00 pm </br> Jul 29 10:00 am - 6:00 pm
+  instructor: [Christina Koch, Jens von der Linden]
+  latlng: 37.431904,-122.175787
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-28-stanford
+  startdate: 2014-07-28
+  url: http://jensv.github.io/2014-07-28-stanford/
+  user: jensv
+  venue: Stanford University
+- address: Boardroom, St. Leo's College, St. Lucia, Brisbane
+  contact: philipp.bayer@uqconnect.edu.au
+  country: Australia
+  enddate: 2014-07-31
+  humandate: Jul 30-31, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving, Philipp Bayer, Tim McNamara]
+  latlng: -27.50142,153.01515
+  layout: bootcamp
+  registration: close
+  root: .
+  slug: 2014-07-30-pyconaus
+  startdate: 2014-07-30
+  url: http://philippbayer.github.io/2014-07-30-pyconaus/
+  user: philippbayer
+  venue: PyCon AU / University of Queensland
+- address: 1261 Duck Road Kitty Hawk, NC 27949-4472
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-08-07
+  humandate: August 5-7, 2014
+  humantime: 8:00 am - 5:00 pm
+  instructor: [Aron Ahmadia, Chris Kees]
+  latlng: 36.192977, -75.761568
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-05-frf
+  startdate: 2014-08-05
+  url: http://geocarpentry.github.io/2014-08-05-frf/
+  user: geocarpentry
+  venue: Field Research Facility
+- address: Farrell Teaching and Learning Center, Holden Auditorium and FLTC 214, Saint
+    Louis, MO
+  contact: molly.gibson@wustl.edu
+  country: United-States
+  enddate: 2014-08-12
+  humandate: Aug 11-12, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Molly Gibson, Daniel Chen, Neem Serra, Jessica Kerr, Ariel Rokem]
+  latlng: 38.6350207,-90.2630784
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-11-wustl
+  startdate: 2014-08-11
+  url: http://mollygibson.github.io/2014-08-11-wustl/
+  user: mollygibson
+  venue: Washington University School of Medicine
+- address: Room 419 Light Hall 1301 Medical Center Dr Nashville, TN 37232
+  contact: scott.s.burns@gmail.com
+  country: United-States
+  enddate: 2014-08-13
+  humandate: Aug 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Scott Burns, Chris Fonnesbeck, Firas Wehbe, Daniel Fabbri]
+  latlng: 36.1422857,-86.8020581
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-12-vu
+  startdate: 2014-08-12
+  url: http://vu-bc.github.io/2014-08-12-vu/
+  user: vu-bc
+  venue: Vanderbilt University
+- address: Li Ka Shing Center room 120, 291 Campus Drive, Stanford, CA 94305
+  contact: abostroem@gmail.com
+  country: United-States
+  enddate: 2014-08-15
+  helper: [Matar Haller, Chris Beitel, Ian Korf, Dani Traphagen]
+  humandate: Aug 14-15, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Azalee Bostroem, Chris Lonnen (Lonnen)]
+  latlng: 37.4320382,-122.175779
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-14-stanford
+  startdate: 2014-08-14
+  url: http://abostroem.github.io/2014-08-14-stanford/
+  user: abostroem
+  venue: Stanford University
+- address: Auditório Ministro João Alberto Lins de Barros do CBPF – Rua Lauro Muller,
+    455 – térreo – Botafogo – Rio de Janeiro – RJ
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-08-18
+  helper: []
+  humandate: Aug 18, 2014
+  humantime: 9:00 am - 13:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -22.954318,-43.174687
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-18-ufrj
+  startdate: 2014-08-18
+  url: http://r-gaia-cs.github.io/2014-08-18-ufrj/
+  user: r-gaia-cs
+  venue: Universidade Federal do Rio de Janeiro
+- address: <a href="http://maps.unimelb.edu.au/parkville/building/149">Old Arts building</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-08-27
+  humandate: Aug 18, 25 & 27, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving, Scott Kolbe, Isabell Kiral-Kornek, Bernard Meade]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-18-unimelb
+  startdate: 2014-08-18
+  url: http://resbaz.github.io/2014-08-18-unimelb/
+  user: resbaz
+  venue: University of Melbourne
+- address: Am Botanischen Garten 7, R.E49 - PC-room, Kiel
+  contact: rkiko@geomar.de
+  country: Germany
+  enddate: 2014-08-22
+  helper: [Pieter Vandromme, Pina Springer]
+  humandate: Aug 21-22, 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Rainer Kiko, Bernhard Konrad]
+  latlng: 54.346504, 10.115453
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-21-kiel
+  startdate: 2014-08-21
+  url: http://rkiko.github.io/2014-08-21-kiel/
+  user: rkiko
+  venue: Christian Albrechts University, Kiel
+- address: LRSM Auditorium, 3231 Walnut Street, Philadelphia, PA 19104
+  contact: gvwilson@software-carpentry.org
+  country: United-States
+  enddate: 2014-08-22
+  helper: []
+  humandate: Aug 21-22, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Friedline, R. David Murray]
+  latlng: 39.952803,-75.189727
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-21-upenn
+  startdate: 2014-08-21
+  url: http://swcarpentry.github.io/2014-08-21-upenn/
+  user: swcarpentry
+  venue: University of Pennsylvania
+- address: TTU Media and Communications Building, Room 0152, 15th and Flint, Lubbock,
+    TX
+  contact: eric.bruning@ttu.edu
+  country: United-States
+  enddate: 2014-08-24
+  helper: [Eric Bruning, Vanna Sullivan, Tony Reinhart, Aaron Hill]
+  humandate: Aug 23-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [April Wright, John Fonner]
+  latlng: 33.578205, -101.855120
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-23-ttu
+  startdate: 2014-08-23
+  url: http://wrightaprilm.github.io/2014-08-23-ttu/
+  user: wrightaprilm
+  venue: Texas Tech University
+- address: 3rd Floor Teaching Lab, Wisconsin Institutes for Discovery, 330 N Orchard
+    St, Madison, WI
+  contact: lmichael@wisc.edu
+  country: United-States
+  enddate: 2014-08-26
+  eventbrite: '12454047391'
+  helper: [Anthony Scopatz]
+  humandate: Aug 25-26, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Karl Broman, Matt Gidden, Daijiang Li, Lauren Michael, Paul Wilson]
+  latlng: 43.074974,-89.406738
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-25-wisc
+  startdate: 2014-08-25
+  url: http://UW-Madison-ACI.github.io/2014-08-25-wisc/
+  user: UW-Madison-ACI
+  venue: University of Wisconsin-Madison
+- address: Craik-Marshall Building, University of Cambridge, Downing Site, Cambridge,
+    CB2 3AR
+  contact: cambridge@lists.software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-08-27
+  helper: [Jelena Aleksic, David Molnar]
+  humandate: Aug 26-27, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Rob Beagrie, Thomas Kluyver]
+  latlng: 52.201893,0.12303
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-26-cam
+  startdate: 2014-08-26
+  url: http://rbeagrie.github.io/2014-08-26-cam/
+  user: rbeagrie
+  venue: Cambridge University
+- address: Instituto de Informática prédio 43413(67) - Sala 102.
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-08-29
+  helper: []
+  humandate: Aug 28-29, 2014
+  humantime: 9:00 am - 6:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -30.0762942,-51.1245446
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-28-ufrgs
+  startdate: 2014-08-28
+  url: http://acviana.github.io/2014-08-28-ufrgs/
+  user: acviana
+  venue: Universidade Federal do Rio Grande do Sul (Campus do Vale)
+- address: CCSL-IME/USP, Sala B-7. Rua do Matão, 1010
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-09-02
+  eventbrite: 12386974775
+  helper: []
+  humandate: Set 01-02, 2014
+  humantime: 9:00 am - 6:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -23.558745,-46.731859
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-01-ccsl
+  startdate: 2014-09-01
+  url: http://r-gaia-cs.github.io/2014-09-01-ccsl/
+  user: r-gaia-cs
+  venue: Centro de Competência em Software Livre
+- address: CCSL-IME/USP, Sala B-7. Rua do Matão, 1010
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-09-05
+  eventbrite: 12387143279
+  helper: []
+  humandate: Set 04-05, 2014
+  humantime: 9:00 am - 6:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -23.558745,-46.731859
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-04-ccsl
+  startdate: 2014-09-04
+  url: http://r-gaia-cs.github.io/2014-09-04-ccsl/
+  user: r-gaia-cs
+  venue: Centro de Competência em Software Livre
+- address: Newark, DE, USA
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-09-12
+  helper: [Erin Crowgey, Reza Hammond, Modupe Adetunji, Liang Sun, Matthew Ralston]
+  humandate: Sep 11-12, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua R. Herr, Joshua L. Adelman]
+  latlng: 39.678214, -75.750622
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-11-udel
+  startdate: 2014-09-11
+  url: http://jrherr.github.io/2014-09-11-udel/
+  user: jrherr
+  venue: University of Delaware
+- address: Engineering 6 room 4022, 200 University Ave, Waterloo
+  contact: nmabukhdeir@uwaterloo.ca
+  country: Canada
+  enddate: 2014-09-14
+  helper: [WatPy, SHARCNET]
+  humandate: September 13-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Nasser M Abukhdeir, Pawel Pomorski, Albert O'Connor]
+  latlng: 43.473269, -80.538639
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-13-uwaterloo
+  startdate: 2014-09-13
+  url: http://amjoconn.github.io/2014-09-13-uwaterloo/
+  user: amjoconn
+  venue: Unversity of Waterloo
+- address: <a href="http://maps.unimelb.edu.au/parkville/building/104#.Uw0fhPiLelM">Theatre
+    3, Alan Gilbert Building</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-09-25
+  humandate: Sep 15, 18, 22 & 25, 2014
+  humantime: 1:30 pm - 5:00 pm
+  instructor: [Damien Irving]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-15-unimelb
+  startdate: 2014-09-15
+  url: http://resbaz.github.io/2014-09-15-unimelb/
+  user: resbaz
+  venue: University of Melbourne
+- address: Room 1.51, Royal School of Mines (RSM) Building, South Kensington Campus,
+    Imperial College London, London.
+  contact: support@archer.ac.uk
+  country: United-Kingdom
+  enddate: 2014-09-17
+  humandate: Sep 16-17, 2014
+  humantime: 10:00 am - 5:00 pm
+  instructor: [Mike Jackson, Arno Proeme]
+  latlng: 51.499471,-0.176400
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-16-imperial
+  startdate: 2014-09-16
+  url: http://hpcarcher.github.io/2014-09-16-imperial/
+  user: hpcarcher
+  venue: Imperial College London
+- address: Day 1 - Biological Scienes Learning Center (BSLC) 109; Day 2 - Gordon Center
+    for Integrative Science (GCIS) W301
+  contact: jdblischak@uchicago.edu
+  country: United-States
+  enddate: 2014-09-19
+  helper: [Daniel Rabe, Nick Knoblauch, Suchandra Thapa, Bala Desinghu]
+  humandate: Sep 18-19, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Will Trimble, Emily Davenport, Dan Braithwaite, John Blischak]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-18-chicago
+  startdate: 2014-09-18
+  url: http://jdblischak.github.io/2014-09-18-chicago/
+  user: jdblischak
+  venue: University of Chicago
+- address: 1 Cyclotron Road Berkeley, CA 94720
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-09-23
+  helper: [Kyle Barbary, Yigong Zhang]
+  humandate: Sep 22-23, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Jessica Hamrick, Thomas Kluyver]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-09-22-lbl
+  startdate: 2014-09-22
+  url: http://swcarpentry.github.io/2014-09-22-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley Lab
+- address: 20th and C St NW. Washington DC. (Martin Building Dining Room E)
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-09-25
+  helper: [Açmae El Yacoubi]
+  humandate: Sep 24-25, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ivan Gonzalez, Steve Eddins, Daniel Chen]
+  latlng: 38.892944, -77.044877
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-24-frb
+  startdate: 2014-09-24
+  url: http://chendaniely.github.io/2014-09-24-frb/
+  user: chendaniely
+  venue: Federal Reserve Board
+- address: Earth, Ocean and Atmospheric Sciences, ESB-5108
+  contact: sallen@eos.ubc.ca
+  country: Canada
+  enddate: 2014-08-26
+  helper: [Jordan Aaron, Karina Ramos Musalem, Drew Snauffer, Nancy Soontiens, Kathi
+      Unglert, Kang Wang]
+  host: Susan Allen
+  humandate: Sep 25-26, 2014
+  humantime: 9:00 - 4:00 Thu, 9:00 - 4:30 Fri
+  instructor: [Doug Latornell, Susan Allen]
+  latlng: 49.263,-123.252
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-25-ubc
+  startdate: 2014-09-25
+  url: http://douglatornell.github.io/2014-09-25-ubc/
+  user: douglatornell
+  venue: University of British Columbia
+- address: Life Sciences C-Wing, Room 180/182
+  contact: eric.d.johnson@asu.edu
+  country: United-States
+  enddate: 2014-09-28
+  eventbrite: '13072962583'
+  helper: [To Be Determined]
+  humandate: Sep 27-28, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Jonathan Strootman]
+  latlng: 33.419982, -111.934157
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-27-asu
+  startdate: 2014-09-27
+  url: http://naupaka.github.io/2014-09-27-asu/
+  user: naupaka
+  venue: Arizona State University
+- address: iDigBio at University of Florida, Gainesville, FL
+  contact: data-carpentry@software-carpentry.org
+  country: United-States
+  enddate: 2014-09-30
+  helper: [Dan Stoner, Deborah Paul, Pam Soltis, Derek Masaki, Shari Ellis, Kevin
+      Love, Juliet Pulliam, Tommy Tang, Bernardo Santos, Jonathan Foox]
+  humandate: Sep 29-30, 2014
+  humantime: 8:30 am - 5:30 pm
+  instructor: [Francois Michonneau, Tracy Teal, Matt Collins, Katja Seltmann]
+  latlng: 42.723303,-84.479780
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-29-iDigBio
+  startdate: 2014-09-29
+  url: http://datacarpentry.github.io/2014-09-29-iDigBio/
+  user: datacarpentry
+  venue: University of Florida
+- address: Biomedical and Physical Sciences Building 567 Wilson Road Room 1441 East
+    Lansing, MI 48824 (Seminar Room)
+  contact: jory@msu.edu
+  country: United-States
+  enddate: 2014-10-01
+  eventbrite: 13109602173
+  helper: ['Emily Dolson, Josh Nahum, Eric Bruger']
+  humandate: Sep 30 Oct 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jory Schossau, Leigh Sheneman, Luiz Irber]
+  latlng: 42.724324, -84.476082
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-30-msu
+  startdate: 2014-09-30
+  url: http://joryschossau.github.io/2014-09-30-msu/
+  user: joryschossau
+  venue: Michigan State University
+- <!-- eventbrite: 12933361031 -->
+  address: Innovation Center (Room 105), 2719 E. 10th St., Bloomington, IN
+  contact: igonzalez@mailaps.org
+  country: United-States
+  enddate: 2014-10-07
+  helper: [Badi' Abdul-Wahid, Kevin Bohan, Eric Holk, DongInn Kim]
+  humandate: Oct 6-7, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Ivan Gonzalez, Jeremiah Lant]
+  latlng: 39.171706,-86.499819
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-06-indiana
+  startdate: 2014-10-06
+  url: http://iglpdc.github.io/2014-10-06-indiana/
+  user: iglpdc
+  venue: Indiana University
+- address: 102 Rightmire Hall, 1060 Carmack Rd, Columbus, OH 43210
+  contact: sheldon.mckay@gmail.com
+  country: United-States
+  enddate: 2014-10-07
+  helper: [Jeffrey Campbell, Joy-El Talbot, Eric Mukundi, Wilberforce Ouma]
+  humandate: Oct 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sheldon McKay, Trevor Bekolay]
+  latlng: 40.003486, -83.037452
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-06-osu
+  startdate: 2014-10-06
+  url: http://mckays630.github.io/2014-10-06-osu/
+  user: mckays630
+  venue: Ohio State University
+- address: Rooms 368/374, Rotman School of Management, 105 St. George Street, Toronto,
+    Ontario
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-10-07
+  eventbrite: '13023831631'
+  helper: [Catalina Anghel, Samantha Clark, Thomas Guignard, Tom Wright, Lee Zamparo]
+  humandate: Oct 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Gabriel Devenyi, Tommy Guy, Jeramia Ory, Elizabeth
+      Patitsas, Greg Wilson]
+  latlng: 43.665263,-79.39862
+  layout: bootcamp
+  lessons: [Python, SQL, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-10-06-rotman
+  startdate: 2014-10-06
+  url: http://swcarpentry.github.io/2014-10-06-rotman/
+  user: swcarpentry
+  venue: University of Toronto
+- address: Sloane Physics Lab, Room 43, 217 Prospect Street, New Haven, CT 06511
+  contact: rbsi.yale@gmail.com
+  country: United-States
+  enddate: 2014-10-12
+  eventbrite: 13155403165
+  helper: [Jieming Chen, Wendell Smith, Tomomi Sunayama, Manuel Mai, Dan Guest]
+  humandate: Oct 11-12, 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Camille Avestruz, Matthew Lightman]
+  latlng: 41.3181294,-72.9237981
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-10-11-yale
+  startdate: 2014-10-11
+  url: http://mattphotonman.github.io/2014-10-11-yale/
+  user: mattphotonman
+  venue: Yale University
+- address: HBH 227; 6100 Main St. Houston, TX 77204
+  contact: rcsg@rice.edu
+  country: United-States
+  enddate: 2014-10-14
+  eventbrite: 13095572209
+  helper: [Joseph Ghobrial, Erik Engquist]
+  humandate: Oct 13-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [April Wright, Chandler Wilkerson, Scott Talafuse]
+  latlng: 29.719960, -95.400902
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-13-rice
+  startdate: 2014-10-13
+  url: http://chwilk.github.io/2014-10-13-rice/
+  user: chwilk
+  venue: Rice University
+- address: Gerstein Library, 9 King's College Circle, Toronto, Ontario
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-10-31
+  eventbrite: 13047803331
+  helper: [Xu Fei, Luke Johnston, Daiva Nielsen, Sahar Rahmani, Tom Wright]
+  humandate: Oct 30-31, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Pauline Barmby, Thomas Guignard, Greg Wilson]
+  latlng: 43.662152,-79.394085
+  layout: bootcamp
+  lessons: [Python, SQL, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-10-30-utoronto
+  startdate: 2014-10-30
+  url: http://swcarpentry.github.io/2014-10-30-utoronto/
+  user: swcarpentry
+  venue: University of Toronto
+- address: Law School Seminar Room 444 (upstairs from the Law School Bar)
+  contact: diego.barneche@mq.edu.au
+  country: Australia
+  enddate: 2014-11-01
+  helper: [Sarah McIntyre, Steson Lo]
+  hostcontact: alex.holcombe@sydney.edu.au
+  humandate: Oct 31-Nov 1, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Diego Barneche, Philipp Bayer, Dan Warren]
+  instructorcontact: diego.barneche@mq.edu.au
+  latlng: -33.887526,151.190262
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-31-USyd
+  startdate: 2014-10-31
+  url: http://dbarneche.github.io/2014-10-31-USyd/
+  user: dbarneche
+  venue: University of Sydney
+- address: James L. Allen Center, 2169 Campus Drive, Evanston, IL 60208-2800
+  contact: edd@debian.org
+  country: United-States
+  enddate: 2014-11-01
+  helper: [' ']
+  humandate: Oct 31 - Nov 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Karthik Ram, Ramnath Vaidyanathan, Dirk Eddelbuettel]
+  latlng: 42.056459,-87.675267
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-31-nw
+  startdate: 2014-10-31
+  url: http://karthik.github.io/2014-10-31-nw/
+  user: karthik
+  venue: Northwestern University
+- address: Winterthurerstrasse 190
+  contact: admin@software-carpentry.org
+  country: Switzerland
+  enddate: 2014-11-07
+  helper: [Frank Pennekamp, Peter Fields, Jelena Aleksic]
+  humandate: Nov 6-7, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Laurent Gatto, Robert Stojnic]
+  latlng: 47.396018,8.5524058
+  layout: workshop
+  lessons: [R, Git, bash]
+  registration: restricted
+  root: .
+  slug: 2014-11-06-UZH
+  startdate: 2014-11-06
+  url: http://lgatto.github.io/2014-11-06-UZH/
+  user: lgatto
+  venue: Institute of Molecular Life Sciences, University of Zurich
+- address: Faculté de médecine vétérinaire de l'Université de Montréal, St-Hyacinthe,
+    QC
+  contact: denis.haine@umontreal.ca
+  country: Canada
+  enddate: 2014-11-07
+  helper: []
+  humandate: Nov 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [John D. Blischak, Denis Haine, Marianne Corvellec, Gabriel Devenyi]
+  latlng: 45.619605,-72.963607
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-11-06-fmv
+  startdate: 2014-11-06
+  url: http://dhaine.github.io/2014-11-06-fmv/
+  user: dhaine
+  venue: GREZOSP
+- address: 60 Garden Street, Cambridge, MA 02138
+  contact: iglpdc+harvard@gmail.com
+  country: United-States
+  enddate: 2014-11-08
+  helper: [Christopher Erdmann, Bob Freeman, Jean Roth, Peter Williams]
+  humandate: Nov 7-8, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Daniel Chen, Ivan Gonzalez]
+  latlng: 42.382136, -71.127843
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-11-07-harvard
+  startdate: 2014-11-07
+  url: http://iglpdc.github.io/2014-11-07-harvard/
+  user: iglpdc
+  venue: Research Computing & Harvard-Smithsonian Center for Astrophysics, Harvard
+    University
+- address: 29 Grafton Street, Manchester, M13 9WU
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-11-14
+  helper: ['Andy Brass, Mike Cornell']
+  humandate: Nov 10-14, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aleksandra Pawlik, Aleksandra Nenadic]
+  latlng: 53.463651,-2.227592
+  layout: workshop
+  lessons: [Python, Git, Bash, VM]
+  registration: restricted
+  root: .
+  slug: 2014-11-10-manchester
+  startdate: 2014-11-10
+  url: http://anenadic.github.io/2014-11-10-manchester/
+  user: anenadic
+  venue: The Nowgen Centre, University of Manchester
+- address: EMBL Heidelberg
+  contact: admin@software-carpentry.org
+  country: Germany
+  enddate: 2014-11-14
+  helper: []
+  humandate: Nov 12-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Luis Pedro Coelho]
+  latlng: 49.38485,8.71074
+  layout: redirect
+  lessons: [Python, Git, Bash]
+  redirect: http://www.embl.de/training/events/2014/SWC14-01/index.html
+  registration: open
+  root: .
+  slug: 2014-11-12-embl
+  startdate: 2014-11-12
+  url: http://swcarpentry.github.io/2014-11-12-embl/
+  user: swcarpentry
+  venue: European Molecular Biology Laboratory
+- address: Charles Thackrah Building, University of Leeds, Leeds, LS2 9JT
+  contact: a.walker@leeds.ac.uk
+  country: United-Kingdom
+  enddate: 2014-11-26
+  helper: [Aaron O'Leary, Peter Willetts, Marlene Mengoni, Jo Leng]
+  humandate: Nov 24-26, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Martin Callaghan, Devasena Inupakutika, Andrew Walker]
+  latlng: 53.8070,-1.5607
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-11-24-leeds
+  startdate: 2014-11-24
+  url: http://andreww.github.io/2014-11-24-leeds/
+  user: andreww
+  venue: NERC / University of Leeds
+- address: Atlas 1-2 Room, Kilburn Building, Oxford Road, M13 9PL Manchester
+  contact: data-carpentry@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-11-28
+  eventbrite: 13760815971
+  helper: ['Ian Dunlop, Aleksandra Nenadic, Christian Brenninkmeijer']
+  humandate: Nov 27-28, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aleksandra Pawlik, Shoaib Sufi, Alejandra Gonzalez-Beltran]
+  latlng: 53.467293, -2.233876
+  layout: bootcamp2
+  registration: open
+  root: .
+  slug: 2014-11-27-elixiruk-manchester
+  startdate: 2014-11-27
+  url: http://apawlik.github.io/2014-11-27-elixiruk-manchester/
+  user: apawlik
+  venue: University of Manchester
+- address: TS 3B and TS 3C, Snape Building, Upper Campus
+  contact: admin@software-carpentry.org
+  country: South-Africa
+  enddate: 2014-11-28
+  helper: [Dane Kennedy (CSIR), Hein de Jager (UCT), Ashley Rustin (UCT), David Matten
+      (SU), Armin Deffur (UCT), Anelda van der Walt (UCT), Warren Jacobus (UWC), Chris
+      Mitsengu (UCT), Gustavo Salazar (UCT), Jon Ambler (UCT), Benjamin Hugo (UCT),
+    Jon Zwart (UCT), Adrianna Pinska (UCT), Timothy Povall (UCT)]
+  humandate: Nov 27-28, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: ['Jonah Duckles (University of Oklahoma, USA)', 'James Hetherington
+      (University College London, UK)', '', 'David Merand (University of the Witwatersrand,
+      South Africa)']
+  latlng: -33.9574965,18.4622421
+  layout: bootcamp
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-11-27-uct
+  startdate: 2014-11-27
+  url: http://jduckles.github.io/2014-11-27-uct/
+  user: jduckles
+  venue: University of Cape Town
+- address: Room 3217, James Clerk Maxwell Building, Peter Guthrie Tait Road, Edinburgh,
+    EH9 3FD
+  contact: support@archer.ac.uk
+  country: United-Kingdom
+  enddate: 2014-12-04
+  helper: [Emmanouil Farsarakis, Leighton Pritchard, Peter Cock]
+  humandate: Dec 3-4, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Mike Jackson, Arno Proeme, Mario Antonioletti, Alistair Grant]
+  latlng: 55.921628,-3.174155
+  layout: workshop
+  lessons: [Git, Python, VM]
+  registration: open
+  root: .
+  slug: 2014-12-03-edinburgh
+  startdate: 2014-12-03
+  url: http://hpcarcher.github.io/2014-12-03-edinburgh/
+  user: hpcarcher
+  venue: The University of Edinburgh
+- address: ul. Kawiory 21, 30-055 Kraków
+  contact: admin-uk@software-carpentry.org
+  country: Poland
+  enddate: 2014-12-07
+  eventbrite: 14426226231
+  helper: ['Barbara Szczygieł, Iwona Grelowska, Patrycja Radaczyńska, Anna Ślimak']
+  humandate: 6-7 Dec 2014
+  humantime: 9:30  - 17:30
+  instructor: [Paulina Lach, Aleksandra Pawlik]
+  latlng: 50.0677112,19.9124284
+  layout: workshop
+  lessons: [Python, SQL, Git, Bash]
+  registration: open
+  root: .
+  slug: 2014-12-06-wise-krakow
+  startdate: 2014-12-06
+  url: http://apawlik.github.io/2014-12-06-wise-krakow/
+  user: apawlik
+  venue: Women in Science and Engineering
+- address: Theatre 2, Alan Gilbert
+  contact: scottcr@unimelb.edu.au
+  country: Australia
+  enddate: 2014-12-09
+  etherpad: https://etherpad.mozilla.org/2014-12-08-combine-r
+  helper: [Andrew Lonsdale, Harriet Dashnow, Timothy Rice, Noel Faux, Simon Gladman,
+    Pip Griffin, Alistair Walsh]
+  humandate: Dec 8-9, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Scott Ritchie, Damien Irving]
+  latlng: -37.800138,144.959285
+  layout: workshop
+  root: .
+  slug: 2014-12-08-combine-r
+  startdate: 2014-12-08
+  url: http://resbaz.github.io/2014-12-08-combine-r/
+  user: resbaz
+  venue: University of Melbourne
+- address: Auditório do BEG, CCB. Entrada para o campus fica na esquina entre a Rua
+    Professor Lauro Caldeira de Andrara e a Rua João Pio Duarte Silva - entrada do
+    bairro Córrego Grande). Nos prédios do CCB (MIP), procure o segundo bloco, andar
+    térreo, corredor da direita, última sala do corredor
+  contact: diego.barneche@mq.edu.au
+  country: Brazil
+  enddate: 2014-12-12
+  etherpad: https://etherpad.mozilla.org/SWC-UFSC
+  helper: ['']
+  humandate: Dez 11-12, 2014
+  humantime: 8:00 am - 5:30 pm
+  instructor: [Diego Barneche, Raniere Silva]
+  latlng: -27.59803,-48.51514
+  layout: workshop
+  root: .
+  slug: 2014-12-11-ufsc
+  startdate: 2014-12-11
+  url: http://dbarneche.github.io/2014-12-11-ufsc/
+  user: dbarneche
+  venue: Universidade Federal de Santa Catarina
+- address: Lab 323, Kelvin Building, G12 8SU
+  contact: alistair.grant@ed.ac.uk
+  country: United-Kingdom
+  enddate: 2014-12-12
+  helper: [Paul Mullen, Sean Leavey, Gavin Kirby]
+  humandate: Dec 11-12, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Alistair Grant, Norman Gray]
+  latlng: 55.871709,-4.291651
+  layout: workshop
+  root: .
+  slug: 2014-12-11-ugsupa
+  startdate: 2014-12-11
+  url: http://supa-uk.github.io/2014-12-11-ugsupa/
+  user: supa-uk
+  venue: University of Glasgow
+- address: Room 240, Searle Chemistry Lab, 5735 S. Ellis Ave, Chicago, IL 60637
+  contact: balamurugan@uchicago.edu
+  country: United-States
+  enddate: 2014-12-17
+  helper: [Anna Olson]
+  humandate: Dec 15-17, 2014
+  humantime: 8:30 am - 4:30 pm (Day 1), 8.30 am - 4.30 pm (Day 2), 8.30 am - 11.00
+    am (Day 3)
+  instructor: ['Bala Desinghu, Suchandra Thapa, David Champion, Lincoln Bryant, Rob
+      Gardner']
+  latlng: 41.790743, -87.601077
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-12-15-UChicago
+  startdate: 2014-12-15
+  url: http://SWC-OSG-Workshop.github.io/2014-12-15-UChicago/
+  user: SWC-OSG-Workshop
+  venue: University of Chicago
+- address: 1 Cyclotron Road, Berkeley, CA
+  contact: nlucido@lbl.gov
+  country: United-States
+  enddate: 2014-12-17
+  helper: [Sam Penrose]
+  humandate: Dec 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jens von der Linden, Andrea Zonca, Chris Holdgraf]
+  latlng: 37.8706976,-122.30098
+  layout: workshop
+  root: .
+  slug: 2014-12-16-lbl
+  startdate: 2014-12-16
+  url: http://zonca.github.io/2014-12-16-lbl/
+  user: zonca
+  venue: Lawrence Berkeley National Lab
+- Registration: restricted
+  address: SPL Rm. 48, Sloane Physics Laboratory, 217 Prospect St, New Haven, CT
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-12-19
+  helper: [Camille Avestruz, Tomomi Sunayama, Nick Sawyer, Jieming Chen, Luis Vargas]
+  humandate: Dec. 18-19, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Robert Till]
+  latlng: 41.317623, -72.923169
+  layout: workshop
+  lessons: [Matlab, SQL, Bash]
+  root: .
+  slug: 2014-12-18-yale
+  startdate: 2014-12-18
+  url: http://dhavide.github.io/2014-12-18-yale/
+  user: dhavide
+  venue: Yale University
+- address: Room 609, Seattle Convention Center, Seattle WA
+  contact: kabostroem@ucdavis.edu
+  country: United-States
+  enddate: 2015-01-04
+  helper: [Pauline Barmby, Sophie Clayton, Jens von der Linden]
+  humandate: Jan 3-4, 2015
+  humantime: 9:00 am - 5:30 pm
+  instructor: [Azalee Bostroem, Erik Bray, Matt Davis, Phil Rosenfield]
+  latlng: 47.6117,-122.3325
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: open
+  root: .
+  slug: 2015-01-03-aas
+  startdate: 2015-01-03
+  url: http://abostroem.github.io/2015-01-03-aas/
+  user: abostroem
+  venue: American Astronomical Society 225th Meeting
+- &id1306
+  address: Mathematics Building, Room 135, UC Boulder
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2015-01-06
+  eventbrite: 14752447969
+  humandate: Jan 5-6, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Christina Koch, Mariela Perignon, Rachel Slaybaugh, Leah Wasser]
+  latlng: 40.00796,-105.264317
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-05-wise-cuboulder
+  startdate: 2015-01-05
+  url: http://christinalk.github.io/2015-01-05-wise-cuboulder/
+  user: christinalk
+  venue: Women in Science and Engineering, University of Colorado
+- &id1307
+  address: North Campus Research Complex, Building 10 Room G064 and the South Atrium,
+    2800 Plymouth Road, Ann Arbor, MI
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2015-01-06
+  helper: [Alyxandria Schubert, Iris Holmes, Marian Schmidt, Michelle Berry]
+  humandate: Jan 5-6, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sarah Supp, Kara Woo, Christie Bahlai, Dana Bauer]
+  latlng: 42.29932560385452,-83.70677590370178
+  layout: workshop
+  lessons: [R, SQL, Git, Bash, VM]
+  registration: restricted
+  root: .
+  slug: 2015-01-05-wise-umich
+  startdate: 2015-01-05
+  url: http://danabauer.github.io/2015-01-05-wise-umich/
+  user: danabauer
+  venue: Women in Science and Engineering, University of Michigan
+- &id1308
+  address: 3100 Marine Street, Boulder, CO 80309
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2015-01-09
+  humandate: Jan 7-9, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aron Ahmadia, Chris Kees]
+  latlng: 40.013294, -105.251890
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2015-01-07-instaar
+  startdate: 2015-01-07
+  url: http://geocarpentry.github.io/2015-01-07-instaar/
+  user: geocarpentry
+  venue: Institute of Arctic and Alpine Research (INSTAAR), Room 620
+- &id1309
+  address: null
+  contact: imunoz@sesync.org
+  country: United-States
+  enddate: 2015-01-09
+  helper: [Sean Davis]
+  humandate: Jan 8-9, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ian Munoz, Daniel Chen]
+  latlng: 39.00281, -77.10444
+  layout: workshop
+  lessons: [R, Python, SQL, Git, Bash, VM]
+  registration: restricted
+  root: .
+  slug: 2015-01-08-NIH
+  startdate: 2015-01-08
+  url: http://ianamunoz.github.io/2015-01-08-NIH/
+  user: ianamunoz
+  venue: National Institutes of Health Library
+- &id1310
+  address: 1050 Massachusetts Ave., Cambridge,  2nd floor Conference Room
+  contact: tjc.swc@gmail.com
+  country: United-States
+  enddate: 2015-01-09
+  helper: [Matthew Lamberti]
+  humandate: Jan 8-9, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Tim Cerino, Ivan Gonzalez]
+  latlng: 42.369970, -71.113038
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-08-nber
+  startdate: 2015-01-08
+  url: http://Koltrane.github.io/2015-01-08-nber/
+  user: Koltrane
+  venue: National Bureau of Economic Research
+- &id1311
+  address: ERC 1058, UOIT, 2000 Simcoe St N, Oshawa, ON
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2015-01-09
+  helper: ['Jessica Cervi, Kevin Green']
+  humandate: Jan 8-9, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Catalina Anghel, Dhavide Aruliah, Thomas Wright]
+  latlng: 43.945879, -78.896292
+  layout: workshop
+  lessons: [Python, SQL, Git, Bash]
+  registration: open
+  root: .
+  slug: 2015-01-08-uoit
+  startdate: 2015-01-08
+  url: http://dhavide.github.io/2015-01-08-uoit/
+  user: dhavide
+  venue: University of Ontario Institute of Technology
+- &id1312
+  address: Sonntag Pavilion, St. Joseph's Hospital. 350 West Thomas Rd, Phoenix, AZ
+    85013
+  contact: sammankin@gmail.com
+  country: United-States
+  enddate: 2015-01-11
+  helper: [To be determined]
+  humandate: Jan 10-11, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Jonathan Strootman]
+  latlng: 33.480726,-112.079483
+  layout: workshop
+  lessons: [R, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-10-st_josephs
+  startdate: 2015-01-10
+  url: http://naupaka.github.io/2015-01-10-st_josephs/
+  user: naupaka
+  venue: St. Joseph’s Hospital and Medical Center
+- &id1313
+  address: Stanley Hall Room 044, 801 National Road West, Richmond, IN 47374
+  contact: jeremiahlant@gmail.com
+  country: United-States
+  enddate: 2015-01-12
+  helper: [Michael Lerner, Charlie Peck, Demian Riccardi]
+  humandate: Jan 11-12, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jeremiah Lant, Jonah Duckles]
+  latlng: 39.823910, -84.913179
+  layout: workshop
+  lessons: [Python, Bash, Git, SQL]
+  registration: restricted
+  root: .
+  slug: 2015-01-11-earlham
+  startdate: 2015-01-11
+  url: http://jlant.github.io/2015-01-11-earlham/
+  user: jlant
+  venue: Earlham College
+- &id1314
+  address: Wellcome Trust for Human Genetics, Roosevelt Drive, Oxford, OX3 7BN
+  contact: jane.charlesworth@ndm.ox.ac.uk
+  country: United-Kingdom
+  enddate: 2015-01-14
+  eventbrite: 14958184332
+  helper: [Tom Smith, Mike Morgan, Jane Charlesworth]
+  humandate: Jan 13-14, 2015
+  humantime: 9:30 am - 4:30 pm
+  instructor: [Philip Fowler]
+  latlng: 51.752110,-1.215238
+  layout: workshop
+  lessons: [Python, Git, Shell, SQL]
+  registration: restricted
+  root: .
+  slug: 2015-01-13-oxford
+  startdate: 2015-01-13
+  url: http://philipwfowler.github.io/2015-01-13-oxford/
+  user: philipwfowler
+  venue: Oxford University
+- address: School of Earth and Environment, University of Leeds, Leeds, LS2 9JT
+  contact: a.walker@leeds.ac.uk
+  country: United-Kingdom
+  enddate: 2015-01-16
+  helper: [Jo Leng, Grace Cox]
+  humandate: Jan 14-16, 2015
+  humantime: 9:00 am - 5:30 pm
+  instructor: [Martin Callaghan, Aleksandra Pawlik, Andrew Walker, Aaron O'Leary,
+    Peter Willetts]
+  latlng: 53.8052724,-1.5554359
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2015-01-14-leeds
+  startdate: 2015-01-14
+  url: http://andreww.github.io/2015-01-14-leeds/
+  user: andreww
+  venue: NERC / University of Leeds
+- address: Atmospheric Oceanic and Planetary Physics Department, Dobson Room, Atmospheric
+    Physics Building, Sherrington Road, Oxford
+  contact: jamesallen0108@gmail.com
+  country: United-Kingdom
+  enddate: 2015-01-15
+  helper: [Edward Doddridge, Russell Jones]
+  humandate: Jan 14-15, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [James Allen, TBD]
+  latlng: 51.759155,-1.25596
+  layout: workshop
+  root: .
+  slug: 2015-01-14-oxford
+  startdate: 2015-01-14
+  url: http://jpallen.github.io/2015-01-14-oxford/
+  user: jpallen
+  venue: University of Oxford
+- address: 2119 Hornbake South, College Park, MD
+  contact: msmorul@sesync.org
+  country: United-States
+  enddate: 2015-01-16
+  eventbrite: https://www.eventbrite.com/e/umd-data-carpentry-tickets-14847664765
+  helper: [Donal Heidenblad, Andrea Wiggins, Susan Winters]
+  humandate: Jan 15-16, 2015
+  humantime: 9:00 am - 5 pm
+  instructor: [Ian Munoz, Mike Smorul]
+  latlng: 38.988202,-76.941699
+  layout: bootcamp
+  raw: raw.github.com/sesync-ci/2015-01-15-umd/gh-pages
+  registration: open
+  root: .
+  slug: 2015-01-15-umd
+  sponsors: SESYNC and Maryland's iSchool
+  startdate: 2015-01-15
+  url: http://sesync-ci.github.io/2015-01-15-umd/
+  user: sesync-ci
+  venue: University of Maryland
+- address: Seattle, WA
+  contact: bmarwick@uw.edu
+  country: United-States
+  enddate: 2015-01-16
+  eventbrite: 14655221161
+  helper: [Tania Melo, Tiffany Timbers, Earle Wilson]
+  humandate: Jan 15-16, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Russell Alleen-Willems, Becca Blakewood, Tyler Fox, Tracy Fuentes,
+    Emilia Gan, Esther Le Grezause, Chungho Kim, Jens von der Linden, Maria Mckinley,
+    Ben Marwick, Jaclyn Saunders, Peter Schmiedeskamp, Rachael Tatman, Sam White]
+  latlng: 47.655481,-122.305098
+  layout: workshop
+  lessons: [R, Python, SQL, Git, Bash]
+  registration: open
+  root: .
+  slug: 2015-01-15-uw
+  startdate: 2015-01-15
+  url: http://sophieclayton.github.io/2015-01-15-uw/
+  user: sophieclayton
+  venue: University of Washington
+- address: New Orleans, Louisiana
+  contact: cogrady@tulane.edu
+  country: United-States
+  enddate: 2015-01-27
+  eventbrite: 14944695988
+  helper: [To Be Determined]
+  humandate: Jan 26 - 27, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Nichole Bennett]
+  latlng: 29.936756,-90.122193
+  layout: workshop
+  lessons: [R, SQL, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-26-tulane
+  startdate: 2015-01-26
+  url: http://naupaka.github.io/2015-01-26-tulane/
+  user: naupaka
+  venue: Tulane Univeristy
+- address: Multi-media Room, Peter Gilgan Centre for Research and Learning, 686 Bay
+    Street, Toronto, Ontario, M5G 0A4
+  contact: thomas.wright@sickkids.ca
+  country: Canada
+  enddate: 2015-01-30
+  etherpad: https://etherpad.mozilla.org/2015-01-29-sickkids
+  eventbrite: '14777984349'
+  helper: [Xu Fei, Luke Johnston, Daiva Nielsen, Sahar Rahmani]
+  humandate: Jan 29-30, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tom Wright, Greg Wilson, Elizabeth Patitsas]
+  latlng: 43.65,-79.38
+  layout: workshop
+  root: .
+  slug: 2015-01-29-sickkids
+  startdate: 2015-01-29
+  url: http://tomwright01.github.io/2015-01-29-sickkids/
+  user: tomwright01
+  venue: The Hospital For Sick Children
+- address: NCSA 1030, 1205 W Clark St, Urbana, IL
+  contact: training@cse.illinois.edu
+  country: United-States
+  enddate: 2015-01-30
+  etherpad: https://etherpad.mozilla.org/OR1ObWDaah
+  eventbrite: 10121948019
+  helper: [David LeBauer]
+  humandate: Jan 29-30, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Neal Davis, Ivan Gonzalez, Matthew Turk]
+  latlng: 40.093692, -88.237606
+  layout: workshop
+  root: .
+  slug: 2015-01-29-uiuc
+  startdate: 2015-01-29
+  url: http://uiuc-cse.github.io/2015-01-29-uiuc/
+  user: uiuc-cse
+  venue: University of Illinois
+- address: Room C24 in the Sackville St Building, Sackville Street, Manchester
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2015-02-04
+  helper: [Shoaib Sufi]
+  humandate: Feb 03-04, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aleksandra Pawlik]
+  latlng: 53.4773,-2.2374
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2015-02-03-CDT-reg-medicine
+  startdate: 2015-02-03
+  url: http://apawlik.github.io/2015-02-03-CDT-reg-medicine/
+  user: apawlik
+  venue: EPSRC & MRC Centre for Doctoral Training in Regenerative Medicine, University
+    of Manchester
+- address: Sidney Myer Asia Centre
+  contact: isa.kiral@gmail.com
+  country: Australia
+  enddate: 2015-02-17
+  etherpad: https://etherpad.mozilla.org/2015-02-16-resbaz-matlab
+  helper: [Bryan Paton, Kerry Halupka, Andrew Boyd, Gregory Bass]
+  humandate: Feb 16-17, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Isabell Kiral-Kornek, Scott Kolbe, Bill Mills]
+  latlng: -37.799243, 144.964422
+  layout: workshop
+  root: .
+  slug: 2015-02-16-resbaz-matlab
+  startdate: 2015-02-16
+  url: http://resbaz.github.io/2015-02-16-resbaz-matlab/
+  user: resbaz
+  venue: University of Melbourne
+- address: Sidney Myer Asia Centre
+  contact: irving.damien@gmail.com
+  country: Australia
+  enddate: 2015-02-17
+  etherpad: https://etherpad.mozilla.org/2015-02-16-resbaz-python
+  helper: [Thomas Coudrat, Sam Hames, Michael Imelfort, Robert Johnson, Tom Remenyi,
+    John Rugis, Alistair Walsh, Constantine Zakkaroff, Errol Lloyd, Sung Bae]
+  humandate: Feb 16-17, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving]
+  latlng: -37.799243, 144.964422
+  layout: workshop
+  root: .
+  slug: 2015-02-16-resbaz-python
+  startdate: 2015-02-16
+  url: http://resbaz.github.io/2015-02-16-resbaz-python/
+  user: resbaz
+  venue: University of Melbourne
+- address: Sidney Myer Asia Centre
+  contact: scottcr@unimelb.edu.au
+  country: Australia
+  enddate: 2015-02-17
+  etherpad: https://etherpad.mozilla.org/2015-02-16-resbaz-r
+  helper: [Areej Alsheikh-Hussain, Noel Faux, Pip Griffin, Andrew Lonsdale, Jack Simpson,
+    Mike Sumner]
+  humandate: Feb 16-17, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Scott Ritchie]
+  latlng: -37.799243, 144.964422
+  layout: workshop
+  root: .
+  slug: 2015-02-16-resbaz-r
+  startdate: 2015-02-16
+  url: http://resbaz.github.io/2015-02-16-resbaz-r/
+  user: resbaz
+  venue: University of Melbourne
+- address: BIO5 Institute, Keating Bioresearch Bldg, Room 103, 1657 East Helen Street,
+    Tucson, AZ 85721
+  contact: naupaka@gmail.com
+  country: United-States
+  enddate: 2015-02-22
+  eventbrite: 15013479722
+  helper: [Blake Joyce, John McMullin, Andre Mercer, Uwe Hilgert]
+  humandate: Feb 21-22, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Jonathan Strootman]
+  latlng: 32.2375235,-110.9470173
+  layout: workshop
+  lessons: [R, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-02-21-iplant
+  startdate: 2015-02-21
+  url: http://naupaka.github.io/2015-02-21-iplant/
+  user: naupaka
+  venue: iPlant Collaborative, University of Arizona
+- address: Planning Studio, Rooms 314 & 315, Level 3, Steele Building
+  contact: irving.damien@gmail.com
+  country: Australia
+  enddate: 2015-07-14
+  etherpad: https://etherpad.mozilla.org/2015-07-13-amos
+  helper: [Scott Wales, Hol Wolff]
+  humandate: Jul 13-14, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving, Rob Johnson, Nic Hannah]
+  latlng: -27.497257,153.014473
+  layout: workshop
+  root: .
+  slug: 2015-07-13-amos
+  startdate: 2015-07-13
+  url: http://damienirving.github.io/2015-07-13-amos/
+  user: damienirving
+  venue: University of Queensland
+workshops_num_upcoming: 23
+workshops_upcoming:
+- *id1305
+- *id1306
+- *id1307
+- *id1308
+- *id1309
+- *id1310
+- *id1311
+- *id1312
+- *id1313
+- *id1314

--- a/_dashboard_cache.yml
+++ b/_dashboard_cache.yml
@@ -1,0 +1,222 @@
+num_issues: 99
+num_repos: 13
+records:
+- description: Introduction to the Unix shell
+  ident: swcarpentry/shell-novice
+  issues:
+  - {number: 37, title: copied references from glossary, updated: '2014-12-29', url: 'https://github.com/swcarpentry/shell-novice/pull/37'}
+  - {number: 36, title: 'index.md: Fill in the Prerequisites FIXME', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/36'}
+  - {number: 35, title: '06-find.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/35'}
+  - {number: 34, title: '05-script.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/34'}
+  - {number: 33, title: '04-loop.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/33'}
+  - {number: 32, title: '03-pipefilter.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/32'}
+  - {number: 31, title: '02-filedir.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/31'}
+  - {number: 30, title: '01-filedir.md: Fill in FIXME challenge titles', updated: '2014-12-19',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/30'}
+  - {number: 29, title: Dead link to discussion.html, updated: '2014-12-18', url: 'https://github.com/swcarpentry/shell-novice/issues/29'}
+  - {number: 28, title: 'Suggested small fixes for the Unix Shell Loops lesson ',
+    updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/28'}
+  - {number: 25, title: removed empty spaces in 02-create.md, updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/25'}
+  - {number: 24, title: Add man page nav instructions & word boundary info, updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/24'}
+  - {number: 23, title: Small changes in shell course for an assignment of the instructor's
+      training, updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/23'}
+  - {number: 22, title: 'Minor edit: Spell out significance of the trash bin.', updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/22'}
+  - {number: 21, title: ' Correcting images to match text description in 01-filedir.md
+      file #873 ', updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/21'}
+  - {number: 20, title: Update 02-create.md, updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/20'}
+  - {number: 18, title: Csh and its incompatibility with bash mentioned, updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/18'}
+  - {number: 16, title: Csh and its incompatibility with bash mentioned, updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/16'}
+  - {number: 12, title: Proposed changes to the shell directories lesson (assignment),
+    updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/12'}
+  - {number: 8, title: Turn the 1st shell 02-create challenge into MCQ, updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/8'}
+  - {number: 7, title: added div statements to 01-filedir lesson that center images
+      (refactor t..., updated: '2014-12-17', url: 'https://github.com/swcarpentry/shell-novice/pull/7'}
+  - {number: 5, title: Add in a diagram showing redirects and pipes, updated: '2014-12-17',
+    url: 'https://github.com/swcarpentry/shell-novice/pull/5'}
+  - {number: 26, title: Remove mentions of man pages, updated: '2014-12-16', url: 'https://github.com/swcarpentry/shell-novice/issues/26'}
+  - {number: 14, title: Remove auto-generated files from version control and find
+      sources for downloaded data., updated: '2014-11-09', url: 'https://github.com/swcarpentry/shell-novice/issues/14'}
+  url: https://github.com/swcarpentry/shell-novice
+- description: Introduction to Git
+  ident: swcarpentry/git-novice
+  issues:
+  - {number: 6, title: reference updates, updated: '2015-01-02', url: 'https://github.com/swcarpentry/git-novice/pull/6'}
+  - {number: 4, title: minor revisions to open science lessons for clarity, updated: '2014-12-16',
+    url: 'https://github.com/swcarpentry/git-novice/pull/4'}
+  - {number: 1, title: Remove data/data.csv, updated: '2014-12-05', url: 'https://github.com/swcarpentry/git-novice/issues/1'}
+  url: https://github.com/swcarpentry/git-novice
+- description: Introduction to Mercurial
+  ident: swcarpentry/hg-novice
+  issues:
+  - {number: 1, title: ' update reference', updated: '2014-12-29', url: 'https://github.com/swcarpentry/hg-novice/pull/1'}
+  url: https://github.com/swcarpentry/hg-novice
+- description: Introduction to SQL
+  ident: swcarpentry/sql-novice-survey
+  issues:
+  - {number: 14, title: Shift some focus from complex query construction to schema
+      design, updated: '2015-01-03', url: 'https://github.com/swcarpentry/sql-novice-survey/issues/14'}
+  - {number: 13, title: '  instr function not available in SQLite 3.7.13 and older',
+    updated: '2015-01-03', url: 'https://github.com/swcarpentry/sql-novice-survey/issues/13'}
+  - {number: 12, title: Database reconstruction, updated: '2014-12-31', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/12'}
+  - {number: 11, title: SQLite & Python working together on OSX, updated: '2014-12-31',
+    url: 'https://github.com/swcarpentry/sql-novice-survey/issues/11'}
+  - {number: 10, title: Glossary entries, updated: '2014-12-29', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/10'}
+  - {number: 9, title: Edit text since there is no longer any red formatting in table.,
+    updated: '2014-12-20', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/9'}
+  - {number: 8, title: 01-select.md talks about three entries in tables being red,
+    updated: '2014-12-20', url: 'https://github.com/swcarpentry/sql-novice-survey/issues/8'}
+  - {number: 4, title: add section on LIKE keyword, updated: '2014-12-16', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/4'}
+  - {number: 6, title: Fix glossary indentation, updated: '2014-12-14', url: 'https://github.com/swcarpentry/sql-novice-survey/pull/6'}
+  - {number: 5, title: Remove HTML tags and others small fixes, updated: '2014-12-14',
+    url: 'https://github.com/swcarpentry/sql-novice-survey/pull/5'}
+  url: https://github.com/swcarpentry/sql-novice-survey
+- description: Python for non-programmers
+  ident: swcarpentry/python-novice-inflammation
+  issues:
+  - {number: 1, title: Unescape the less than and greater than inequalities, updated: '2015-01-02',
+    url: 'https://github.com/swcarpentry/python-novice-inflammation/pull/1'}
+  - {number: 3, title: 'challenge titles, glossary entries, grid images', updated: '2014-12-31',
+    url: 'https://github.com/swcarpentry/python-novice-inflammation/pull/3'}
+  - {number: 2, title: 'Seaborn comment as stated on issue #907 for bc repo', updated: '2014-12-27',
+    url: 'https://github.com/swcarpentry/python-novice-inflammation/pull/2'}
+  url: https://github.com/swcarpentry/python-novice-inflammation
+- description: R for non-programmers
+  ident: swcarpentry/r-novice-inflammation
+  issues: []
+  url: https://github.com/swcarpentry/r-novice-inflammation
+- description: MATLAB for non-programmers
+  ident: swcarpentry/matlab-novice-inflammation
+  issues:
+  - {number: 5, title: Matlab novice material review, updated: '2014-12-28', url: 'https://github.com/swcarpentry/matlab-novice-inflammation/pull/5'}
+  - {number: 6, title: '01-intro: conform to template', updated: '2014-12-21', url: 'https://github.com/swcarpentry/matlab-novice-inflammation/pull/6'}
+  - {number: 4, title: Conform to lesson template, updated: '2014-12-21', url: 'https://github.com/swcarpentry/matlab-novice-inflammation/issues/4'}
+  - {number: 3, title: Getting the MATLAB materials up on the SWC website, updated: '2014-12-14',
+    url: 'https://github.com/swcarpentry/matlab-novice-inflammation/issues/3'}
+  url: https://github.com/swcarpentry/matlab-novice-inflammation
+- description: Software Carpentry presentations
+  ident: swcarpentry/slideshows
+  issues:
+  - {number: 2, title: Cite statistics, updated: '2015-01-03', url: 'https://github.com/swcarpentry/slideshows/issues/2'}
+  url: https://github.com/swcarpentry/slideshows
+- description: From Excel to a database via Python
+  ident: swcarpentry/capstone-novice-spreadsheet-biblio
+  issues: []
+  url: https://github.com/swcarpentry/capstone-novice-spreadsheet-biblio
+- description: What instructors need to know
+  ident: swcarpentry/instructor-training
+  issues: []
+  url: https://github.com/swcarpentry/instructor-training
+- description: Python for non-programmers using Turtles
+  ident: swcarpentry/python-novice-turtles
+  issues: []
+  url: https://github.com/swcarpentry/python-novice-turtles
+- description: Workshop administration tool
+  ident: swcarpentry/amy
+  issues:
+  - {number: 121, title: Supporting notes about events under negotiation, updated: '2015-01-04',
+    url: 'https://github.com/swcarpentry/amy/pull/121'}
+  - {number: 2, title: Add list of provisional events to home page, updated: '2015-01-04',
+    url: 'https://github.com/swcarpentry/amy/issues/2'}
+  - {number: 120, title: 'WIP: workshops/models.py: Add Host and EventHost models',
+    updated: '2015-01-03', url: 'https://github.com/swcarpentry/amy/pull/120'}
+  - {number: 106, title: Add bulk person ingest from CSV, updated: '2015-01-03', url: 'https://github.com/swcarpentry/amy/pull/106'}
+  - {number: 110, title: Add per-person award administration and per-event "Assign
+      awards" button, updated: '2015-01-02', url: 'https://github.com/swcarpentry/amy/pull/110'}
+  - {number: 101, title: 'basic search for event, site, person, work in progress',
+    updated: '2015-01-02', url: 'https://github.com/swcarpentry/amy/pull/101'}
+  - {number: 37, title: Allow award of new badges, updated: '2014-12-29', url: 'https://github.com/swcarpentry/amy/issues/37'}
+  - {number: 108, title: Developer guidelines, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/108'}
+  - {number: 70, title: 'Replace Django''s auth.User with our workshops.Person?',
+    updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/70'}
+  - {number: 61, title: 'Use person.name instead of personal, middle, and family names',
+    updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/61'}
+  - {number: 28, title: Allow addition of new skills, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/28'}
+  - {number: 22, title: Page displaying all person should have expand/contract to
+      show details, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/22'}
+  - {number: 19, title: Event details page should allow validation of Eventbrite link,
+    updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/19'}
+  - {number: 12, title: Distinguish lead instructor from other instructors in all
+      displays, updated: '2014-12-24', url: 'https://github.com/swcarpentry/amy/issues/12'}
+  - {number: 89, title: Use Python's logging module for debugging, updated: '2014-12-23',
+    url: 'https://github.com/swcarpentry/amy/issues/89'}
+  - {number: 64, title: 'Additional event attendance information (slots and applicants)?',
+    updated: '2014-12-23', url: 'https://github.com/swcarpentry/amy/issues/64'}
+  - {number: 27, title: Add form for bulk addition of new persons, updated: '2014-12-23',
+    url: 'https://github.com/swcarpentry/amy/issues/27'}
+  - {number: 99, title: Headings hierarchy, updated: '2014-12-22', url: 'https://github.com/swcarpentry/amy/issues/99'}
+  - {number: 82, title: Display map of known airports, updated: '2014-12-18', url: 'https://github.com/swcarpentry/amy/issues/82'}
+  - {number: 10, title: Add CSS to make display less ugly, updated: '2014-12-16',
+    url: 'https://github.com/swcarpentry/amy/issues/10'}
+  - {number: 74, title: 'Event_sponsor table ', updated: '2014-12-15', url: 'https://github.com/swcarpentry/amy/issues/74'}
+  - {number: 62, title: Separate country table, updated: '2014-12-15', url: 'https://github.com/swcarpentry/amy/issues/62'}
+  - {number: 6, title: Rename 'site' to 'host', updated: '2014-12-15', url: 'https://github.com/swcarpentry/amy/issues/6'}
+  - {number: 63, title: 'Do we need a cohort table?', updated: '2014-12-14', url: 'https://github.com/swcarpentry/amy/issues/63'}
+  - {number: 18, title: Use calendar pop-up for picking dates for workshops, updated: '2014-12-14',
+    url: 'https://github.com/swcarpentry/amy/issues/18'}
+  - {number: 52, title: Forms should also display original data when invalid data
+      entered, updated: '2014-12-11', url: 'https://github.com/swcarpentry/amy/issues/52'}
+  - {number: 51, title: Automatic email reminders about upcoming workshops to admins,
+    updated: '2014-12-10', url: 'https://github.com/swcarpentry/amy/issues/51'}
+  - {number: 44, title: Spatial Data, updated: '2014-12-07', url: 'https://github.com/swcarpentry/amy/issues/44'}
+  - {number: 42, title: Email list co-management with hosts, updated: '2014-12-07',
+    url: 'https://github.com/swcarpentry/amy/issues/42'}
+  - {number: 41, title: Add administrative page, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/41'}
+  - {number: 36, title: Display details of a single badge, updated: '2014-12-02',
+    url: 'https://github.com/swcarpentry/amy/issues/36'}
+  - {number: 33, title: Show whether an instructor training class counts toward a
+      badge, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/33'}
+  - {number: 32, title: Training cohort display should show completion rates, updated: '2014-12-02',
+    url: 'https://github.com/swcarpentry/amy/issues/32'}
+  - {number: 31, title: 'Record training cohorts as workshops?', updated: '2014-12-02',
+    url: 'https://github.com/swcarpentry/amy/issues/31'}
+  - {number: 29, title: The database should record the instructors for every instructor
+      training workshop, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/29'}
+  - {number: 21, title: Create checklist for event, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/21'}
+  - {number: 20, title: Event details page should include links to assessment forms,
+    updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/20'}
+  - {number: 16, title: 'Allow hosts, instructors, and helpers to be selected on event
+      details page', updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/16'}
+  - {number: 5, title: Add location information to sites, updated: '2014-12-02', url: 'https://github.com/swcarpentry/amy/issues/5'}
+  url: https://github.com/swcarpentry/amy
+- description: Software Carpentry website
+  ident: swcarpentry/site
+  issues:
+  - {number: 719, title: Partial support for interactive construction of dashboard,
+    updated: '2015-01-04', url: 'https://github.com/swcarpentry/site/pull/719'}
+  - {number: 717, title: 'IOError: [Errno 2] No such file or directory: ''./git-token.txt''',
+    updated: '2015-01-04', url: 'https://github.com/swcarpentry/site/issues/717'}
+  - {number: 715, title: Future Workshops not sorted, updated: '2015-01-04', url: 'https://github.com/swcarpentry/site/issues/715'}
+  - {number: 711, title: Update FAQ to reflect latest SCF documents, updated: '2014-12-20',
+    url: 'https://github.com/swcarpentry/site/issues/711'}
+  - {number: 509, title: Invalid HTTPS certs for software-carpentry.org and files.software-carpentry.org,
+    updated: '2014-12-20', url: 'https://github.com/swcarpentry/site/issues/509'}
+  - {number: 672, title: Remove instruction to send notices about workshops to announcements
+      list, updated: '2014-11-20', url: 'https://github.com/swcarpentry/site/issues/672'}
+  - {number: 655, title: 'Suggestion: Have an ''I want this workshop in <country>''
+      button', updated: '2014-10-30', url: 'https://github.com/swcarpentry/site/issues/655'}
+  - {number: 618, title: Update post-assessment survey for workshop instructors, updated: '2014-10-09',
+    url: 'https://github.com/swcarpentry/site/issues/618'}
+  - {number: 629, title: Filter site posts by author, updated: '2014-10-08', url: 'https://github.com/swcarpentry/site/issues/629'}
+  - {number: 617, title: Update pre-assessment survey for workshop attendees, updated: '2014-10-02',
+    url: 'https://github.com/swcarpentry/site/issues/617'}
+  - {number: 620, title: Remove the "registration" field from workshops, updated: '2014-10-01',
+    url: 'https://github.com/swcarpentry/site/issues/620'}
+  - {number: 619, title: 'Add and display a flag for workshops to show kind (SWC,
+      DC, etc.)', updated: '2014-10-01', url: 'https://github.com/swcarpentry/site/issues/619'}
+  - {number: 580, title: Menu iconification in small browser windows, updated: '2014-10-01',
+    url: 'https://github.com/swcarpentry/site/issues/580'}
+  - {number: 32, title: Add a "show your support" page to the site for buying swag,
+    updated: '2013-12-26', url: 'https://github.com/swcarpentry/site/issues/32'}
+  url: https://github.com/swcarpentry/site

--- a/_includes/recent_blog_posts.html
+++ b/_includes/recent_blog_posts.html
@@ -1,0 +1,42 @@
+<h4><a href="{{page.root}}/blog/2015/01/future-and-funding-of-science.html">The Future and Funding of Science</a></h4>
+<small>By Greg Wilson / <a href="{{page.root}}/blog/2015/01/future-and-funding-of-science.html">2015-01-04</a> </small>
+<p>
+    <p>   I was talking with friends over the holiday about the future of science   and how it might one day be funded.   Since it'll be ten years before I'm proven wrong,   it seems like a good topic with which to start the new year. </p>
+    <a class="pull-right" href="{{page.root}}/blog/2015/01/future-and-funding-of-science.html">...read more</a>
+</p><br /><br />
+
+<h4><a href="{{page.root}}/blog/2014/12/projects-projects-projects.html">Projects, Projects, Projects</a></h4>
+<small>By Greg Wilson / <a href="{{page.root}}/blog/2014/12/projects-projects-projects.html">2014-12-28</a> </small>
+<p>
+    <p>   We have updated our <a href="{{page.root}}/pages/projects.html">projects page</a> with links to: </p> <ol>   <li>     things we're building ourselves, and   </li>   <li>     things that our members are building.   </li> </ol> <p>   The first list includes the templates for   <a href="https://github.com/swcarpentry/lesson-template">lessons</a>   and <a href="https://github.com/swcarpentry/workshop-template">workshop websites</a>,   a <a href="https://github.com/swcarpentry/amy">a tool for managing workshops</a>   (for which we're using Django),   the <a href="https://github.com/twitwi/deck.browsercast.js/">latest version</a> of   <a href="http://third-bit.com/browsercast/">Browsercast</a>,   and more.   The second list has everything from   <a href="http://www.activepapers.org/" class="project">active papers</a>   to <a href="http://jrsmith3.github.io/tec/">utilities for simulating vacuum thermionic energy conversion devices</a>.   If you'd like to help with the first,   or if you're a <a href="{{page.root}}/blog/2014/12/standing-for-election.html#members">member</a>   and would like your project listed in the second,   please <a href="mailto:{{site.contact}}">get in touch</a>. </p>
+    <a class="pull-right" href="{{page.root}}/blog/2014/12/projects-projects-projects.html">...read more</a>
+</p><br /><br />
+
+<h4><a href="{{page.root}}/blog/2014/12/welcome-aboard.html">Welcome Aboard</a></h4>
+<small>By Greg Wilson / <a href="{{page.root}}/blog/2014/12/welcome-aboard.html">2014-12-23</a> </small>
+<p>
+    <p>   A lot of people qualified as instructors this fall and winter,   thanks in part to the live sessions we ran in Charlottesville, Norwich, and Seattle.   They join the 86 other people who received their badge this year;   we look forward to seeing them all run workshops before 2015 is over. </p>
+    <a class="pull-right" href="{{page.root}}/blog/2014/12/welcome-aboard.html">...read more</a>
+</p><br /><br />
+
+<h4><a href="{{page.root}}/blog/2014/12/minutes-2014-dec-02.html">Interim Steering Committee Meeting: Dec 2, 2014</a></h4>
+<small>By Greg Wilson / <a href="{{page.root}}/blog/2014/12/minutes-2014-dec-02.html">2014-12-19</a> </small>
+<p>
+    <p>Software Carpentry Foundation Interim Board Meeting: Dec 2, 2014</p>
+    <a class="pull-right" href="{{page.root}}/blog/2014/12/minutes-2014-dec-02.html">...read more</a>
+</p><br /><br />
+
+<h4><a href="{{page.root}}/blog/2014/12/standing-for-election.html">Standing for Election</a></h4>
+<small>By Greg Wilson / <a href="{{page.root}}/blog/2014/12/standing-for-election.html">2014-12-18</a> </small>
+<p>
+    <p>   From 26-30 January,   an election will be held for the seven vacant positions on the   inaugural Steering Committee of the Software Carpentry Foundation.   This will be one of the biggest steps in the project's journey   from two guys staying up until 3:00 am fourteen years ago   to write lessons on Perl for scientists at Los Alamos   to a mature open project run by the volunteers it belongs to. </p> <p>   If you are a qualified instructor who has taught at least twice in the past two years,   or have done a significant chunk of non-teaching work for Software Carpentry,   you can both stand for election and vote.   We strongly urge you to consider standing:   if you're willing and able to commit to giving the Foundation 3 hours a week,   you'll help thousands of scientists get more done in less time and with less pain.   It'll be fun, too:   few things in life are as rewarding as building something,   and our members are building something extraordinary. </p> <p>   In order to stand for election,   you must write a blog post to introduce yourself to the community   by Friday, January 16   (i.e., a full week before the start of the election).   This post: </p> <ul>   <li>     <p>       must be around 500 words long,     </p>   </li>   <li>     <p>       can be written in any format (e.g. question and answer, paragraph text),       and     </p>   </li>   <li>     <p>       must be titled, "2015 Election: Your Name"     </p>   </li> </ul> <p>   You can submit your post as a pull request   to <a href="{{site.github_url}}/site">this website's repository</a>   or <a href="mailto:{{site.contact}}">by email</a>.   It should explain: </p> <ul>   <li>     <p>       what your background is,     </p>   </li>   <li>     <p>       what your previous involvement with Software Carpentry has been,       and most importantly     </p>   </li>   <li>     <p>       what you will do as a member of the Steering Committee       to contribute to the growth and success of Software Carpentry.     </p>   </li> </ul> <p>   The last point is the most important.   If you have experience managing money,   we need a Treasurer;   if your passion is helping new instructors or figuring out how well we're doing,   we need people to lead   <a href="{{page.root}}/blog/2014/12/plans-for-2015-mentorship-and-assessment.html">mentorship and assessment</a>,   while if you come from a part of the world that hasn't seen much Software Carpentry activity yet,   you might want to take the lead in getting us going there. </p> <p>   (Actually,   the point that's <em>really</em> most important is that   everyone will still be very welcome to volunteer in other ways,   and that doing so will be as valuable as ever.   We will still need topic maintainers,   help with the website,   and many other things,   and I hope that having more people coordinating things   will actually make it easier for you all to lend a hand.) </p> <p>   If seven or fewer nominations are received,   those people who nominated will be automatically appointed to the Steering Committee   and no formal election will be held.   Vacancies on the Steering Committee can be filled at any time at the Committee's discretion.   The regular positions on the Steering Committee   (Chair, Vice-Chair, Secretary, Treasurer and then any others the Committee feels it needs)   will be decided by a vote at the Committee's first meeting. </p>
+    <a class="pull-right" href="{{page.root}}/blog/2014/12/standing-for-election.html">...read more</a>
+</p><br /><br />
+
+<h4><a href="{{page.root}}/blog/2014/12/beta-release-of-new-format-lessons.html">All I Want for Christmas is a Pull Request...</a></h4>
+<small>By Greg Wilson / <a href="{{page.root}}/blog/2014/12/beta-release-of-new-format-lessons.html">2014-12-18</a> </small>
+<p>
+    <p>   As <a href="{{page.root}}/blog/2014/10/new-lesson-template-v2.html">we said back in October</a>,   we're splitting the <a href="{{site.github_url}}/bc">existing lesson repository</a>   into smaller and more manageable pieces.   To do that,   we have defined   <a href="{{site.github_url}}/lesson-template">a new template for lessons</a>,   and have been extracting the history of the existing material from the current repository.   (We wanted to get the entire history of each lesson   so that people would receive credit for the work they've done.)   The second step has taken longer than planned,   but we now have all of the core novice lessons in repositories of their own: </p>
+    <a class="pull-right" href="{{page.root}}/blog/2014/12/beta-release-of-new-format-lessons.html">...read more</a>
+</p><br /><br />
+

--- a/_workshop_cache.yml
+++ b/_workshop_cache.yml
@@ -1,0 +1,4580 @@
+- country: Canada
+  enddate: 2011-11-08
+  humandate: Nov 7-8, 2011
+  instructor: [Jonathan Dursi, Tommy Guy, Katy Huff, Dominique Vuvan]
+  latlng: 43.661476,-79.395189
+  layout: bootcamp
+  registration: open
+  slug: 2011-11-07-toronto
+  startdate: 2011-11-07
+  url: http://swcarpentry.github.io/2011-11-07-toronto/
+  user: swcarpentry
+  venue: University of Toronto
+- country: United-States
+  enddate: 2012-01-19
+  humandate: Jan 18-19, 2012
+  instructor: [Greg Wilson]
+  latlng: 39.332604,-76.62319
+  layout: bootcamp
+  registration: open
+  slug: 2012-01-18-stsci
+  startdate: 2012-01-18
+  url: http://swcarpentry.github.io/2012-01-18-stsci/
+  user: swcarpentry
+  venue: Space Telescope Science Institute
+- country: Italy
+  enddate: 2012-03-02
+  humandate: Feb 20 - March 2, 2012
+  instructor: [Stephen Crouch, Tommy Guy, Katy Huff]
+  latlng: 45.703255,13.718013
+  layout: bootcamp
+  registration: open
+  slug: 2012-02-20-itcp
+  startdate: 2012-02-20
+  url: http://swcarpentry.github.io/2012-02-20-itcp/
+  user: swcarpentry
+  venue: International Centre for Theoretical Physics
+- address: Bahen Centre for Information Technology, 40 St. George Street, Toronto,
+    ON
+  country: Canada
+  enddate: 2012-02-24
+  humandate: February 23-24, 2012
+  instructor: [Matt Davis, Jonathan Dursi, Mike Fletcher, Greg Wilson]
+  latlng: 43.661476,-79.395189
+  layout: bootcamp
+  registration: open
+  slug: 2012-02-23-toronto
+  startdate: 2012-02-23
+  url: http://swcarpentry.github.io/2012-02-23-toronto/
+  user: swcarpentry
+  venue: University of Toronto
+- country: United-States
+  enddate: 2012-03-08
+  humandate: March 7-8, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Greg Wilson]
+  latlng: 39.1663815,-86.526621
+  layout: bootcamp
+  registration: open
+  slug: 2012-03-07-indiana
+  startdate: 2012-03-07
+  url: http://swcarpentry.github.io/2012-03-07-indiana/
+  user: swcarpentry
+  venue: Indiana University
+- country: United-States
+  enddate: 2012-03-27
+  humandate: March 26-27, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Steve Haddock, Greg Wilson]
+  latlng: 36.802151,-121.788163
+  layout: bootcamp
+  registration: open
+  slug: 2012-03-26-mbari
+  startdate: 2012-03-26
+  url: http://swcarpentry.github.io/2012-03-26-mbari/
+  user: swcarpentry
+  venue: Monterey Bay Aquarium Research Institute
+- address: Conference Room 238, Oakland Scientific Facility (OSF), 415 20th Street
+    ("Thomas L Berkley Way") at Franklin Street, Oakland, CA
+  country: United-States
+  enddate: 2012-03-29
+  humandate: March 28-29, 2012
+  instructor: [Michelle Levesque, Greg Wilson]
+  latlng: 37.8083814,-122.2675787
+  layout: bootcamp
+  registration: open
+  slug: 2012-03-28-nersc
+  startdate: 2012-03-28
+  url: http://swcarpentry.github.io/2012-03-28-nersc/
+  user: swcarpentry
+  venue: NERSC
+- country: United-States
+  enddate: 2012-04-03
+  humandate: April 2-3, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Milad Fatenejad, Katy Huff, Anthony Scopatz, Joshua Smith]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: open
+  slug: 2012-04-02-chicago
+  startdate: 2012-04-02
+  url: http://swcarpentry.github.io/2012-04-02-chicago/
+  user: swcarpentry
+  venue: University of Chicago
+- address: Room 314, Biology and Natural Resources Building, Utah State University,
+    5305 Old Main Hill, Logan, UT
+  country: United-States
+  enddate: 2012-04-15
+  humandate: April 14-15, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Curtis Dyreson, Jason Pell, Greg Wilson]
+  latlng: 41.7449488,-111.8042944
+  layout: bootcamp
+  registration: open
+  slug: 2012-04-14-utahstate
+  startdate: 2012-04-14
+  url: http://swcarpentry.github.io/2012-04-14-utahstate/
+  user: swcarpentry
+  venue: Utah State University
+- country: United-Kingdom
+  enddate: 2012-05-01
+  humandate: April 30 - May 1, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Cannam, Greg Wilson]
+  latlng: 51.5598815,-0.1334579
+  layout: bootcamp
+  registration: open
+  slug: 2012-04-30-ucl
+  startdate: 2012-04-30
+  url: http://swcarpentry.github.io/2012-04-30-ucl/
+  user: swcarpentry
+  venue: University College London
+- country: United-States
+  enddate: 2012-05-08
+  humandate: May 7-8, 2012
+  instructor: [C. Titus Brown, Greg Wilson]
+  latlng: 42.7272884,-84.482106
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-07-michiganstate
+  startdate: 2012-05-07
+  url: http://swcarpentry.github.io/2012-05-07-michiganstate/
+  user: swcarpentry
+  venue: Michigan State University
+- contact: swc2012@ncl.ac.uk
+  country: United-Kingdom
+  enddate: 2012-05-15
+  humandate: May 14-15, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Chris Cannam, Neil Chue Hong, Stephen Crouch, Mike Jackson, Steve McGough]
+  latlng: 54.980095,-1.6146142
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-14-newcastle
+  startdate: 2012-05-14
+  url: http://swcarpentry.github.io/2012-05-14-newcastle/
+  user: swcarpentry
+  venue: Newcastle University
+- address: Computing Sciences Centre (CSC) 1-59, University of Alberta, Edmonton,
+    AB
+  country: Canada
+  enddate: 2012-05-17
+  humandate: May 16-17, 2012
+  instructor: [Rosangela Canino-Koning, Greg Wilson]
+  latlng: 53.5234543,-113.5259951
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-16-alberta
+  startdate: 2012-05-16
+  url: http://swcarpentry.github.io/2012-05-16-alberta/
+  user: swcarpentry
+  venue: University of Alberta
+- address: Room DMP 201, 6245 Agronomy Road
+  country: Canada
+  enddate: 2012-05-23
+  humandate: May 22-23, 2012
+  instructor: [Adina Chuang Howe, Greg Wilson]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2012-05-22-ubc
+  startdate: 2012-05-22
+  url: http://swcarpentry.github.io/2012-05-22-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Room 475, Bloomberg Center for Physics &amp; Astronomy
+  country: United-States
+  enddate: 2012-06-19
+  humandate: June 18-19, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Joshua Smith, Sasha Wood]
+  latlng: 39.3275798,-76.6207579
+  layout: bootcamp
+  registration: open
+  slug: 2012-06-18-jhu
+  startdate: 2012-06-18
+  url: http://swcarpentry.github.io/2012-06-18-jhu/
+  user: swcarpentry
+  venue: Johns Hopkins University
+- address: Place d'Italie
+  country: France
+  enddate: 2012-06-29
+  humandate: June 28-29, 2012
+  instructor: [Feth Arezki, Christophe Combelles, Alexandre Gramfort, Konrad Hinsen,
+    Nelle Varoquaux]
+  latlng: 48.831673,2.355623
+  layout: bootcamp
+  registration: open
+  slug: 2012-06-28-inria
+  startdate: 2012-06-28
+  url: http://swcarpentry.github.io/2012-06-28-inria/
+  user: swcarpentry
+  venue: INRIA Paris
+- address: Room 32-141, CSAIL, MIT, 32 Vassar Street, Cambridge, MA
+  country: United-States
+  enddate: 2012-07-10
+  humandate: July 9-10, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jessica McKellar, Greg Wilson]
+  latlng: 42.3591326,-71.093201
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-09-mit
+  startdate: 2012-07-09
+  url: http://swcarpentry.github.io/2012-07-09-mit/
+  user: swcarpentry
+  venue: MIT
+- address: Davis Centre DC 1568, University of Waterloo, 200 University Avenue West,
+    Waterloo, ON
+  country: Canada
+  enddate: 2012-07-13
+  eventbrite: 3558725243
+  humandate: July 12-13, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Greg Wilson]
+  latlng: 43.4701302,-80.5357712
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-12-waterloo
+  startdate: 2012-07-12
+  url: http://swcarpentry.github.io/2012-07-12-waterloo/
+  user: swcarpentry
+  venue: University of Waterloo
+- address: Rm 255, Sobey Building, Saint Mary's University, Halifax, Nova Scotia
+  country: Canada
+  enddate: 2012-07-17
+  humandate: July 16-17, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Ely, Greg Wilson]
+  latlng: 44.6322608,-63.5802627
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-16-halifax
+  startdate: 2012-07-16
+  url: http://swcarpentry.github.io/2012-07-16-halifax/
+  user: swcarpentry
+  venue: Halifax
+- country: Canada
+  enddate: 2012-07-20
+  humandate: July 19-20, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Jonathan Dursi, Greg Wilson]
+  latlng: 43.7835514,-79.1863972
+  layout: bootcamp
+  registration: open
+  slug: 2012-07-19-utsc
+  startdate: 2012-07-19
+  url: http://swcarpentry.github.io/2012-07-19-utsc/
+  user: swcarpentry
+  venue: University of Toronto (Scarborough)
+- address: University of York
+  country: United-Kingdom
+  enddate: 2012-09-14
+  humandate: Sept 13-14, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Cannam, Adam Stark, Becky Stewart, Greg Wilson]
+  latlng: 53.9481933,-1.0529144
+  layout: bootcamp
+  registration: open
+  slug: 2012-09-13-dafx
+  startdate: 2012-09-13
+  url: http://swcarpentry.github.io/2012-09-13-dafx/
+  user: swcarpentry
+  venue: DAFx Conference
+- address: Room 3213, Kristine Bonnevies hus, Blindernveien 31, University of Oslo
+  country: Norway
+  enddate: 2012-09-18
+  humandate: Sept 17-18, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Hans Petter Langtangen, Greg Wilson]
+  latlng: 59.9399586,10.7217496
+  layout: bootcamp
+  registration: open
+  slug: 2012-09-17-oslo
+  startdate: 2012-09-17
+  url: http://swcarpentry.github.io/2012-09-17-oslo/
+  user: swcarpentry
+  venue: University of Oslo
+- country: United-States
+  enddate: 2012-09-29
+  humandate: Sept 28-29, 2012
+  instructor: [Erik Bray, Chang She, Eric Weinstein, Greg Wilson]
+  latlng: 40.8080777,-73.9635678
+  layout: bootcamp
+  registration: open
+  slug: 2012-09-28-columbia
+  startdate: 2012-09-28
+  url: http://swcarpentry.github.io/2012-09-28-columbia/
+  user: swcarpentry
+  venue: Columbia University
+- address: Stewart Center, Room 318
+  country: United-States
+  enddate: 2012-10-09
+  humandate: Oct 8-9, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Hansen, Anthony Scopatz]
+  latlng: 40.4282668,-86.9143245
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-08-purdue
+  startdate: 2012-10-08
+  url: http://swcarpentry.github.io/2012-10-08-purdue/
+  user: swcarpentry
+  venue: Purdue University
+- address: Building 50A, Room 5132
+  country: United-States
+  enddate: 2012-10-18
+  humandate: Oct 17-18, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Katy Huff, Justin Kitzes]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-17-lbl
+  startdate: 2012-10-17
+  url: http://swcarpentry.github.io/2012-10-17-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley National Laboratory
+- country: Canada
+  enddate: 2012-10-19
+  eventbrite: 3869257052
+  humandate: Oct 18-19, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Davor Cubranic, Ted Hart, Laura Tremblay-Boyer, Greg Wilson]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-18-ubc
+  startdate: 2012-10-18
+  url: http://swcarpentry.github.io/2012-10-18-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Goldman School of Public Policy, Room 150
+  country: United-States
+  enddate: 2012-10-21
+  eventbrite: 3942004642
+  humandate: Oct 20-21, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Katy Huff, Justin Kitzes]
+  latlng: 37.8695,-122.258949
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-20-ucb
+  startdate: 2012-10-20
+  url: http://swcarpentry.github.io/2012-10-20-ucb/
+  user: swcarpentry
+  venue: University of California Berkeley
+- country: United-Kingdom
+  enddate: 2012-10-23
+  humandate: Oct 22-23, 2012
+  instructor: [Mike Jackson, Steve McGough]
+  latlng: 54.980095,-1.6146142
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-22-newcastle
+  startdate: 2012-10-22
+  url: http://swcarpentry.github.io/2012-10-22-newcastle/
+  user: swcarpentry
+  venue: University of Newcastle
+- address: 383 Hill Annex, Caltech Campus, Pasadena, CA 91125
+  country: United-States
+  enddate: 2012-10-24
+  humandate: Oct 23-24, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis]
+  latlng: 34.141411,-118.1249
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-23-caltech
+  startdate: 2012-10-23
+  url: http://swcarpentry.github.io/2012-10-23-caltech/
+  user: swcarpentry
+  venue: Caltech
+- country: United-States
+  enddate: 2012-10-26
+  eventbrite: 4647209930
+  humandate: Oct 25-26, 2012
+  instructor: [Azalee Bostroem, Erik Bray]
+  latlng: 38.831513,-77.308746
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-25-gmu
+  startdate: 2012-10-25
+  url: http://swcarpentry.github.io/2012-10-25-gmu/
+  user: swcarpentry
+  venue: George Mason University
+- address: New Biochemistry
+  contact: philip.fowler@bioch.ox.ac.uk
+  country: United-Kingdom
+  enddate: 2012-10-31
+  humandate: Oct 30-31, 2012
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Stephen Crouch, Mike Jackson]
+  latlng: 51.7571373,-1.2569052
+  layout: bootcamp
+  registration: open
+  slug: 2012-10-30-oxford
+  startdate: 2012-10-30
+  url: http://swcarpentry.github.io/2012-10-30-oxford/
+  user: swcarpentry
+  venue: Oxford University
+- address: Information Technology Building, Room A113
+  country: Canada
+  enddate: 2012-11-09
+  eventbrite: 4522284274
+  humandate: Nov 8-9, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Lynne Williams, Greg Wilson]
+  latlng: 43.2613285,-79.9202476
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-08-mcmaster
+  startdate: 2012-11-08
+  url: http://swcarpentry.github.io/2012-11-08-mcmaster/
+  user: swcarpentry
+  venue: McMaster University
+- address: Life Sciences Building
+  country: United-States
+  enddate: 2012-11-11
+  eventbrite: 4262808174
+  humandate: Nov 10-11, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Ely, Jessica Kerr, Sarah Supp]
+  latlng: 38.6480562,-90.3050959
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-10-wustl
+  startdate: 2012-11-10
+  url: http://swcarpentry.github.io/2012-11-10-wustl/
+  user: swcarpentry
+  venue: Washington University in St. Louis
+- address: La Jolla, CA
+  country: United-States
+  enddate: 2012-11-16
+  eventbrite: 3869222950
+  humandate: Nov 15-16, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [C. Titus Brown, Justin Kitzes, Caitlyn Pickens, Tracy Teal]
+  latlng: 32.8953297,-117.2421882
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-15-scripps
+  startdate: 2012-11-15
+  url: http://swcarpentry.github.io/2012-11-15-scripps/
+  user: swcarpentry
+  venue: Scripps Research Institute
+- country: United-States
+  enddate: 2012-11-29
+  eventbrite: 4224585850
+  humandate: Nov 28-29, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ethan White, Greg Wilson]
+  latlng: 34.2274248,-77.8791793
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-28-unc
+  startdate: 2012-11-28
+  url: http://swcarpentry.github.io/2012-11-28-unc/
+  user: swcarpentry
+  venue: University of North Carolina
+- address: Hawaii Institute of Marine Biology
+  country: United-States
+  enddate: 2012-12-01
+  eventbrite: 4314420548
+  humandate: Nov 30 - Dec 1, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Erik Bray, Fernando Perez]
+  latlng: 21.3006615,-157.8191655
+  layout: bootcamp
+  registration: open
+  slug: 2012-11-30-hawaii
+  startdate: 2012-11-30
+  url: http://swcarpentry.github.io/2012-11-30-hawaii/
+  user: swcarpentry
+  venue: University of Hawaii
+- contact: michaelj@epcc.ed.ac.uk
+  country: United-Kingdom
+  enddate: 2012-12-05
+  humandate: Dec 4-5, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Mike Jackson]
+  latlng: 55.9453279,-3.1911838
+  layout: bootcamp
+  registration: open
+  slug: 2012-12-04-edinburgh
+  startdate: 2012-12-04
+  url: http://swcarpentry.github.io/2012-12-04-edinburgh/
+  user: swcarpentry
+  venue: University of Edinburgh
+- country: United-States
+  enddate: 2012-12-11
+  eventbrite: 3666777430
+  humandate: Dec 10-11, 2012
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Rosangela Canino-Koning, Emily Jane McTavish, Jason Pell, Andy Terrel]
+  latlng: 30.2835989,-97.7344283
+  layout: bootcamp
+  registration: open
+  slug: 2012-12-10-uta
+  startdate: 2012-12-10
+  url: http://swcarpentry.github.io/2012-12-10-uta/
+  user: swcarpentry
+  venue: University of Texas (Austin)
+- address: MSL 101
+  country: Canada
+  enddate: 2013-01-12
+  humandate: Jan 11 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jennifer Bryan, Davor Cubranic, Ted Hart, Bernhard Konrad, Rick White]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-11-ubc
+  startdate: 2013-01-11
+  url: http://swcarpentry.github.io/2013-01-11-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Kent Hall, Room 120, 1020 East 58th Street Chicago, IL 60637
+  country: United-States
+  enddate: 2013-01-13
+  eventbrite: 4044017766
+  humandate: Jan 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Katy Huff, Anthony Scopatz]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-12-chicago
+  startdate: 2013-01-12
+  url: http://swcarpentry.github.io/2013-01-12-chicago/
+  user: swcarpentry
+  venue: University of Chicago
+- country: Canada
+  enddate: 2013-01-13
+  eventbrite: 4859419655
+  humandate: Jan 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ross Dickson, Jessica McKellar]
+  latlng: 45.4174172,-73.9489284
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-12-mcgill
+  startdate: 2013-01-12
+  url: http://swcarpentry.github.io/2013-01-12-mcgill/
+  user: swcarpentry
+  venue: McGill University
+- address: Engineering 6 Building, Room 4022
+  country: Canada
+  enddate: 2013-01-13
+  eventbrite: 4455642948
+  humandate: Jan 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Nasser Mohieddin Abukhdeir, Greg Wilson]
+  latlng: 43.4691285,-80.5398649
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-12-waterloo
+  startdate: 2013-01-12
+  url: http://swcarpentry.github.io/2013-01-12-waterloo/
+  user: swcarpentry
+  venue: University of Waterloo
+- address: 1 Maximus-von-Imhof-Forum, 85354 Freising, Germany
+  country: Germany
+  enddate: 2013-01-23
+  eventbrite: 4602466100
+  humandate: Jan 22-23, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stephen Crouch, Konrad Hinsen]
+  latlng: 48.264934,11.669121
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-22-tum
+  startdate: 2013-01-22
+  url: http://swcarpentry.github.io/2013-01-22-tum/
+  user: swcarpentry
+  venue: Technische Universitat Munchen
+- address: Suite 500, 366 Adelaide St West, Toronto, ON
+  country: Canada
+  enddate: 2013-01-25
+  eventbrite: 5086301264
+  humandate: Jan 24-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson]
+  latlng: 43.6471184,-79.3942998
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-24-camh
+  startdate: 2013-01-24
+  url: http://swcarpentry.github.io/2013-01-24-camh/
+  user: swcarpentry
+  venue: Mozilla Foundation
+- address: 41 Spemannstrasse, 72076 Tuebingen, Germany
+  country: Germany
+  enddate: 2013-01-26
+  eventbrite: 5014203618
+  humandate: Jan 25-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stephen Crouch, Luis Figueira]
+  latlng: 48.5369804,9.058935
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-25-tuebingen
+  startdate: 2013-01-25
+  url: http://swcarpentry.github.io/2013-01-25-tuebingen/
+  user: swcarpentry
+  venue: Max Planck Institute Tuebingen
+- country: United-States
+  enddate: 2013-02-02
+  humandate: Jan 30 - Feb 2, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Adina Chuang Howe, Justin Ely, Daniel Krasner, Jared Lander, Ian Langmore,
+    Chang She, Alex Viana, David Warde-Farley]
+  latlng: 40.8080777,-73.9635678
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-01-30-columbia
+  startdate: 2013-01-30
+  url: http://swcarpentry.github.io/2013-01-30-columbia/
+  user: swcarpentry
+  venue: Columbia University
+- country: United-States
+  enddate: 2013-02-01
+  humandate: Jan 31 - Feb 1, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tommy Guy, Chris Lasher]
+  latlng: 37.2283843,-80.4234167
+  layout: bootcamp
+  registration: open
+  slug: 2013-01-31-vt
+  startdate: 2013-01-31
+  url: http://swcarpentry.github.io/2013-01-31-vt/
+  user: swcarpentry
+  venue: Virginia Tech
+- country: Canada
+  enddate: 2013-02-06
+  eventbrite: 5227315040
+  humandate: Feb 5-6, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ted Hart, Ethan White]
+  latlng: 49.2617149,-123.2534305
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-05-ubc
+  startdate: 2013-02-05
+  url: http://swcarpentry.github.io/2013-02-05-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Room E8A 341, Macquarie University, Sydney
+  country: Australia
+  enddate: 2013-02-08
+  eventbrite: 4114901782
+  humandate: Feb 7-8, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Eli Bressert, Greg Wilson]
+  latlng: -33.773636,151.112005
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-07-macquarie
+  startdate: 2013-02-07
+  url: http://swcarpentry.github.io/2013-02-07-macquarie/
+  user: swcarpentry
+  venue: Macquarie University
+- address: Theatre 2 (room 109), Alan Gilbert Building, University of Melbourne
+  country: Australia
+  enddate: 2013-02-15
+  humandate: Feb 14-15, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson]
+  latlng: -37.8253285,144.9516212
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-14-amos
+  startdate: 2013-02-14
+  url: http://swcarpentry.github.io/2013-02-14-amos/
+  user: swcarpentry
+  venue: AMOS Conference (Melbourne)
+- country: United-States
+  enddate: 2013-02-26
+  eventbrite: 4309568034
+  humandate: Feb 25-26, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [C. Titus Brown, Matt Davis, Julia Gustavsen, Bernhard Konrad, Doug
+      Latornell, Greg Wilson]
+  latlng: 47.655965,-122.309377
+  layout: bootcamp
+  registration: open
+  slug: 2013-02-25-uwash
+  startdate: 2013-02-25
+  url: http://swcarpentry.github.io/2013-02-25-uwash/
+  user: swcarpentry
+  venue: University of Washington
+- country: United-States
+  enddate: 2013-03-07
+  humandate: March 4-5 and March 6-7, 2013
+  instructor: [Geoff Oxberry, Greg Wilson]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-03-04-lbl
+  startdate: 2013-03-04
+  url: http://swcarpentry.github.io/2013-03-04-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley National Laboratory
+- country: United-States
+  enddate: 2013-03-08
+  humandate: March 7-8, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Carlos Anderson, Stephen Crouch, Ben Morris]
+  latlng: 38.031441,-78.499356
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-03-07-virginia
+  startdate: 2013-03-07
+  url: http://swcarpentry.github.io/2013-03-07-virginia/
+  user: swcarpentry
+  venue: University of Virginia
+- country: Lebanon
+  enddate: 2013-03-21
+  humandate: March 20-21, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia]
+  latlng: 33.900058,35.482727
+  layout: bootcamp
+  registration: open
+  slug: 2013-03-20-aub
+  startdate: 2013-03-20
+  url: http://swcarpentry.github.io/2013-03-20-aub/
+  user: swcarpentry
+  venue: American University of Beirut
+- address: Room 314, Biology and Natural Resources Building, Utah State University,
+    5305 Old Main Hill, Logan, UT
+  country: United-States
+  enddate: 2013-03-24
+  eventbrite: 5398228246
+  humandate: March 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dan McGlinn, Ethan White]
+  latlng: 41.7449488,-111.8042944
+  layout: bootcamp
+  registration: open
+  slug: 2013-03-23-utahstate
+  startdate: 2013-03-23
+  url: http://swcarpentry.github.io/2013-03-23-utahstate/
+  user: swcarpentry
+  venue: Utah State University
+- address: Library Computer Laboratory
+  country: Saudi-Arabia
+  enddate: 2013-03-25
+  eventbrite: 5790053205
+  humandate: March 24-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, David Ketcheson, Enas Yunis]
+  latlng: 22.3101,39.1259
+  layout: bootcamp
+  registration: full
+  slug: 2013-03-24-kaust
+  startdate: 2013-03-24
+  url: http://swcarpentry.github.io/2013-03-24-kaust/
+  user: swcarpentry
+  venue: King Abdullah University of Science and Technology
+- country: United-States
+  enddate: 2013-04-05
+  eventbrite: 5396735782
+  humandate: April 4-5, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [C. Titus Brown, Karen Cranston, Rich Enbody, David Koop]
+  latlng: 32.2363584,-110.9495396
+  layout: bootcamp
+  registration: full
+  slug: 2013-04-04-arizona
+  startdate: 2013-04-04
+  url: http://swcarpentry.github.io/2013-04-04-arizona/
+  user: swcarpentry
+  venue: University of Arizona
+- contact: host-ucl@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-04-08
+  eventbrite: 5396735782
+  humandate: April 4 and 8, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ben Waugh, James Hetherington, Miguel Bernabeu, Andrew Smith]
+  latlng: 51.524789,-0.133578
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-04-04-ucl
+  startdate: 2013-04-04
+  url: http://swcarpentry.github.io/2013-04-04-ucl/
+  user: swcarpentry
+  venue: University College London
+- address: Room A306, Engineering Building
+  country: South-Africa
+  enddate: 2013-04-09
+  eventbrite: 6014414275
+  humandate: April 8-9, 2013
+  humantime: 1:00 pm - 6:00 pm on day one, noon - 4:00 pm on day two
+  instructor: [Aron Ahmadia]
+  latlng: -33.929492,18.865391
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-08-stellenbosch
+  startdate: 2013-04-08
+  url: http://swcarpentry.github.io/2013-04-08-stellenbosch/
+  user: swcarpentry
+  venue: Stellenbosch University
+- contact: michaelj@epcc.ed.ac.uk
+  country: United-Kingdom
+  enddate: 2013-04-12
+  humandate: April 11, 2013
+  humantime: 10:00 - 17:30
+  instructor: [Mike Jackson]
+  latlng: 53.467102,-2.233958
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-11-egi
+  startdate: 2013-04-11
+  url: http://swcarpentry.github.io/2013-04-11-egi/
+  user: swcarpentry
+  venue: EGI Forum, Manchester
+- country: United-States
+  enddate: 2013-04-14
+  humandate: April 13-14, 2013
+  instructor: [Justin Kitzes, Karthik Ram]
+  latlng: 37.8695,-122.258949
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-04-13-ucb
+  startdate: 2013-04-13
+  url: http://swcarpentry.github.io/2013-04-13-ucb/
+  user: swcarpentry
+  venue: University of California Berkeley
+- contact: host-manchester@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-04-19
+  eventbrite: 5397207192
+  humandate: April 18-19, 2013
+  instructor: [Mike Jackson, David Jones, Aleksandra Pawlik]
+  latlng: 53.4783491,-2.2416052
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-18-manchester
+  startdate: 2013-04-18
+  url: http://swcarpentry.github.io/2013-04-18-manchester/
+  user: swcarpentry
+  venue: University of Manchester
+- address: 46 Rue Barrault, 75013 Paris
+  country: France
+  enddate: 2013-04-21
+  eventbrite: 5232959924
+  humandate: April 20-21, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sergi Blanco-Cuaresma, Christophe Cossou, Alexandre Gramfort, Konrad
+      Hinsen, Nicolas Limare, Gael Varoquaux, Nelle Varoquaux]
+  latlng: 48.82629,2.34642
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-20-paris
+  startdate: 2013-04-20
+  url: http://swcarpentry.github.io/2013-04-20-paris/
+  user: swcarpentry
+  venue: Telecom ParisTech
+- address: N111, Pharmacy Hall
+  country: United-States
+  enddate: 2013-04-28
+  eventbrite: 5919069095
+  humandate: April 27-28, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Alex Viana]
+  latlng: 39.291389,-76.625
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-27-umaryland
+  startdate: 2013-04-27
+  url: http://swcarpentry.github.io/2013-04-27-umaryland/
+  user: swcarpentry
+  venue: University of Maryland, Baltimore
+- address: Union South "Fifth Quarter" room
+  country: United-States
+  enddate: 2013-04-30
+  eventbrite: 5915929705
+  humandate: April 29-30, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Gidden, Steve Mcgough, Aronne Merrelli, Paul Wilson]
+  latlng: 43.07718,-89.40399
+  layout: bootcamp
+  registration: open
+  slug: 2013-04-29-wisc
+  startdate: 2013-04-29
+  url: http://swcarpentry.github.io/2013-04-29-wisc/
+  user: swcarpentry
+  venue: University of Wisconsin - Madison
+- address: Faculty of Sciences, Vrije Universiteit, De Boelelaan 1081, 1081 HV Amsterdam
+  country: Netherlands
+  enddate: 2013-05-03
+  humandate: May 2-3, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stefano Cozzini, Justin Ely]
+  latlng: 52.33399,4.86305
+  layout: bootcamp
+  registration: open
+  slug: 2013-05-02-vu
+  startdate: 2013-05-02
+  url: http://swcarpentry.github.io/2013-05-02-vu/
+  user: swcarpentry
+  venue: Vrije Universiteit, Amsterdam
+- address: Christian-Albrechts-Universit&auml;t zu Kiel, Christian-Albrechts-Platz
+    4, 24118 Kiel, Germany
+  country: Germany
+  enddate: 2013-05-07
+  humandate: May 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stefano Cozzini, Justin Ely]
+  latlng: 54.32707,10.18265
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-06-geomar
+  startdate: 2013-05-06
+  url: http://swcarpentry.github.io/2013-05-06-geomar/
+  user: swcarpentry
+  venue: GEOMAR (Kiel)
+- address: Axon/Dendrite Room, Landscape Building, Howard Hughes Medical Institute,
+    Janelia Farm Research Campus, 19700 Helix Drive, Ashburn, VA 20147
+  country: United-States
+  enddate: 2013-05-07
+  humandate: May 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Adina Chuang-Howe, Michael Hansen]
+  latlng: 39.07141,-77.46427
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-06-hhmi
+  startdate: 2013-05-06
+  url: http://swcarpentry.github.io/2013-05-06-hhmi/
+  user: swcarpentry
+  venue: Howard Hughes Medical Institute
+- address: Room B005, Li Ka Shing Center for Learning and Knowledge, Stanford University
+  country: United-States
+  enddate: 2013-05-07
+  humandate: May 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Paul Ivanov, Bernhard Konrad, Ariel Rokem]
+  latlng: 37.42949,-122.17186
+  layout: bootcamp
+  registration: full
+  slug: 2013-05-06-stanford
+  startdate: 2013-05-06
+  url: http://swcarpentry.github.io/2013-05-06-stanford/
+  user: swcarpentry
+  venue: Stanford University
+- country: United-States
+  enddate: 2013-05-10
+  humandate: May 9-10, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Matt Davis, Tracy Teal]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-09-lbl
+  startdate: 2013-05-09
+  url: http://swcarpentry.github.io/2013-05-09-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley National Laboratory
+- address: 366 Adelaide Street West, Suite 500, Toronto, ON
+  country: Canada
+  enddate: 2013-05-10
+  eventbrite: 6181024611
+  humandate: May 9-10, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Gabriel Devenyi, Caitlyn Pickens, Victor Ng, Greg Wilson]
+  latlng: 43.64712,-79.39430
+  layout: bootcamp
+  registration: open
+  slug: 2013-05-09-mozilla
+  startdate: 2013-05-09
+  url: http://swcarpentry.github.io/2013-05-09-mozilla/
+  user: swcarpentry
+  venue: Mozilla Foundation (Toronto)
+- contact: host-oxford-dtc@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-05-10
+  eventbrite: 5656292122
+  humandate: May 9-10, 2013
+  instructor: [Mario Antonioletti, Shoaib Sufi]
+  latlng: 51.759865,-1.258648
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-09-oxford
+  startdate: 2013-05-09
+  url: http://swcarpentry.github.io/2013-05-09-oxford/
+  user: swcarpentry
+  venue: University of Oxford
+- address: King Lounge (Room 245), Memorial Union
+  country: United-States
+  enddate: 2013-05-14
+  eventbrite: 5553687228
+  humandate: May 13-14, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Matt Davis, Chloe Lewis, Tracy Teal]
+  latlng: 38.54926,-121.76709
+  layout: bootcamp
+  registration: full
+  slug: 2013-05-13-ucdavis
+  startdate: 2013-05-13
+  url: http://swcarpentry.github.io/2013-05-13-ucdavis/
+  user: swcarpentry
+  venue: University of California Davis
+- country: United-States
+  enddate: 2013-05-17
+  eventbrite: 5899249815
+  humandate: May 16-17, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jennifer Bryan, Karen Cranston, Ben Morris]
+  latlng: 36.00803,-78.92323
+  layout: bootcamp
+  registration: open
+  slug: 2013-05-16-nescent
+  startdate: 2013-05-16
+  url: http://swcarpentry.github.io/2013-05-16-nescent/
+  user: swcarpentry
+  venue: NESCent
+- address: Krakow, Poland
+  country: Poland
+  enddate: 2013-05-19
+  humandate: May 18-19, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aleksandra Pawlik, Karin Lagesen]
+  latlng: 50.060833,19.932778
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-18-krakow
+  startdate: 2013-05-18
+  url: http://swcarpentry.github.io/2013-05-18-krakow/
+  user: swcarpentry
+  venue: Jagiellonian University
+- country: United-States
+  enddate: 2013-05-21
+  humandate: May 20-21, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jennifer Bryan, Ben Morris]
+  latlng: 36.00283,-78.93827
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-20-duke
+  startdate: 2013-05-20
+  url: http://swcarpentry.github.io/2013-05-20-duke/
+  user: swcarpentry
+  venue: Duke University
+- address: National Center for Atmospheric Research, Boulder, CO
+  country: United-States
+  enddate: 2013-05-24
+  humandate: May 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ted Hart, Alex Viana]
+  latlng: 40.03131,-105.2459
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-23-ucar
+  startdate: 2013-05-23
+  url: http://swcarpentry.github.io/2013-05-23-ucar/
+  user: swcarpentry
+  venue: NCAR
+- address: Skinner 112, UMass Amherst
+  country: United-States
+  enddate: 2013-05-24
+  humandate: May 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tracy Teal, Erik Bray]
+  latlng: 42.388889,-72.527778
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-05-23-umass
+  startdate: 2013-05-23
+  url: http://swcarpentry.github.io/2013-05-23-umass/
+  user: swcarpentry
+  venue: University of Massachusetts Amherst
+- address: Biological Sciences Building, Central Wing 410 (CW410), University of Alberta
+  country: Canada
+  enddate: 2013-05-31
+  eventbrite: 5824534339
+  humandate: May 30-31, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Charlene Nielsen, Greg Wilson]
+  latlng: 53.52345,-113.52600
+  layout: bootcamp
+  registration: full
+  slug: 2013-05-30-alberta
+  startdate: 2013-05-30
+  url: http://swcarpentry.github.io/2013-05-30-alberta/
+  user: swcarpentry
+  venue: University of Alberta
+- contact: host-soton@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-06-04
+  humandate: June 3-4, 2013
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Nelle Varoquaux, James Morrison]
+  latlng: 50.937716,-1.395599
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-03-southampton
+  startdate: 2013-06-03
+  url: http://swcarpentry.github.io/2013-06-03-southampton/
+  user: swcarpentry
+  venue: University of Southampton
+- country: United-States
+  enddate: 2013-06-04
+  humandate: June 3-4, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Jessica Mckellar, Michael Selik, Will Trimble]
+  latlng: 42.35076,-71.06274
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-03-tufts
+  startdate: 2013-06-03
+  url: http://swcarpentry.github.io/2013-06-03-tufts/
+  user: swcarpentry
+  venue: Tufts University
+- address: University of Chicago
+  country: United-States
+  enddate: 2013-06-05
+  humandate: June 4-5 and June 17-18, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Elliott Hauser, Fernanda Foertter, John Blischak]
+  latlng: 41.789722,-87.599722
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-04-dssg
+  startdate: 2013-06-04
+  url: http://swcarpentry.github.io/2013-06-04-dssg/
+  user: swcarpentry
+  venue: Data Science for Social Good
+- address: Blusson Hall Room 10011, Simon Fraser University, Burnaby BC.
+  country: Canada
+  enddate: 2013-06-07
+  eventbrite: 6744439801
+  humandate: June 6-7, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Lynne Williams, Ted Hart, Bernhard Konrad, Julia Gustavsen]
+  latlng: 49.276765,-122.917957
+  layout: bootcamp
+  registration: open
+  slug: 2013-06-06-sfu
+  startdate: 2013-06-06
+  url: http://swcarpentry.github.io/2013-06-06-sfu/
+  user: swcarpentry
+  venue: Simon Fraser University
+- address: La Jolla, CA
+  country: United-States
+  enddate: 2013-06-11
+  humandate: June 10-11, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jessica Kerr, Dhavide Aruliah, Bill Punch]
+  latlng: 32.887151,-117.246212
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-10-salk
+  startdate: 2013-06-10
+  url: http://swcarpentry.github.io/2013-06-10-salk/
+  user: swcarpentry
+  venue: Salk Institute
+- country: United-States
+  enddate: 2013-06-18
+  humandate: June 17-18, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [John Blischak, Will Trimble, Randy Olson, Emily Davenport]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-06-17-chicago
+  startdate: 2013-06-17
+  url: http://swcarpentry.github.io/2013-06-17-chicago/
+  user: swcarpentry
+  venue: University of Chicago
+- address: One Cambridge Center, Cambridge, MA 02142
+  country: United-States
+  enddate: 2013-06-25
+  eventbrite: 6181177067
+  humandate: June 24-25, 2013
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Tracy Teal, Sheeri Cabral, Adina Chuang-Howe, Jessica Mckellar, Aleksandra
+      Pawlik, Sarah Supp, Nelle Varoquaux]
+  latlng: 42.3625,-71.085
+  layout: bootcamp
+  registration: open
+  root: ../..
+  slug: 2013-06-24-wise
+  startdate: 2013-06-24
+  url: http://swcarpentry.github.io/2013-06-24-wise/
+  user: swcarpentry
+  venue: Women in Science and Engineering (Boston)
+- country: United-States
+  enddate: 2013-05-26
+  humandate: June 25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Katy Huff]
+  latlng: 30.2835989,-97.7344283
+  layout: bootcamp
+  registration: open
+  slug: 2013-06-25-scipy
+  startdate: 2013-05-25
+  url: http://swcarpentry.github.io/2013-06-25-scipy/
+  user: swcarpentry
+  venue: SciPy 2013
+- address: Undercroft Room, University of Canterbury, Christchurch
+  country: New-Zealand
+  enddate: 2013-07-04
+  humandate: July 1-4, 2013
+  humantime: 1:00 pm - 5:00 pm
+  instructor: [Shreyas Cholia, Ariel Rokem, Tim McNamara, Nick Jones]
+  latlng: -43.523333,172.581944
+  layout: bootcamp
+  registration: closed
+  slug: 2013-07-01-christchurch
+  startdate: 2013-07-01
+  url: http://swcarpentry.github.io/2013-07-01-christchurch/
+  user: swcarpentry
+  venue: eResearch New Zealand
+- address: The Core, Stephenson Research and Technology Center, University of Oklahoma
+  country: United-States
+  enddate: 2013-07-02
+  humandate: July 1-2, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Paul Ivanov, Aleksandra Pawlik]
+  latlng: 35.20859,-97.44566
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-07-01-oklahoma
+  startdate: 2013-07-01
+  url: http://swcarpentry.github.io/2013-07-01-oklahoma/
+  user: swcarpentry
+  venue: University of Oklahoma
+- address: Auditorium 2, Georg Sverdrups hus, Moltke Moes vei 39, Oslo
+  country: Norway
+  enddate: 2013-07-04
+  eventbrite: 5398444894
+  humandate: July 3-4, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Karin Lagesen, Lex Nederbragt]
+  latlng: 59.9399586,10.7217496
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-03-oslo
+  startdate: 2013-07-03
+  url: http://swcarpentry.github.io/2013-07-03-oslo/
+  user: swcarpentry
+  venue: University of Oslo
+- address: Xiao Hong Shan No.44, Wuhan
+  country: China
+  enddate: 2013-07-09
+  humandate: July 8-9, 2013
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Karen Cranston, Qingpeng Zhang]
+  latlng: 30.538977502418366,114.32192802429199
+  layout: bootcamp
+  registration: closed
+  slug: 2013-07-08-wuhan
+  startdate: 2013-07-08
+  url: http://swcarpentry.github.io/2013-07-08-wuhan/
+  user: swcarpentry
+  venue: Wuhan Institute of Virology
+- country: United-States
+  enddate: 2013-07-12
+  eventbrite: 6106951055
+  humandate: July 11-12, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Hansen, Jeff Shelton]
+  latlng: 39.1663815,-86.526621
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-11-indiana
+  startdate: 2013-07-11
+  url: http://swcarpentry.github.io/2013-07-11-indiana/
+  user: swcarpentry
+  venue: Indiana University
+- contact: host-bath@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-07-16
+  eventbrite: 6059565323
+  humandate: July 15-16, 2013
+  humantime: 9:00 - 17:00
+  instructor: [Mike Jackson, Christopher Woods]
+  latlng: 51.3777431,-2.3263779
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-15-bath
+  startdate: 2013-07-15
+  url: http://swcarpentry.github.io/2013-07-15-bath/
+  user: swcarpentry
+  venue: University of Bath
+- address: Sustainable Software for Chemistry and Materials Software Summer School
+  country: United-States
+  enddate: 2013-07-16
+  humandate: July 15-16, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tommy Guy, Ross Dickson]
+  latlng: 37.2283843,-80.4234167
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-07-15-vt
+  startdate: 2013-07-15
+  url: http://swcarpentry.github.io/2013-07-15-vt/
+  user: swcarpentry
+  venue: Virginia Tech
+- address: Utah State University Engineering Building (ENGR) Room 302
+  country: United-States
+  enddate: 2013-07-17
+  eventbrite: 6309398581
+  humandate: July 16-17, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ben Morris, Ethan White]
+  latlng: 41.74080,-111.81416
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-16-cuahsi
+  startdate: 2013-07-16
+  url: http://swcarpentry.github.io/2013-07-16-cuahsi/
+  user: swcarpentry
+  venue: CUAHSI Water Data Center
+- address: 140 DeBartolo Hall
+  country: United-States
+  enddate: 2013-07-19
+  eventbrite: 7012698169
+  humandate: July 18-19, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Randy Olson, Will Trimble]
+  latlng: 41.70522,-86.23531
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-18-notredame
+  startdate: 2013-07-18
+  url: http://swcarpentry.github.io/2013-07-18-notredame/
+  user: swcarpentry
+  venue: University of Notre Dame
+- country: United-States
+  enddate: 2013-07-19
+  humandate: July 18-19, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Jacob Vanderplas, Kyle Mandli]
+  latlng: 47.655,-122.303333
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-18-washington
+  startdate: 2013-07-18
+  url: http://swcarpentry.github.io/2013-07-18-washington/
+  user: swcarpentry
+  venue: University of Washington
+- address: Pittsburgh, PA
+  country: United-States
+  enddate: 2013-07-28
+  humandate: July 27-28, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Erik Bray, Josh Smith]
+  latlng: 40.443322,-79.943583
+  layout: bootcamp
+  registration: open
+  slug: 2013-07-27-cmu
+  startdate: 2013-07-27
+  url: http://swcarpentry.github.io/2013-07-27-cmu/
+  user: swcarpentry
+  venue: Carnegie Mellon University
+- address: Minneapolis Convention Center
+  country: United-States
+  enddate: 2013-08-04
+  humandate: Aug 4, 2013
+  humantime: 8:00 a.m. - 5:00 p.m.
+  instructor: [Ted Hart, Ben Morris, Ethan White]
+  latlng: 44.968657,-93.27457
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-04-esa
+  startdate: 2013-08-04
+  url: http://swcarpentry.github.io/2013-08-04-esa/
+  user: swcarpentry
+  venue: Ecological Society of America Annual Meeting
+- address: The Commons, University of Kansas
+  contact: ejm@ku.edu
+  country: United-States
+  enddate: 2013-08-23
+  humandate: Aug 22-23, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Darren Boss, Karen Cranston, Mark Holder, Emily Jane McTavish]
+  latlng: 38.9584551,-95.2432842
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-22-ku
+  startdate: 2013-08-22
+  url: http://swcarpentry.github.io/2013-08-22-ku/
+  user: swcarpentry
+  venue: University of Kansas
+- address: Vicksburg, MS
+  country: United-States
+  enddate: 2013-08-29
+  humandate: Aug 27-29, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Andy Terrel]
+  latlng: 32.3019199,-90.8733522
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-27-erdc
+  startdate: 2013-08-27
+  url: http://swcarpentry.github.io/2013-08-27-erdc/
+  user: swcarpentry
+  venue: US Army Engineer Research and Development Center
+- address: Wisconsin Institutes for Discovery, 3rd Floor Teaching Lab
+  country: United-States
+  enddate: 2013-08-29
+  eventbrite: 7317971249
+  humandate: Aug 28-29, 2013
+  humantime: 8:30 a.m. - 4:30 p.m.
+  instructor: [Matt Gidden, Jens von der Linden, Lauren Michael, Paul Wilson, Anthony
+      Scopatz]
+  latlng: 43.07718,-89.40399
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-08-28-wisc
+  startdate: 2013-08-28
+  url: http://swcarpentry.github.io/2013-08-28-wisc/
+  user: swcarpentry
+  venue: University of Wisconsin - Madison
+- country: United-States
+  enddate: 2013-09-06
+  eventbrite: 7583026035
+  humandate: Sept 5-6, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Adina Chuang Howe, Jory Schossau]
+  latlng: 41.66293,-91.56203
+  layout: bootcamp
+  registration: open
+  slug: 2013-09-05-iowa
+  startdate: 2013-09-05
+  url: http://swcarpentry.github.io/2013-09-05-iowa/
+  user: swcarpentry
+  venue: University of Iowa
+- contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-09-13
+  humandate: Sept 12-13, 2013
+  humantime: 9:00 a.m. - 5:00 p.m.
+  instructor: [Karthik Ram, Christopher Woods]
+  latlng: 51.457971,-2.601474
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-09-12-bristol
+  startdate: 2013-09-12
+  url: http://swcarpentry.github.io/2013-09-12-bristol/
+  user: swcarpentry
+  venue: University of Bristol
+- country: Canada
+  enddate: 2013-09-22
+  humandate: Sept 21-22, 2013
+  latlng: 43.468889,-80.54
+  layout: bootcamp
+  registration: open
+  slug: 2013-09-21-uwaterloo
+  startdate: 2013-09-21
+  url: http://swcarpentry.github.io/2013-09-21-uwaterloo/
+  user: swcarpentry
+  venue: University of Waterloo
+  instructor: [Gabriel Devenyi, Tommy Guy]
+- country: United-States
+  enddate: 2013-09-26
+  eventbrite: 7723648641
+  humandate: Sept 23-26, 2013
+  humantime: 8:00 am - 11:30 am
+  instructor: [Randy Olson, Jory Schossau, Tracy Teal, Jordan Fish, Michael Crusoe]
+  latlng: 42.724085,-84.476265
+  layout: bootcamp
+  registration: open
+  slug: 2013-09-23-msu
+  startdate: 2013-09-23
+  url: http://swcarpentry.github.io/2013-09-23-msu/
+  user: swcarpentry
+  venue: Michigan State University
+- address: Ingkarni Wardli, Room 218
+  country: Australia
+  enddate: 2013-09-26
+  humandate: Sep 24-26, 2013
+  humantime: 9:00 - 17:00
+  instructor: [Ben Morris, Diego Barneche, Philipp Bayer]
+  latlng: -34.919159,138.60414
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-09-24-acpfgA
+  startdate: 2013-09-24
+  url: http://swcarpentry.github.io/2013-09-24-acpfgA/
+  user: swcarpentry
+  venue: 'Australian Bioinformatics Network: Adelaide'
+- address: ESB-5108
+  country: Canada
+  enddate: 2013-09-27
+  eventbrite: 7405051709
+  humandate: Sept 26-27, 2013
+  instructor: [Julia Gustavsen, Doug Latornell]
+  latlng: 49.261111,-123.253056
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-09-26-ubc
+  startdate: 2013-09-26
+  url: http://swcarpentry.github.io/2013-09-26-ubc/
+  user: swcarpentry
+  venue: University of British Columbia
+- address: Building 60, Monash University Clayton campus
+  country: Australia
+  enddate: 2013-10-03
+  humandate: Oct 1-3, 2013
+  humantime: 9:00 - 17:00
+  instructor: [Ben Morris, Philipp Bayer]
+  latlng: -37.9083,145.138
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-10-01-acpfgM
+  startdate: 2013-10-01
+  url: http://swcarpentry.github.io/2013-10-01-acpfgM/
+  user: swcarpentry
+  venue: 'Australian Bioinformatics Network: Melbourne'
+- address: The Westin Bonaventure Hotel, Los Angeles
+  country: United-States
+  enddate: 2013-10-29
+  humandate: Oct 29, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [April Wright]
+  latlng: 34.052778,-118.255833
+  layout: bootcamp
+  registration: restricted
+  slug: 2013-10-29-vertpaleo
+  startdate: 2013-10-29
+  url: http://swcarpentry.github.io/2013-10-29-vertpaleo/
+  user: swcarpentry
+  venue: Society of Vertebrate Paleontology Annual Meeting
+- address: Aquarium Conference Room, NOAA National Marine Fisheries Service, Woods Hole
+  contact: james.maning@noaa.gov
+  country: United-States
+  enddate: 2013-11-15
+  humandate: Nov 14-15, 2013
+  humantime: 9:00 - 16:30
+  latlng: 41.526667,-70.663056
+  layout: bootcamp
+  registration: open
+  slug: 2013-11-14-whoi
+  startdate: 2013-11-14
+  url: http://swcarpentry.github.io/2013-11-14-whoi/
+  user: swcarpentry
+  venue: Woods Hole Scientific Community
+  instructor: [Ross Dickson, Will Trimble]
+- address: 3700 San Martin Drive, Baltimore, MD 21218
+  contact: gvwilson@software-carpentry.org
+  country: United-States
+  enddate: 2013-09-17
+  humandate: Sept 16-17, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Erik Bray, Justin Ely, Greg Wilson]
+  latlng: 39.33272,-76.62327
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-09-16-stsci
+  startdate: 2013-09-16
+  url: http://swcarpentry.github.io/2013-09-16-stsci/
+  user: swcarpentry
+  venue: Space Telescope Science Institute
+- address: BSLC 115, 924 East 57th Street
+  contact: jdblischak@uchicago.edu
+  country: United-States
+  enddate: 2013-09-20
+  humandate: Sept 19-20, 2013
+  humantime: 8:30 am - 4:30 pm
+  instructor: [John Blischak, Will Trimble, Emily Davenport]
+  latlng: 41.79149, -87.60270
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-09-19-chicago
+  startdate: 2013-09-19
+  url: http://jdblischak.github.io/2013-09-19-chicago/
+  user: jdblischak
+  venue: University of Chicago
+- address: Davidson Continuing Education Conference Center, 3415 S Figueroa St., Los
+    Angeles
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2013-09-17
+  humandate: Sept 16-17, 2013
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Ariel Rokem, Matt Terry, John Mehringer, Karan Vahi]
+  latlng: 34.020493, -118.281233
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-09-16-ISI
+  startdate: 2013-09-16
+  url: http://arokem.github.io/2013-09-16-ISI/
+  user: arokem
+  venue: University of Southern California
+- address: Centre Fran&ccedilois Jacob, room 28_01_01C
+  contact: jdblischak@uchicago.edu
+  country: France
+  enddate: 2013-10-04
+  humandate: Oct 03-04, 2013
+  humantime: 13:30 - 18:30, 9:00 - 17:30
+  instructor: [John Blischak, Diego Barneche]
+  latlng: 48.84042, 2.31068
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-10-03-pasteur
+  startdate: 2013-10-03
+  url: http://jdblischak.github.io/2013-10-03-pasteur/
+  user: jdblischak
+  venue: Institut Pasteur
+- address: Canberra
+  contact: karthik.ram@berkeley.edu
+  country: Australia
+  enddate: 2013-10-10
+  humandate: October 9-10, 2013
+  humantime: 8:30 am - 5 pm
+  instructor: [Karthik Ram]
+  latlng: -35.27770,149.11853
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2013-10-09-canberra
+  startdate: 2013-10-09
+  url: http://swcarpentry.github.io/2013-10-09-canberra/
+  user: swcarpentry
+  venue: CSIRO/ANU
+- address: MRMB 1152, 900 S. Ashland, Chicago, IL 60607
+  contact: microbe@uic.edu
+  country: United-States
+  enddate: 2013-10-18
+  humandate: Oct 17-18, 2013
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Rachel Poretsky, Neal Davis, Will Trimble, John Blischak]
+  latlng: 41.870206, -87.666934
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-10-17-uic
+  startdate: 2013-10-17
+  url: http://jdblischak.github.io/2013-10-17-uic/
+  user: jdblischak
+  venue: University of Illinois at Chicago
+- address: Phillips Auditorium at the Center for Astrophysics, 60 Garden Street
+  contact: harvard@lists.software-carpentry.org
+  country: United-States
+  enddate: 2013-08-24
+  humandate: August 23-24, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Erik Bray, Jessica McKellar, R. David Murray, Mike Selik]
+  latlng: 42.381705,-71.127904
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-08-23-harvard
+  startdate: 2013-08-23
+  url: http://swcarpentry.github.io/2013-08-23-harvard/
+  user: swcarpentry
+  venue: Harvard University
+- address: 11th Floor, Greenwich Digital Enterprise Centre, 6 Mitre Passage, London
+    SE10 0ER
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-10-25
+  eventbrite: 7995483707
+  humandate: Oct 24-25, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson, James Hetherington, Karthik Ram]
+  latlng: 51.50066,0.00663
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2013-10-24-greenwich
+  startdate: 2013-10-24
+  url: http://swcarpentry.github.io/2013-10-24-greenwich/
+  user: swcarpentry
+  venue: Greenwich, England
+- address: NYC
+  contact: ely@stsci.edu
+  country: United-States
+  enddate: 2013-10-26
+  humandate: October 25-26, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Ely, David Koop, Ivan Gonzalez, David Warde-Farley]
+  latlng: 40.8080777,-73.9635678
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-10-25-columbia
+  startdate: 2013-10-25
+  url: http://justincely.github.io/2013-10-25-columbia/
+  user: justincely
+  venue: Columbia University and CUSP
+- address: Reed Hall, Streatham Drive, Exeter, Devon EX4 4QR
+  contact: host-exeter@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-11-15
+  humandate: November 14-15, 2013
+  humantime: 9:00 am - 5.00 pm
+  instructor: [David Martin, Christopher Woods]
+  latlng: 50.735788,-3.535033
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-11-14-exeter
+  startdate: 2013-11-14
+  url: http://chryswoods.github.io/2013-11-14-exeter/
+  user: chryswoods
+  venue: Exeter University
+- address: Old Arts, Second Floor, Collaborative Learning Space 2 (room 257)
+  contact: karenl@unimelb.edu.au
+  country: Australia
+  enddate: 2013-12-04
+  humandate: Nov 25 & 27/Dec 2 & 4, 2013
+  humantime: 3:00 pm - 6:00 pm
+  instructor: [Damien Irving]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-11-25-unimelb
+  startdate: 2013-11-25
+  url: http://damienirving.github.io/2013-11-25-unimelb/
+  user: damienirving
+  venue: University of Melbourne
+- address: Room 3217, James Clark Maxwell Building, Kings Buildings, Mayfield Road,
+    Edinburgh, EH9 3JZ
+  contact: host-edinburgh@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-12-04
+  humandate: Dec 3-4, 2013
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Mike Jackson, Mario Antonioletti]
+  latlng: 55.921628,-3.174155
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2013-12-03-edinburgh
+  startdate: 2013-12-03
+  url: http://mikej888.github.io/2013-12-03-edinburgh/
+  user: mikej888
+  venue: The University of Edinburgh
+- address: SESYNC, Annapolis, MD
+  contact: mshelley@sesync.org
+  country: United-States
+  enddate: 2013-12-06
+  humandate: Dec 3-6, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Will Trimble, Amanda Whitlock, Bernhard Konrad, Aron Ahmadia, R.
+      David Murray]
+  latlng: 38.976734, -76.503296
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-12-03-sesync
+  startdate: 2013-12-03
+  url: http://wltrimbl.github.io/2013-12-03-sesync/
+  user: wltrimbl
+  venue: National Socio-Environmental Synthesis Center (SESYNC)
+- address: Room 320, Kelvin Building
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2013-12-13
+  humandate: Dec 12-13, 2013
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ben Morris, James Morrison]
+  latlng: 55.87185,-4.29155
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-12-12-glasgow
+  startdate: 2013-12-12
+  url: http://bendmorris.github.io/2013-12-12-glasgow/
+  user: bendmorris
+  venue: Glasgow University
+- address: College of Life Sciences, University of Dundee, Dundee DD1 5EH
+  contact: d.m.a.martin@dundee.ac.uk
+  country: United-Kingdom
+  enddate: 2013-12-16
+  humandate: December 16-17, 2013
+  humantime: 9:00 am - 5.00 pm
+  instructor: [David Martin, Martin Jones]
+  latlng: 56.464,-2.97
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2013-12-16-dundee
+  startdate: 2013-12-16
+  url: http://davidmam.github.io/2013-12-16-dundee/
+  user: davidmam
+  venue: Dundee University
+- address: Bailey Hall 214-216, 10 Bailey Drive, Fredericton, New Brunswick
+  contact: jgustavsen@eos.ubc.ca
+  country: Canada
+  enddate: 2014-01-07
+  humandate: Jan 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Julia Gustavsen, Ross Dickson]
+  latlng: 45.947214,-66.640325
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-06-unb
+  startdate: 2014-01-06
+  url: http://jooolia.github.io/2014-01-06-unb/
+  user: jooolia
+  venue: University of New Brunswick
+- address: Wilberforce Road, Cambridge
+  contact: r.cam.bootcamp@gmail.com
+  country: United-Kingdom
+  enddate: 2014-01-08
+  humandate: Jan 7-8, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stephen Eglen, Laurent Gatto, Aleksandra Pawlik]
+  latlng: 52.209868,0.102439
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-07-cam
+  startdate: 2014-01-07
+  url: http://sje30.github.io/2014-01-07-cam/
+  user: sje30
+  venue: Centre for Mathematical Sciences, University of Cambridge
+- address: ISU Memorial Union (1/8/14 - Oak and South Ballroom, 1/9/14 - Oak and Sun
+    Room)
+  contact: howead@msu.edu
+  country: United-States
+  enddate: 2014-01-09
+  humandate: Jan 8-9, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jonah Duckles, Molly Gibson, Adina Howe, William Trimble]
+  latlng: 42.02662,-93.64647
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-08-iastate
+  startdate: 2014-01-08
+  url: http://adina.github.io/2014-01-08-iastate/
+  user: adina
+  venue: Iowa State University
+- address: 366 Adelaide Street West, Toronto
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-01-14
+  humandate: Jan 13-14, 2014
+  humantime: 8:45 am - 4:30 pm
+  instructor: [Andromeda Yelton, Chris Gray, Victor Ng, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-01-13-toronto
+  startdate: 2014-01-13
+  url: http://swcarpentry.github.io/2014-01-13-toronto/
+  user: swcarpentry
+  venue: Mozilla Toronto
+- address: Hazard Conference Room, 215 South Ferry Road, Narragansett, RI 02882
+  contact: igonzalez@mailaps.org
+  country: United-States
+  enddate: 2014-01-14
+  humandate: Jan 13-14, 2014
+  humantime: 8:00 am - 4:00 pm
+  instructor: [Patrick Fuller, Ivan Gonzalez]
+  latlng: 41.492635,-71.422294
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-13-uri
+  startdate: 2014-01-13
+  url: http://iglpdc.github.io/2014-01-13-uri/
+  user: iglpdc
+  venue: Coastal Institute, University of Rhode Island
+- address: Researcher's Link, Wisconsin Institutes for Discovery
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-01-14
+  eventbrite: 9770502837
+  humandate: Jan 13-14, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Paul Wilson, Matt Gidden, Lauren Michael, Cliff Davis, Danielle Nielsen,
+    Aronne Merrelli]
+  latlng: 43.07718,-89.40399
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-13-wisc
+  startdate: 2014-01-13
+  url: http://uw-madison-aci.github.io/2014-01-13-wisc/
+  user: uw-madison-aci
+  venue: University of Wisconsin-Madison
+- address: Room IT407, Information Technology Building, University of Manchester,
+    Oxford Road, M13 9PL
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-01-15
+  humandate: Jan 14-15, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Michael Croucher, Jos Martin, Shoaib Sufi, Aleksandra Pawlik]
+  latlng: 53.467972,-2.233154
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-14-manchester
+  startdate: 2014-01-14
+  url: http://apawlik.github.io/2014-01-14-manchester/
+  user: apawlik
+  venue: University of Manchester
+- address: Moffitt 103
+  contact: jkitzes@berkeley.edu
+  country: United-States
+  enddate: 2014-01-19
+  humandate: Jan 18-19, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Justin Kitzes, Chris Holdgraf, Mark Wilber]
+  latlng: 34.413963,-119.848947
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-18-ucb
+  startdate: 2014-01-18
+  url: http://swcarpentry.github.io/2014-01-18-ucb/
+  user: swcarpentry
+  venue: University of California Berkeley
+- address: '405 Avenue Ogilvy #101, Montreal'
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-01-21
+  eventbrite: 9698535581
+  humandate: Jan 20-21, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson, Julia Evans]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-01-20-montreal
+  startdate: 2014-01-20
+  url: http://gvwilson.github.io/2014-01-20-montreal/
+  user: gvwilson
+  venue: CRIM (Montreal)
+- address: 3909 Halls Ferry Rd Vicksburg, MS 39180
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-01-22
+  humandate: January 21-22, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Randal Olson]
+  latlng: 32.301199,-90.871617
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-21-erdc
+  startdate: 2014-01-21
+  url: http://geocarpentry.github.io/2014-01-21-erdc/
+  user: geocarpentry
+  venue: US Army Engineer Research and Development Center
+- address: Hartley Conference Center, Mitchell Earth Sciences bldg., Stanford, CA
+  contact: arokem@gmail.com
+  country: United-States
+  enddate: 2014-01-28
+  humandate: Jan 27-28, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ariel Rokem, Justin Kitzes]
+  latlng: 37.4225, -122.1653
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-27-Stanford
+  startdate: 2014-01-27
+  url: http://arokem.github.io/2014-01-27-Stanford/
+  user: arokem
+  venue: Stanford University
+- address: Newman Alumni Center (tentative)
+  contact: SKhuri@med.miami.edu
+  country: United-States
+  enddate: 2014-01-28
+  humandate: Jan 27-28, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Jenny Bryan, Carlos Anderson, Bernhard Konrad, Justin Ely, Victor Ng,
+    Jonah Duckles]
+  latlng: 25.7174346,-80.2781389
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-27-miami
+  startdate: 2014-01-27
+  url: http://jennybc.github.io/2014-01-27-miami/
+  user: jennybc
+  venue: University of Miami
+- address: Alma Mater Room, I Hotel and Conference Center, 1900 South 1st Street,
+    Champaign, IL 61820
+  contact: davis68@illinois.edu
+  country: United-States
+  enddate: 2014-01-31
+  humandate: Jan 30-31, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Selik, Neal Davis]
+  latlng: 40.093692, -88.237606
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-01-30-cse
+  startdate: 2014-01-30
+  url: http://uiuc-cse.github.io/2014-01-30-cse/
+  user: uiuc-cse
+  venue: University of Illinois, Computational Science and Engineering
+- address: 15 Vassar Street, 48-316
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-02-01
+  humandate: Jan 30 - Feb 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Randy Olson]
+  latlng: 42.361947,-71.090936
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-30-mit
+  startdate: 2014-01-30
+  url: http://geocarpentry.github.io/2014-01-30-mit/
+  user: geocarpentry
+  venue: Massachusetts Institute of Technology
+- address: 1424 Bren Hall, University of California, Santa Barbara
+  contact: jkitzes@berkeley.edu
+  country: United-States
+  enddate: 2014-02-01
+  humandate: Jan 31-Feb 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Justin Kitzes, Shane Grigsby, Mark Wilber]
+  latlng: 34.412114,-119.842014
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-01-31-ucsb
+  startdate: 2014-01-31
+  url: http://swcarpentry.github.io/2014-01-31-ucsb/
+  user: swcarpentry
+  venue: University of California Santa Barbara
+- address: Norwich Research Park, Norwich
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-02-04
+  humandate: Feb 3-4, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aleksandra Pawlik, Rob Davey]
+  latlng: 52.6217629,-1.2409930
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-03-TGAC
+  startdate: 2014-02-03
+  url: http://apawlik.github.io/2014-02-03-TGAC/
+  user: apawlik
+  venue: The Genome Analysis Centre (TGAC)
+- address: Institute for Marine and Antarctic Studies, <a href="http://www.utas.edu.au/commercial-services-development/building-works/current-projects/institute-for-marine-and-antarctic-studies-imas">Castray
+    Esplanade, Battery Point</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-02-11
+  humandate: Feb 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Damien Irving]
+  latlng: -42.8806,147.3250
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-10-hobart
+  startdate: 2014-02-10
+  url: http://damienirving.github.io/2014-02-10-hobart/
+  user: damienirving
+  venue: AMOS conference
+- address: 366 Adelaide Street West, Toronto
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-02-12
+  eventbrite: 9459779455
+  humandate: Feb 11-12, 2014
+  humantime: 8:45 am - 4:30 pm
+  instructor: [Trevor Bekolay, Bonny Biswas, Abigail Cabunoc, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-11-toronto
+  startdate: 2014-02-11
+  url: http://swcarpentry.github.io/2014-02-11-toronto/
+  user: swcarpentry
+  venue: Mozilla Toronto
+- address: 8888 University Drive, Burnaby
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-03-01
+  eventbrite: 8883102599
+  humandate: Feb 22 and Mar 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Bernhard Konrad, Scott Chamberlain, Christina Koch, Lynne Williams]
+  latlng: 49.276765,-122.917957
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-22-SFU
+  startdate: 2014-02-22
+  url: http://bernhardkonrad.github.io/2014-02-22-SFU/
+  user: bernhardkonrad
+  venue: Simon Fraser University
+- address: TBD
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-02-16
+  humandate: Feb 15-16, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Emily Jane McTavish, Jonah Duckles]
+  latlng: 39.091816,-94.550378
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-15-umkc
+  startdate: 2014-02-15
+  url: http://swcarpentry.github.io/2014-02-15-umkc/
+  user: swcarpentry
+  venue: University of Missouri - Kansas City
+- address: High St, Kensington NSW 2052 (Boral Theatre in the AGSM)
+  contact: a.letten@unsw.edu.au
+  country: Australia
+  enddate: 2014-02-14
+  humandate: Feb 13-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Daniel Falster, Rich FitzJohn, Diego Barneche]
+  latlng: -33.917410,151.231307
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-13-UNSW
+  startdate: 2014-02-13
+  url: http://nicercode.github.io/2014-02-13-UNSW/
+  user: nicercode
+  venue: University of New South Wales
+- address: CB06.06.103 (Bld 6, level 6, Rm 103)<br> 15 Broadway, Ultimo NSW 2007,
+    Australia <a href ="http://maps.uts.edu.au/map.cfm">map</a>
+  contact: daniel.falster@mq.edu.au
+  country: Australia
+  enddate: 2014-02-19
+  humandate: Feb 18-19, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Daniel Falster, Rich FitzJohn, Diego Barneche]
+  latlng: -33.883898,151.201013
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-18-UTS
+  startdate: 2014-02-18
+  url: http://nicercode.github.io/2014-02-18-UTS/
+  user: nicercode
+  venue: University of Technology, Sydney
+- address: Accra - Cape Coast Rd, Biriwa, Central, Biriwa
+  contact: admin@software-carpentry.org
+  country: Ghana
+  enddate: 2014-02-20
+  humandate: Feb 18-20, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Stefano Cozzini, Kwasi Kwakwa]
+  latlng: 5.161988,-1.165945
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-02-18-aims
+  startdate: 2014-02-18
+  url: http://swcarpentry.github.io/2014-02-18-aims/
+  user: swcarpentry
+  venue: African Institute for Mathematical Sciences
+- address: London
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-02-19
+  humandate: Feb 18-19, 2014
+  humantime: 10:00 am - 5:00 pm
+  instructor: [James Hetherington, Owain Kenway, Miguel Bernabeu Llinares, Mayeul
+      d'Avezac]
+  latlng: 51.5243625,-0.1344750
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-18-UCL
+  startdate: 2014-02-18
+  url: http://apawlik.github.io/2014-02-18-UCL/
+  user: apawlik
+  venue: University College London
+- address: Madrid
+  contact: abostroem@stsci.edu
+  country: Spain
+  enddate: 2014-02-24
+  humandate: Feb 24-25, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Azalee Bostroem, Justin Ely]
+  latlng: 40.46871,-3.94383
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-24-esac
+  startdate: 2014-02-25
+  url: http://justincely.github.io/2014-02-24-esac/
+  user: justincely
+  venue: ESAC
+- address: ETH Hoenggerberg, HIT E51, Zurich
+  contact: admin@software-carpentry.org
+  country: Switzerland
+  enddate: 2014-03-01
+  humandate: Feb 28-Mar 1, 2014
+  humantime: 9:00 am - 5:30 pm
+  instructor: [Stefano Cozzini, Sam Thomson]
+  latlng: 47.4103, 8.508272
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-02-28-ethz
+  startdate: 2014-02-28
+  url: http://swcarpentry.github.io/2014-02-28-ethz/
+  user: swcarpentry
+  venue: ETH Zurich
+- address: Brown Science and Engineering Library Electronic Classroom, Clark Hall
+    (Room 133)
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-11
+  humandate: Mar 10-11 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Michael Hansen, Stephen Turner, Erik Bray]
+  latlng: 38.033553,-78.507977
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-10-uva
+  startdate: 2014-03-10
+  url: http://synesthesiam.github.io/2014-03-10-uva/
+  user: synesthesiam
+  venue: University of Virginia
+- address: 4 Washington Place, 2nd Floor, Manhattan (for Python) and<br/> 1 MetroTech
+    Center, 19th Floor, Brooklyn (for R)
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-18
+  eventbrite: 10435144799
+  humandate: Mar 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Elena Glassman, Matthew Lightman, Michael Selik, Sarah Supp, Tracy
+      Teal, Alex Viana, David Warde-Farley]
+  ipythonnotebook: http://nbviewer.ipython.org/urls
+  latlng: 40.729513,-73.996461
+  layout: bootcamp
+  raw: raw.github.com/swcarpentry/bc/gh-pages
+  registration: open
+  root: .
+  slug: 2014-03-17-nyu
+  startdate: 2014-03-17
+  url: http://swcarpentry.github.io/2014-03-17-nyu/
+  user: swcarpentry
+  venue: New York University
+- address: Kinzie and Tamalpais Rooms, David Brower Center, 2150 Alliston Way, Berkeley
+    CA
+  contact: davclark@berkeley.edu
+  country: United-States
+  enddate: 2014-03-18
+  humandate: Mar 17-18, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Justin Kitzes, Matt Davis, Chang She, Cindee Madison, Chris Holdgraf,
+    Thomas Kluyver, Dav Clark, Anna Schneider]
+  latlng: 37.873913,-122.250563
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-03-17-ucb
+  startdate: 2014-03-17
+  url: http://swcarpentry.github.io/2014-03-17-ucb/
+  user: swcarpentry
+  venue: University of California - Berkeley
+- address: HUB 145, 4001 Stevens Way NE and OUG 220, 4060 George Washington Ln NE,
+    Seattle
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-18
+  eventbrite: 10299635487
+  humandate: Mar 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Bernhard Konrad, Jenny Bryan, Tommy Guy, Christina Koch, Lynne Williams,
+    Trevor King]
+  latlng: 47.655335,-122.303519
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-17-uw
+  startdate: 2014-03-17
+  url: http://ljwilliams.github.io/2014-03-17-uw/
+  user: ljwilliams
+  venue: University of Washington
+- address: 100 S. Grant Street, West Lafayette, IN
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-03-18
+  humandate: March 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Neal Davis, Joshua Herr, Jeff Shelton]
+  latlng: 40.423784,-86.909696
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-17-purdue
+  startdate: 2014-03-17
+  url: http://swcarpentry.github.io/2014-03-17-purdue/
+  user: swcarpentry
+  venue: Purdue University
+- address: <a href="http://maps.unimelb.edu.au/parkville/building/104#.Uw0fhPiLelM">Alan
+    Gilbert Building</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-03-28
+  humandate: Mar 18, 21, 26 & 28, 2014
+  humantime: 9:00 am - 12:30 pm
+  instructor: [Damien Irving]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-03-18-combine
+  startdate: 2014-03-18
+  url: http://resbaz.github.io/2014-03-18-combine/
+  user: resbaz
+  venue: University of Melbourne
+- address: Room 110, Petch Building
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-04-03
+  eventbrite: 10138651981
+  humandate: Apr 2-3, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ethan White, Greg Wilson, Bill Mills]
+  latlng: 48.461821,-123.310443
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-02-uvic
+  startdate: 2014-04-02
+  url: http://swcarpentry.github.io/2014-04-02-uvic/
+  user: swcarpentry
+  venue: University of Victoria
+- address: <a href="http://vejviser.sdu.dk/opslag?lid=1082">Room U24</a> on day 1,
+    <a href="http://vejviser.sdu.dk/opslag?lid=1799">room U30A</a> on day 2
+  contact: admin@software-carpentry.org
+  country: Denmark
+  enddate: 2014-04-04
+  humandate: Apr 3-4, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Luis Pedro Coelho, Steven Koenig]
+  latlng: 55.368735,10.426408
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-03-sdu
+  startdate: 2014-04-03
+  url: http://luispedro.github.io/2014-04-03-sdu/
+  user: luispedro
+  venue: University of Southern Denmark
+- address: 101 David L. Boren Blvd, Norman OK 73019
+  contact: jduckles@ou.edu
+  country: United-States
+  enddate: 2014-04-05
+  helpers: [Mark Stacy, Mark Laufersweiler]
+  humandate: April 4-5, 2014
+  instructor: [Jonah Duckles, Emily Jane McTavish]
+  latlng: 35.183121,-97.441238
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-04-ou
+  startdate: 2014-04-04
+  url: http://jduckles.github.io/2014-04-04-ou/
+  user: jduckles
+  venue: University of Oklahoma
+- address: 3080 Center Green Drive, Boulder, CO
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-04-10
+  humandate: Apr 09-10, 2014
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Edmund Hart, Camille Avestruz]
+  latlng: 40.031528, -105.245847
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-09-ucar
+  startdate: 2014-04-09
+  url: http://emhart.github.io/2014-04-09-ucar/
+  user: emhart
+  venue: University Corporation for Atmospheric Research
+- address: School of Life Sciences on Gibbet Hill Campus, Coventry
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-04-10
+  humandate: Apr 09-10, 2014
+  humantime: 9:45 am - 4:00 pm
+  instructor: [Aleksandra Pawlik, Christina Koch]
+  latlng: 52.3802961,-1.5639370
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-09-GARNET
+  startdate: 2014-04-09
+  url: http://apawlik.github.io/2014-04-09-GARNET/
+  user: apawlik
+  venue: GARNet, Warwick University
+- address: Lawrence Berkeley National Laboratory, Berkeley, California
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-04-15
+  humandate: Apr 14-15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Katy Huff, Rachel Slaybaugh, Azalee Bostroem, Cindee Madison, Jessica
+      Kerr, Molly Gibson, and Suzanne Kiihne]
+  latlng: 37.8734481,-122.2563972
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-wise
+  startdate: 2014-04-14
+  url: http://swcarpentry.github.io/2014-04-14-wise/
+  user: swcarpentry
+  venue: Women in Science and Engineering
+- address: Room 523, Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-04-15
+  eventbrite: 10151376039
+  humandate: Apr 14-15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Anthony Scopatz, Ivan Gonzalez, Marcello Barisonzi, Marianne Corvellec,
+    Denis Haine]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon
+  startdate: 2014-04-14
+  url: http://swcarpentry.github.io/2014-04-14-pycon/
+  user: swcarpentry
+  venue: Software Skills for Scientists and Engineers
+- address: Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-04-15
+  eventbrite: 10812972893
+  humandate: Apr 14-15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Luke Lee, Jessica Hamrick]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon-lib
+  startdate: 2014-04-14
+  url: http://dhavide.github.io/2014-04-14-pycon-lib/
+  user: dhavide
+  venue: Software Skills for Librarians
+- address: Room 525, Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  eventbrite: 10151618765
+  humandate: Apr 14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Titus Brown]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon-ngs
+  startdate: 2014-04-14
+  url: http://swcarpentry.github.io/2014-04-14-pycon-ngs/
+  user: swcarpentry
+  venue: Next-Generation Sequencing
+- address: Room 525, Palais de Congres, Montreal, Quebec
+  contact: admin@software-carpentry.org
+  country: Canada
+  eventbrite: 10319320365
+  helper: [Denis Haine, John Blischak]
+  humandate: Apr 15, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ramnath Vaidyanathan]
+  latlng: 45.530677,-73.624497
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-14-pycon-r
+  startdate: 2014-04-15
+  url: http://swcarpentry.github.io/2014-04-14-pycon-r/
+  user: swcarpentry
+  venue: R for Python Programmers
+- address: Vilvite, Thorm&oslash;hlensgate 51, 5006 Bergen
+  contact: david.fredman@uib.no
+  country: Norway
+  enddate: 2014-04-24
+  humandate: April 23-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Lex Nederbragt, Karin Lagesen, David Fredman]
+  latlng: 60.3812811,5.3291539
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-04-23-uib
+  startdate: 2014-04-23
+  url: http://elixirno.github.io/2014-04-23-uib/
+  user: elixirno
+  venue: University of Bergen
+- address: Virginia Science and Technology Campus, Ashburn, VA
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-04-30
+  humandate: Apr 29-30, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aron Ahmadia, Joshua R. Herr, William Rowell]
+  latlng: 39.059322,-77.445661
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-04-29-gwu
+  startdate: 2014-04-29
+  url: http://jrherr.github.io/2014-04-29-gwu/
+  user: jrherr
+  venue: George Washington University
+- address: Waterfront Campus, European Way, Southampton, Hampshire, SO14 3ZH
+  country: United-Kingdom
+  enddate: 2014-05-09
+  humandate: May 08-09, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Bogdan Vera, Devasena Inupakutika]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  organizer: Maike Sonnewald
+  registration: restricted
+  root: .
+  slug: 2014-05-08-soton
+  startdate: 2014-05-08
+  url: http://DevasenaInupakutika.github.io/2014-05-08-soton/
+  user: DevasenaInupakutika
+  venue: National Oceanography Centre
+- address: Mills Library L107, 1280 Main St. W. Hamilton, Ontario
+  contact: devenyga@mcmaster.ca
+  country: Canada
+  enddate: 2014-05-06
+  eventbrite: 11361824523
+  humandate: May 5-6, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Greg Wilson, Gabriel Devenyi]
+  latlng: 43.2627392,-79.9175982
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-05-05-mcmaster
+  startdate: 2014-05-05
+  url: http://gdevenyi.github.io/2014-05-05-mcmaster/
+  user: gdevenyi
+  venue: McMaster University Wong e-Classroom
+- address: "Av. Italia, km 8, sala 2106 no pavilhao 2."
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-05-13
+  eventbrite: 11429715587
+  helper: [Marcus Vinicius Freire Guimaraes]
+  humandate: 12 e 13 de Maio, 2014
+  humantime: 8:00 - 17:30
+  instructor: [Raniere Silva, Fernando Mayer]
+  latlng: -32.06811,-52.16238
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-05-12-furg
+  startdate: 2014-05-12
+  url: http://r-gaia-cs.github.io/2014-05-12-furg/
+  user: r-gaia-cs
+  venue: Universidade Federal do Rio Grande
+- address: One Bungtown Road, Cold Spring Harbor, NY
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-05-13
+  humandate: May 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Will Trimble, Sheldon McKay]
+  latlng: 40.859197,-73.468704
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-05-12-cshl
+  startdate: 2014-05-12
+  url: http://wltrimbl.github.io/2014-05-12-cshl/
+  user: wltrimbl
+  venue: Cold Spring Harbor Laboratory, Hershey Building, east conference room
+- address: Mozilla, 366 Adelaide Street West, Toronto
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-05-13
+  humandate: May 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua Ainsley, Abigail Cabunoc, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-12-oicr-toronto
+  startdate: 2014-05-12
+  url: http://swcarpentry.github.io/2014-05-12-oicr-toronto/
+  user: swcarpentry
+  venue: Ontario Institute for Cancer Research
+- address: University of British Columbia, Vancouver, BC
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-05-13
+  humandate: May 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jenny Bryan, Shaun Jackman, Andy Leung]
+  latlng: 49.26508,-123.25378
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-12-ubc
+  startdate: 2014-05-12
+  url: http://jennybc.github.io/2014-05-12-ubc/
+  user: jennybc
+  venue: bioinformatics.ca
+- address: Karolinska Institutet Science Park, Stockholm
+  contact: admin@software-carpentry.org
+  country: Sweden
+  enddate: 2014-05-20
+  humandate: May 19-20, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Konrad Hinsen, Nelle Varoquaux, Karin Lagesen, Lex Nederbragt]
+  latlng: 59.329323,18.068581
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-19-scilifelab
+  startdate: 2014-05-19
+  url: http://gvwilson.github.io/2014-05-19-scilifelab/
+  user: gvwilson
+  venue: Science Life Lab
+- address: Room 620, Administrative and Research Center, 3100 Marine St. Boulder,
+    CO 80309
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-05-23
+  humandate: May 23, 2014
+  humantime: 8:00 am - 5:00 pm
+  instructor: [Aron Ahmadia, Ted Hart]
+  latlng: 40.013187,-105.253465
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-23-csdms
+  startdate: 2014-05-23
+  url: http://geocarpentry.github.io/2014-05-23-csdms/
+  user: geocarpentry
+  venue: Community Surface Dynamics Modeling System Meeting
+- address: SeaCave in the Eckart Bldg, La Jolla, CA
+  contact: ntpierce@ucsd.edu
+  country: United-States
+  enddate: 2014-05-30
+  humandate: May 29-30, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Lasher, Will Trimble, Andrea Zonca]
+  latlng: 32.867307,-117.252586
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-05-29-ucsd
+  startdate: 2014-05-29
+  url: http://gotgenes.github.io/2014-05-29-ucsd/
+  user: gotgenes
+  venue: Scripps Institution of Oceanography, UC San Diego
+- address: Faculty of Medicine, Nursing and Health Sciences (Krongold Centre (Building
+    5) / Room G19), Wellington Road, Clayton, Victoria 3800
+  contact: Matthew.Dimmock@monash.edu
+  country: Australia
+  enddate: 2014-06-04
+  humandate: Jun 02-04, 2014
+  humantime: 1:00 pm - 5:00 pm
+  instructor: [Matthew Dimmock, Damien Irving]
+  latlng: -37.915211,145.134682
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-02-monash
+  startdate: 2014-06-02
+  url: http://badger-d.github.io/2014-06-02-monash/
+  user: badger-d
+  venue: Monash University
+- address: Pisa
+  contact: admin@software-carpentry.org
+  country: Italy
+  enddate: 2014-06-06
+  humandate: Jun 04-06, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aleksandra Pawlik, "R\xE9mi Emonet"]
+  latlng: 43.720699,10.408022
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-03-cern
+  startdate: 2014-06-05
+  url: http://apawlik.github.io/2014-06-03-cern/
+  user: apawlik
+  venue: "Italian National Institute for Nuclear Physics, Department of Physics, Universit\xE0\
+    \ di Pisa"
+- address: Mann Library, Room B30A<br>237 Mann Drive<br>Ithaca, NY 14853
+  contact: mudrak@cornell.edu
+  country: United-States
+  enddate: 2014-06-05
+  eventbrite: 11562775573
+  humandate: Jun 4-5, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Gabriel A. Devenyi, Jeramia Ory]
+  latlng: 42.449286,-76.476284
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-04-cornell
+  startdate: 2014-06-04
+  url: http://gdevenyi.github.io/2014-06-04-cornell/
+  user: gdevenyi
+  venue: Cornell University
+- address: 20 Konstantinou Kavafi Street, 2121 Aglantzia, Nicosia
+  contact: admin@software-carpentry.org
+  country: Cyprus
+  enddate: 2014-06-11
+  humandate: Jun 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Luis Pedro Coelho, Marios Isaakidis]
+  latlng: 35.164972,33.361289
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-10-cyi
+  startdate: 2014-06-10
+  url: http://luispedro.github.io/2014-06-10-cyi/
+  user: luispedro
+  venue: Cyprus Institute
+- address: Albro-Falconer-Manely Science Center, Room 232, 440 Westview Dr. S.W.,
+    Atlanta, GA 30354
+  contact: hqin@spelman.edu
+  country: United-States
+  enddate: 2014-06-11
+  humandate: Jun 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Will Trimble, Elijah Lowe]
+  latlng: 33.745,-84.409
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-10-spelman
+  startdate: 2014-06-10
+  url: http://wltrimbl.github.io/2014-06-10-spelman/
+  user: wltrimbl
+  venue: Spelman College
+- address: Amman
+  contact: admin@software-carpentry.org
+  country: Jordan
+  enddate: 2014-06-17
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Luis Pedro Coelho, Marios Isaakidis]
+  latlng: 31.956578,35.945695
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-15-khbp
+  startdate: 2014-06-16
+  url: http://luispedro.github.io/2014-06-15-khbp/
+  user: luispedro
+  venue: Ibis Hotel (Open One Meeting Room)
+- address: UCDavis Shields Library
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-17
+  eventbrite: '11471139487'
+  humandate: Jun 16-17, 2014
+  humantime: 8:30 am - 5:00 pm
+  instructor: [Naupaka Zimmerman, Bernhard Konrad, Dav Clark, Andrea Zonca]
+  latlng: 38.5397144,-121.7490892
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-16-davis
+  startdate: 2014-06-16
+  url: http://BernhardKonrad.github.io/2014-06-16-davis/
+  user: BernhardKonrad
+  venue: UC Davis
+- address: 888 Columbia Ave, Claremont, CA 91711; Kravis Center, room LC62 (Freeberg
+    Forum)
+  contact: psn@kecksci.claremont.edu
+  country: United-States
+  enddate: 2014-06-17
+  eventbrite: 11558171803
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Preston Holmes, Bill Mills]
+  latlng: 34.102082,-117.711183
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-16-claremont
+  startdate: 2014-06-16
+  url: http://ptone.github.io/2014-06-16-claremont/
+  user: ptone
+  venue: Claremont Colleges
+- address: 366 Adelaide Street West, Toronto, Ontario
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-06-17
+  eventbrite: 11526822035
+  helper: [Catalina Anghel]
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Pauline Barmby, Jennifer Campbell, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-06-16-toronto
+  startdate: 2014-06-16
+  url: http://swcarpentry.github.io/2014-06-16-toronto/
+  user: swcarpentry
+  venue: Mozilla Toronto
+- address: CRTP Classroom, 2nd Floor, Hock Plaza, 2424 Erwin Road
+  contact: cliburn.chan@duke.edu
+  country: United-States
+  enddate: 2014-06-17
+  humandate: Jun 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Cliburn Chan, Karen Cranston, Joshua Granek]
+  latlng: 36.009706, -78.941628
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-16-duke
+  startdate: 2014-06-16
+  url: http://cliburn.github.io/2014-06-16-duke/
+  user: cliburn
+  venue: Duke University
+- address: Bowers Auditorium, Sage Hall, 205 Prospect, New Haven, CT 06511
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-21
+  eventbrite: 11719002853
+  humandate: June 20-21, 2014
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Camille Avestruz, Matthew Lightman]
+  ipythonnotebook: http://nbviewer.ipython.org/urls
+  latlng: 41.317165,-72.923847
+  layout: bootcamp
+  raw: raw.github.com/swcarpentry/bc/gh-pages
+  registration: restricted
+  root: .
+  slug: 2014-06-20-yale
+  startdate: 2014-06-20
+  url: http://cavestruz.github.io/2014-06-20-yale/
+  user: cavestruz
+  venue: Yale University
+- address: Delta Bessborough Hotel, 601 Spadina Crescent East, Saskatoon, SK
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-06-24
+  humandate: Jun 22-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Ian Mitchell]
+  latlng: 52.127165, -106.658892
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-06-22-caims
+  startdate: 2014-06-22
+  url: http://dhavide.github.io/2014-06-22-caims/
+  user: dhavide
+  venue: Canadian Applied and Industrial Mathematics Society
+- address: 1230 York Ave, New York, NY 10065
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-25
+  humandate: June 24-25, 2014
+  humantime: 9:00 am - 4:45 pm
+  instructor: [Camille Avestruz, Tim Cerino, Dan Chen, Ivan Gonzalez]
+  ipythonnotebook: http://nbviewer.ipython.org/urls
+  latlng: 40.76332, -73.955464
+  layout: bootcamp
+  raw: raw.github.com/swcarpentry/bc/gh-pages
+  registration: restricted
+  root: .
+  slug: 2014-06-24-ru
+  startdate: 2014-06-24
+  url: http://cavestruz.github.io/2014-06-24-ru/
+  user: cavestruz
+  venue: Rockefeller University
+- address: Room 08-146AB, Smilow Center for Translational Research, 3400 Civic Center
+    Blvd., Philadelphia
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-06-25
+  helper: [Alyssa Batula, Maneesha Sane]
+  humandate: Jun 24-25, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dana Bauer, Adina Howe]
+  latlng: 39.94733,-75.193134
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-06-24-wise-penn
+  startdate: 2014-06-24
+  url: http://swcarpentry.github.io/2014-06-24-wise-penn/
+  user: swcarpentry
+  venue: Women in Science and Engineering (Philadelphia)
+- address: Department of Meteorology, Whiteknights, Earley Gate,Reading, RG6 7BE,
+    Berkshire
+  contact: admin@software-carpentry.org, Kathie Bowden (k.e.bowden@reading.ac.uk),
+    <a href="http://www.met.reading.ac.uk/contact.html">Meteorology Dept.</a>
+  country: United-Kingdom
+  enddate: 2014-06-26
+  humandate: June 25-26, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Christina Koch, Devasena Inupakutika]
+  latlng: 51.4419,0.9456
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-25-Reading
+  startdate: 2014-06-25
+  url: http://DevasenaInupakutika.github.io/2014-06-25-Reading/
+  user: DevasenaInupakutika
+  venue: University of Reading
+- address: South bend, IN
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-06-27
+  helper: []
+  humandate: Jun 26-27, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua R. Herr, Sheldon McKay]
+  latlng: 41.705467, -86.235296
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-26-nd
+  startdate: 2014-06-26
+  url: http://jrherr.github.io/2014-06-26-nd/
+  user: jrherr
+  venue: University of Notre Dame
+- address: University Park, NG7 2RD, Nottingham
+  contact: gavin.thomas@sheffield.ac.uk
+  country: United-Kingdom
+  enddate: 2014-07-11
+  helper: []
+  humandate: Jul 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aur Saraf, Devasena Inupakutika]
+  latlng: 52.938636,-1.195158
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-10-Nottingham
+  startdate: 2014-07-10
+  url: http://DevasenaInupakutika.github.io/2014-07-10-Nottingham/
+  user: DevasenaInupakutika
+  venue: The University of Nottingham
+- address: Li Ka Shing Center at Stanford's Medical School, room LK130
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-07-01
+  humandate: Jun 30-Jul 1, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Paul Ivanov, Naupaka Zimmerman]
+  latlng: 37.431904,-122.175787
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-06-30-stanford
+  startdate: 2014-06-30
+  url: http://ivanov.github.io/2014-06-30-stanford/
+  user: ivanov
+  venue: Stanford University
+- address: Sobey School of Business, 4th floor, 923 Robie Street, Halifax, NS
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-07-03
+  humandate: Jul 2-3, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Stephanie Gagne]
+  latlng: 44.631627,-63.580168
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-02-smu
+  startdate: 2014-07-02
+  url: http://dhavide.github.io/2014-07-02-smu/
+  user: dhavide
+  venue: Saint Mary's University
+- address: Stanley Milner Library, 7 Sir Winston Churchill Square, Edmonton, AB
+  contact: macdonellc4@macewan.ca
+  country: Canada
+  enddate: 2014-07-11
+  eventbrite: '11668602103'
+  humandate: Jul 10-11, 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Cam Macdonell, Sam Popowich, Dana Ouellette, Vicky Varga]
+  latlng: 53.542948,-113.489552
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-10-epl
+  startdate: 2014-07-10
+  url: http://cmacdonell.github.io/2014-07-10-epl/
+  user: cmacdonell
+  venue: Software Skills for Librarians at EPL
+- address: Rm 3200, 40 St. George Street, University of Toronto
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-07-09
+  eventbrite: 11725123159
+  helper: [Elizabeth Patitsas, Catalina Anghel]
+  humandate: Jul 8-9, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Emily Davenport, Erika Mudrak, Dana Bauer, Camille Avestruz]
+  latlng: 43.659641,-79.396792
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-08-wise-toronto
+  startdate: 2014-07-08
+  url: http://erdavenport.github.io/2014-07-08-wise-toronto/
+  user: erdavenport
+  venue: Women in Science and Engineering (Toronto)
+- address: Hilton Garden Inn conference room, 1 Circle Rd, Stony Brook, NY 11794
+  contact: olsonran@msu.edu
+  country: United-States
+  enddate: 2014-07-09
+  humandate: Jul 08-09, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tommy Guy, Randy Olson]
+  latlng: 40.918188, -73.122074
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-08-stonybrook
+  startdate: 2014-07-08
+  url: http://guyrt.github.io/2014-07-08-stonybrook/
+  user: guyrt
+  venue: Stony Brook University
+- address: Frisco, CO, USA
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-07-11
+  helper: []
+  humandate: Jul 10-11, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua R. Herr, Fan Yang, Ted M. Hart]
+  latlng: 39.582399, -106.098913
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-10-esip
+  startdate: 2014-07-10
+  url: http://jrherr.github.io/2014-07-10-esip/
+  user: jrherr
+  venue: Federation of Earth Science Information Partners (ESIP) Summer Meeting
+- address: Kenneth C. Rowe Management Building, Room 1014
+  contact: diego.barneche@mq.edu.au
+  country: Canada
+  enddate: 2014-07-15
+  helper: [Daniel Morrison]
+  humandate: Jul 14-15, 2014
+  humantime: 8:00/9:00 am - 6:00/5:00 pm
+  instructor: [Diego Barneche, Gavin Simpson, Ross Dickson]
+  latlng: 44.6372747,-63.5889263
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-14-Dalhousie
+  startdate: 2014-07-14
+  url: http://dbarneche.github.io/2014-07-14-Dalhousie/
+  user: dbarneche
+  venue: Dalhousie University
+- address: Mozilla Toronto, 366 Adelaide Street West, Toronto, Ontario
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2014-07-16
+  eventbrite: 11727066973
+  helper: [Ruth Collings, Thomas Guignard, Alif Zaman, Orion Buske, Dale Russell]
+  humandate: Jul 15-16, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Abigail Cabunoc, Cam Macdonell, Jennifer Campbell, Greg Wilson]
+  latlng: 43.64711,-79.39423
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-15-toronto
+  startdate: 2014-07-15
+  url: http://swcarpentry.github.io/2014-07-15-toronto/
+  user: swcarpentry
+  venue: Librarians in Toronto
+- address: Portland Hilton, Broadway I and II rooms, 921 SW 6th Ave, Portland, OR
+    97204
+  contact: olsonran@msu.edu
+  country: United-States
+  enddate: 2014-07-18
+  humandate: July 17-18, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sheldon McKay, Randy Olson]
+  latlng: 45.5175515,-122.6799365
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-17-aspb
+  startdate: 2014-07-17
+  url: http://swcarpentry.github.io/2014-07-17-aspb/
+  user: swcarpentry
+  venue: American Society of Plant Biologists
+- address: North Campus Research Complex (NCRC)<br/>Building 18, South Atrium<br/>2800
+    Plymouth Rd.
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-07-20
+  humandate: July 19-20, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Carlos Anderson, Leigh Sheneman, Elijah Lowe]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-19-umich
+  startdate: 2014-07-19
+  url: http://redcurry.github.io/2014-07-19-umich/
+  user: redcurry
+  venue: University of Michigan
+- address: Computer Teaching Suite (room 252), Whittle Building (building 52), College
+    Road, Cranfield, MK43 0AL
+  contact: support@archer.ac.uk
+  country: United-Kingdom
+  enddate: 2014-07-23
+  humandate: Jul 21-23, 2014
+  humantime: 9:30 am - 5:00 pm
+  instructor: [Mike Jackson, Andrew Turner, Arno Proeme]
+  latlng: 52.074389,-0.629225
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-07-21-cranfield
+  startdate: 2014-07-21
+  url: http://hpcarcher.github.io/2014-07-21-cranfield/
+  user: hpcarcher
+  venue: Cranfield University
+- address: 19700 Helix Drive, Ashburn, VA 20147
+  contact: sheldon.mckay@gmail.com
+  country: United-States
+  helper: [Anitha Parvatham, Rob Svirskas, Ben Arthur, Christopher Bruns, Don Olbris,
+    Greg Pinero, Peter Bukowinski]
+  humandate: July 23-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sheldon McKay, William Rowell]
+  latlng: 39.0714096,-77.46427019999999
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-23-jfrc
+  startdate: 2014-07-23
+  url: http://mckays630.github.io/2014-07-23-jfrc/
+  user: mckays630
+  venue: Janelia Farm Research Campus
+- address: Li Ka Shing Center at Stanford's Medical School, room LK120
+  contact: amyhodge@stanford.edu
+  country: United-States
+  enddate: 2014-07-29
+  eventbrite: '12096909181'
+  helper: [Christian Battista, Chris Beitel, Louise Giam, Amy Hodge, Jillynne Quinn,
+    Kelly Zalocusky]
+  humandate: Jul 28-29, 2014
+  humantime: Jul 28 9:00 am - 5:00 pm </br> Jul 29 10:00 am - 6:00 pm
+  instructor: [Christina Koch, Jens von der Linden]
+  latlng: 37.431904,-122.175787
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-07-28-stanford
+  startdate: 2014-07-28
+  url: http://jensv.github.io/2014-07-28-stanford/
+  user: jensv
+  venue: Stanford University
+- address: Boardroom, St. Leo's College, St. Lucia, Brisbane
+  contact: philipp.bayer@uqconnect.edu.au
+  country: Australia
+  enddate: 2014-07-31
+  humandate: Jul 30-31, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving, Philipp Bayer, Tim McNamara]
+  latlng: -27.50142,153.01515
+  layout: bootcamp
+  registration: close
+  root: .
+  slug: 2014-07-30-pyconaus
+  startdate: 2014-07-30
+  url: http://philippbayer.github.io/2014-07-30-pyconaus/
+  user: philippbayer
+  venue: PyCon AU / University of Queensland
+- address: 1261 Duck Road Kitty Hawk, NC 27949-4472
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2014-08-07
+  humandate: August 5-7, 2014
+  humantime: 8:00 am - 5:00 pm
+  instructor: [Aron Ahmadia, Chris Kees]
+  latlng: 36.192977, -75.761568
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-05-frf
+  startdate: 2014-08-05
+  url: http://geocarpentry.github.io/2014-08-05-frf/
+  user: geocarpentry
+  venue: Field Research Facility
+- address1: 567 Wilson Road, BPS Room 1441, East Lansing, MI
+  address2: UT Austin, GDC 7.808
+  contact: tkteal@msu.edu
+  country: United-States
+  enddate: 2014-07-25
+  eventbrite1: 11953052903
+  eventbrite2: 11953089011
+  helper: [Alexis Black Pyrkosz, Kevin Hall, Qingpeng Zhang, Ben Johnson, Josh Nahum,
+    April Wright, Nichole Bennett, Kelly Pierce, Jiarong Guo]
+  humandate: July 24-25, 2014
+  humantime: 9:30 am - 5 pm MSU and 8:30 am - 4 pm UT Austin
+  instructor: [Tracy Teal, Christie Bahlai, Josh Herr, Elijah Lowe]
+  latlng: 42.723303,-84.479780
+  layout: bootcamp2
+  raw: raw.github.com/datacarpentry/2014-07-24-beacon/gh-pages
+  registration: open
+  root: .
+  slug: 2014-07-24-beacon
+  startdate: 2014-07-24
+  url: http://datacarpentry.github.io/2014-07-24-beacon/
+  user: datacarpentry
+  venue: MSU BEACON
+  venue1: MSU BEACON
+  venue2: UT Austin BEACON (via teleconference)
+- address: Farrell Teaching and Learning Center, Holden Auditorium and FLTC 214, Saint
+    Louis, MO
+  contact: molly.gibson@wustl.edu
+  country: United-States
+  enddate: 2014-08-12
+  humandate: Aug 11-12, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Molly Gibson, Daniel Chen, Neem Serra, Jessica Kerr, Ariel Rokem]
+  latlng: 38.6350207,-90.2630784
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-11-wustl
+  startdate: 2014-08-11
+  url: http://mollygibson.github.io/2014-08-11-wustl/
+  user: mollygibson
+  venue: Washington University School of Medicine
+- address: Room 419 Light Hall 1301 Medical Center Dr Nashville, TN 37232
+  contact: scott.s.burns@gmail.com
+  country: United-States
+  enddate: 2014-08-13
+  humandate: Aug 12-13, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Scott Burns, Chris Fonnesbeck, Firas Wehbe, Daniel Fabbri]
+  latlng: 36.1422857,-86.8020581
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-12-vu
+  startdate: 2014-08-12
+  url: http://vu-bc.github.io/2014-08-12-vu/
+  user: vu-bc
+  venue: Vanderbilt University
+- address: Li Ka Shing Center room 120, 291 Campus Drive, Stanford, CA 94305
+  contact: abostroem@gmail.com
+  country: United-States
+  enddate: 2014-08-15
+  helper: [Matar Haller, Chris Beitel, Ian Korf, Dani Traphagen]
+  humandate: Aug 14-15, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Azalee Bostroem, Chris Lonnen (Lonnen)]
+  latlng: 37.4320382,-122.175779
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-14-stanford
+  startdate: 2014-08-14
+  url: http://abostroem.github.io/2014-08-14-stanford/
+  user: abostroem
+  venue: Stanford University
+- address: Auditório Ministro João Alberto Lins de Barros do CBPF – Rua Lauro Muller,
+    455 – térreo – Botafogo – Rio de Janeiro – RJ
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-08-18
+  helper: []
+  humandate: Aug 18, 2014
+  humantime: 9:00 am - 13:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -22.954318,-43.174687
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-18-ufrj
+  startdate: 2014-08-18
+  url: http://r-gaia-cs.github.io/2014-08-18-ufrj/
+  user: r-gaia-cs
+  venue: Universidade Federal do Rio de Janeiro
+- address: <a href="http://maps.unimelb.edu.au/parkville/building/149">Old Arts building</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-08-27
+  humandate: Aug 18, 25 & 27, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving, Scott Kolbe, Isabell Kiral-Kornek, Bernard Meade]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-18-unimelb
+  startdate: 2014-08-18
+  url: http://resbaz.github.io/2014-08-18-unimelb/
+  user: resbaz
+  venue: University of Melbourne
+- address: Am Botanischen Garten 7, R.E49 - PC-room, Kiel
+  contact: rkiko@geomar.de
+  country: Germany
+  enddate: 2014-08-22
+  helper: [Pieter Vandromme, Pina Springer]
+  humandate: Aug 21-22, 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Rainer Kiko, Bernhard Konrad]
+  latlng: 54.346504, 10.115453
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-21-kiel
+  startdate: 2014-08-21
+  url: http://rkiko.github.io/2014-08-21-kiel/
+  user: rkiko
+  venue: Christian Albrechts University, Kiel
+- address: LRSM Auditorium, 3231 Walnut Street, Philadelphia, PA 19104
+  contact: gvwilson@software-carpentry.org
+  country: United-States
+  enddate: 2014-08-22
+  helper: []
+  humandate: Aug 21-22, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Chris Friedline, R. David Murray]
+  latlng: 39.952803,-75.189727
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-21-upenn
+  startdate: 2014-08-21
+  url: http://swcarpentry.github.io/2014-08-21-upenn/
+  user: swcarpentry
+  venue: University of Pennsylvania
+- address: TTU Media and Communications Building, Room 0152, 15th and Flint, Lubbock,
+    TX
+  contact: eric.bruning@ttu.edu
+  country: United-States
+  enddate: 2014-08-24
+  helper: [Eric Bruning, Vanna Sullivan, Tony Reinhart, Aaron Hill]
+  humandate: Aug 23-24, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [April Wright, John Fonner]
+  latlng: 33.578205, -101.855120
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-23-ttu
+  startdate: 2014-08-23
+  url: http://wrightaprilm.github.io/2014-08-23-ttu/
+  user: wrightaprilm
+  venue: Texas Tech University
+- address: 3rd Floor Teaching Lab, Wisconsin Institutes for Discovery, 330 N Orchard
+    St, Madison, WI
+  contact: lmichael@wisc.edu
+  country: United-States
+  enddate: 2014-08-26
+  eventbrite: '12454047391'
+  helper: [Anthony Scopatz]
+  humandate: Aug 25-26, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Karl Broman, Matt Gidden, Daijiang Li, Lauren Michael, Paul Wilson]
+  latlng: 43.074974,-89.406738
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-08-25-wisc
+  startdate: 2014-08-25
+  url: http://UW-Madison-ACI.github.io/2014-08-25-wisc/
+  user: UW-Madison-ACI
+  venue: University of Wisconsin-Madison
+- address: Craik-Marshall Building, University of Cambridge, Downing Site, Cambridge,
+    CB2 3AR
+  contact: cambridge@lists.software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-08-27
+  helper: [Jelena Aleksic, David Molnar]
+  humandate: Aug 26-27, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Rob Beagrie, Thomas Kluyver]
+  latlng: 52.201893,0.12303
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-26-cam
+  startdate: 2014-08-26
+  url: http://rbeagrie.github.io/2014-08-26-cam/
+  user: rbeagrie
+  venue: Cambridge University
+- address: Instituto de Informática prédio 43413(67) - Sala 102.
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-08-29
+  helper: []
+  humandate: Aug 28-29, 2014
+  humantime: 9:00 am - 6:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -30.0762942,-51.1245446
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-08-28-ufrgs
+  startdate: 2014-08-28
+  url: http://acviana.github.io/2014-08-28-ufrgs/
+  user: acviana
+  venue: Universidade Federal do Rio Grande do Sul (Campus do Vale)
+- address: CCSL-IME/USP, Sala B-7. Rua do Matão, 1010
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-09-02
+  eventbrite: 12386974775
+  helper: []
+  humandate: Set 01-02, 2014
+  humantime: 9:00 am - 6:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -23.558745,-46.731859
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-01-ccsl
+  startdate: 2014-09-01
+  url: http://r-gaia-cs.github.io/2014-09-01-ccsl/
+  user: r-gaia-cs
+  venue: Centro de Competência em Software Livre
+- address: CCSL-IME/USP, Sala B-7. Rua do Matão, 1010
+  contact: raniere@ime.unicamp.br
+  country: Brazil
+  enddate: 2014-09-05
+  eventbrite: 12387143279
+  helper: []
+  humandate: Set 04-05, 2014
+  humantime: 9:00 am - 6:00 pm
+  instructor: [Alex Viana, Raniere Silva]
+  latlng: -23.558745,-46.731859
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-04-ccsl
+  startdate: 2014-09-04
+  url: http://r-gaia-cs.github.io/2014-09-04-ccsl/
+  user: r-gaia-cs
+  venue: Centro de Competência em Software Livre
+- address: Newark, DE, USA
+  contact: joshua.r.herr@gmail.com
+  country: United-States
+  enddate: 2014-09-12
+  helper: [Erin Crowgey, Reza Hammond, Modupe Adetunji, Liang Sun, Matthew Ralston]
+  humandate: Sep 11-12, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Joshua R. Herr, Joshua L. Adelman]
+  latlng: 39.678214, -75.750622
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-11-udel
+  startdate: 2014-09-11
+  url: http://jrherr.github.io/2014-09-11-udel/
+  user: jrherr
+  venue: University of Delaware
+- address: Engineering 6 room 4022, 200 University Ave, Waterloo
+  contact: nmabukhdeir@uwaterloo.ca
+  country: Canada
+  enddate: 2014-09-14
+  helper: [WatPy, SHARCNET]
+  humandate: September 13-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Nasser M Abukhdeir, Pawel Pomorski, Albert O'Connor]
+  latlng: 43.473269, -80.538639
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-13-uwaterloo
+  startdate: 2014-09-13
+  url: http://amjoconn.github.io/2014-09-13-uwaterloo/
+  user: amjoconn
+  venue: Unversity of Waterloo
+- address: <a href="http://maps.unimelb.edu.au/parkville/building/104#.Uw0fhPiLelM">Theatre
+    3, Alan Gilbert Building</a>
+  contact: d.irving@student.unimelb.edu.au
+  country: Australia
+  enddate: 2014-09-25
+  humandate: Sep 15, 18, 22 & 25, 2014
+  humantime: 1:30 pm - 5:00 pm
+  instructor: [Damien Irving]
+  latlng: -37.7963,144.9614
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-15-unimelb
+  startdate: 2014-09-15
+  url: http://resbaz.github.io/2014-09-15-unimelb/
+  user: resbaz
+  venue: University of Melbourne
+- address: Room 1.51, Royal School of Mines (RSM) Building, South Kensington Campus,
+    Imperial College London, London.
+  contact: support@archer.ac.uk
+  country: United-Kingdom
+  enddate: 2014-09-17
+  humandate: Sep 16-17, 2014
+  humantime: 10:00 am - 5:00 pm
+  instructor: [Mike Jackson, Arno Proeme]
+  latlng: 51.499471,-0.176400
+  layout: bootcamp
+  registration: open
+  root: .
+  slug: 2014-09-16-imperial
+  startdate: 2014-09-16
+  url: http://hpcarcher.github.io/2014-09-16-imperial/
+  user: hpcarcher
+  venue: Imperial College London
+- address: Day 1 - Biological Scienes Learning Center (BSLC) 109; Day 2 - Gordon Center
+    for Integrative Science (GCIS) W301
+  contact: jdblischak@uchicago.edu
+  country: United-States
+  enddate: 2014-09-19
+  helper: [Daniel Rabe, Nick Knoblauch, Suchandra Thapa, Bala Desinghu]
+  humandate: Sep 18-19, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Will Trimble, Emily Davenport, Dan Braithwaite, John Blischak]
+  latlng: 41.7901128,-87.6007318
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-18-chicago
+  startdate: 2014-09-18
+  url: http://jdblischak.github.io/2014-09-18-chicago/
+  user: jdblischak
+  venue: University of Chicago
+- address: 1 Cyclotron Road Berkeley, CA 94720
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-09-23
+  helper: [Kyle Barbary, Yigong Zhang]
+  humandate: Sep 22-23, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Matt Davis, Jessica Hamrick, Thomas Kluyver]
+  latlng: 37.8759281,-122.2500418
+  layout: bootcamp
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-09-22-lbl
+  startdate: 2014-09-22
+  url: http://swcarpentry.github.io/2014-09-22-lbl/
+  user: swcarpentry
+  venue: Lawrence Berkeley Lab
+- address: 20th and C St NW. Washington DC. (Martin Building Dining Room E)
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-09-25
+  helper: [Açmae El Yacoubi]
+  humandate: Sep 24-25, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ivan Gonzalez, Steve Eddins, Daniel Chen]
+  latlng: 38.892944, -77.044877
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-24-frb
+  startdate: 2014-09-24
+  url: http://chendaniely.github.io/2014-09-24-frb/
+  user: chendaniely
+  venue: Federal Reserve Board
+- address: Earth, Ocean and Atmospheric Sciences, ESB-5108
+  contact: sallen@eos.ubc.ca
+  country: Canada
+  enddate: 2014-08-26
+  helper: [Jordan Aaron, Karina Ramos Musalem, Drew Snauffer, Nancy Soontiens, Kathi
+      Unglert, Kang Wang]
+  host: Susan Allen
+  humandate: Sep 25-26, 2014
+  humantime: 9:00 - 4:00 Thu, 9:00 - 4:30 Fri
+  instructor: [Doug Latornell, Susan Allen]
+  latlng: 49.263,-123.252
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-25-ubc
+  startdate: 2014-09-25
+  url: http://douglatornell.github.io/2014-09-25-ubc/
+  user: douglatornell
+  venue: University of British Columbia
+- address: iDigBio at University of Florida, Gainesville, FL
+  contact: data-carpentry@software-carpentry.org
+  country: United-States
+  enddate: 2014-09-30
+  helper: [Dan Stoner, Deborah Paul, Pam Soltis, Derek Masaki, Shari Ellis, Kevin Love, Juliet Pulliam, Tommy Tang, Bernardo Santos, Jonathan Foox]
+  humandate: Sep 29-30, 2014
+  humantime: 8:30 am - 5:30 pm
+  instructor: [Francois Michonneau, Tracy Teal, Matt Collins, Katja Seltmann]
+  latlng: 42.723303,-84.479780
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-29-iDigBio
+  startdate: 2014-09-29
+  url: http://datacarpentry.github.io/2014-09-29-iDigBio/
+  user: datacarpentry
+  venue: University of Florida
+- address: Life Sciences C-Wing, Room 180/182
+  contact: eric.d.johnson@asu.edu
+  country: United-States
+  enddate: 2014-09-28
+  eventbrite: '13072962583'
+  helper: [To Be Determined]
+  humandate: Sep 27-28, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Jonathan Strootman]
+  latlng: 33.419982, -111.934157
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-27-asu
+  startdate: 2014-09-27
+  url: http://naupaka.github.io/2014-09-27-asu/
+  user: naupaka
+  venue: Arizona State University
+- address: Biomedical and Physical Sciences Building 567 Wilson Road Room 1441 East
+    Lansing, MI 48824 (Seminar Room)
+  contact: jory@msu.edu
+  country: United-States
+  enddate: 2014-10-01
+  eventbrite: 13109602173
+  helper: ['Emily Dolson, Josh Nahum, Eric Bruger']
+  humandate: Sep 30 Oct 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jory Schossau, Leigh Sheneman, Luiz Irber]
+  latlng: 42.724324, -84.476082
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-09-30-msu
+  startdate: 2014-09-30
+  url: http://joryschossau.github.io/2014-09-30-msu/
+  user: joryschossau
+  venue: Michigan State University
+- <!-- eventbrite: 12933361031 -->
+  address: Innovation Center (Room 105), 2719 E. 10th St., Bloomington, IN
+  contact: igonzalez@mailaps.org
+  country: United-States
+  enddate: 2014-10-07
+  helper: [Badi' Abdul-Wahid, Kevin Bohan, Eric Holk, DongInn Kim]
+  humandate: Oct 6-7, 2014
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Ivan Gonzalez, Jeremiah Lant]
+  latlng: 39.171706,-86.499819
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-06-indiana
+  startdate: 2014-10-06
+  url: http://iglpdc.github.io/2014-10-06-indiana/
+  user: iglpdc
+  venue: Indiana University
+- address: 102 Rightmire Hall, 1060 Carmack Rd, Columbus, OH 43210
+  contact: sheldon.mckay@gmail.com
+  country: United-States
+  enddate: 2014-10-07
+  helper: [Jeffrey Campbell, Joy-El Talbot, Eric Mukundi, Wilberforce Ouma]
+  humandate: Oct 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sheldon McKay, Trevor Bekolay]
+  latlng: 40.003486, -83.037452
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-06-osu
+  startdate: 2014-10-06
+  url: http://mckays630.github.io/2014-10-06-osu/
+  user: mckays630
+  venue: Ohio State University
+- address: Rooms 368/374, Rotman School of Management, 105 St. George Street, Toronto,
+    Ontario
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-10-07
+  eventbrite: '13023831631'
+  helper: [Catalina Anghel, Samantha Clark, Thomas Guignard, Tom Wright, Lee Zamparo]
+  humandate: Oct 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Gabriel Devenyi, Tommy Guy, Jeramia Ory, Elizabeth
+      Patitsas, Greg Wilson]
+  latlng: 43.665263,-79.39862
+  layout: bootcamp
+  lessons: [Python, SQL, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-10-06-rotman
+  startdate: 2014-10-06
+  url: http://swcarpentry.github.io/2014-10-06-rotman/
+  user: swcarpentry
+  venue: University of Toronto
+- address: Sloane Physics Lab, Room 43, 217 Prospect Street, New Haven, CT 06511
+  contact: rbsi.yale@gmail.com
+  country: United-States
+  enddate: 2014-10-12
+  eventbrite: 13155403165
+  helper: [Jieming Chen, Wendell Smith, Tomomi Sunayama, Manuel Mai, Dan Guest]
+  humandate: Oct 11-12, 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Camille Avestruz, Matthew Lightman]
+  latlng: 41.3181294,-72.9237981
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-10-11-yale
+  startdate: 2014-10-11
+  url: http://mattphotonman.github.io/2014-10-11-yale/
+  user: mattphotonman
+  venue: Yale University
+- address: HBH 227; 6100 Main St. Houston, TX 77204
+  contact: rcsg@rice.edu
+  country: United-States
+  enddate: 2014-10-14
+  eventbrite: 13095572209
+  helper: [Joseph Ghobrial, Erik Engquist]
+  humandate: Oct 13-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [April Wright, Chandler Wilkerson, Scott Talafuse]
+  latlng: 29.719960, -95.400902
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-13-rice
+  startdate: 2014-10-13
+  url: http://chwilk.github.io/2014-10-13-rice/
+  user: chwilk
+  venue: Rice University
+- address: Gerstein Library, 9 King's College Circle, Toronto, Ontario
+  contact: gvwilson@software-carpentry.org
+  country: Canada
+  enddate: 2014-10-31
+  eventbrite: 13047803331
+  helper: [Xu Fei, Luke Johnston, Daiva Nielsen, Sahar Rahmani, Tom Wright]
+  humandate: Oct 30-31, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Pauline Barmby, Thomas Guignard, Greg Wilson]
+  latlng: 43.662152,-79.394085
+  layout: bootcamp
+  lessons: [Python, SQL, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-10-30-utoronto
+  startdate: 2014-10-30
+  url: http://swcarpentry.github.io/2014-10-30-utoronto/
+  user: swcarpentry
+  venue: University of Toronto
+- address: Law School Seminar Room 444 (upstairs from the Law School Bar)
+  contact: diego.barneche@mq.edu.au
+  country: Australia
+  enddate: 2014-11-01
+  helper: [Sarah McIntyre, Steson Lo]
+  hostcontact: alex.holcombe@sydney.edu.au
+  humandate: Oct 31-Nov 1, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Diego Barneche, Philipp Bayer, Dan Warren]
+  instructorcontact: diego.barneche@mq.edu.au
+  latlng: -33.887526,151.190262
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-31-USyd
+  startdate: 2014-10-31
+  url: http://dbarneche.github.io/2014-10-31-USyd/
+  user: dbarneche
+  venue: University of Sydney
+- address: James L. Allen Center, 2169 Campus Drive, Evanston, IL 60208-2800
+  contact: edd@debian.org
+  country: United-States
+  enddate: 2014-11-01
+  helper: [' ']
+  humandate: Oct 31 - Nov 1, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Karthik Ram, Ramnath Vaidyanathan, Dirk Eddelbuettel]
+  latlng: 42.056459,-87.675267
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-10-31-nw
+  startdate: 2014-10-31
+  url: http://karthik.github.io/2014-10-31-nw/
+  user: karthik
+  venue: Northwestern University
+- address: Faculté de médecine vétérinaire de l'Université de Montréal, St-Hyacinthe,
+    QC
+  contact: denis.haine@umontreal.ca
+  country: Canada
+  enddate: 2014-11-07
+  helper: []
+  humandate: Nov 6-7, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [John D. Blischak, Denis Haine, Marianne Corvellec, Gabriel Devenyi]
+  latlng: 45.619605,-72.963607
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-11-06-fmv
+  startdate: 2014-11-06
+  url: http://dhaine.github.io/2014-11-06-fmv/
+  user: dhaine
+  venue: GREZOSP
+- address: Winterthurerstrasse 190
+  contact: admin@software-carpentry.org
+  country: Switzerland
+  enddate: 2014-11-07
+  helper: [Frank Pennekamp, Peter Fields, Jelena Aleksic]
+  humandate: Nov 6-7, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Laurent Gatto, Robert Stojnic]
+  latlng: 47.396018,8.5524058
+  layout: workshop
+  lessons: [R, Git, bash]
+  registration: restricted
+  root: .
+  slug: 2014-11-06-UZH
+  startdate: 2014-11-06
+  url: http://lgatto.github.io/2014-11-06-UZH/
+  user: lgatto
+  venue: Institute of Molecular Life Sciences, University of Zurich
+- address: 60 Garden Street, Cambridge, MA 02138
+  contact: iglpdc+harvard@gmail.com
+  country: United-States
+  enddate: 2014-11-08
+  helper: [Christopher Erdmann, Bob Freeman, Jean Roth, Peter Williams]
+  humandate: Nov 7-8, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Daniel Chen, Ivan Gonzalez]
+  latlng: 42.382136, -71.127843
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-11-07-harvard
+  startdate: 2014-11-07
+  url: http://iglpdc.github.io/2014-11-07-harvard/
+  user: iglpdc
+  venue: Research Computing & Harvard-Smithsonian Center for Astrophysics, Harvard
+    University
+- address: 29 Grafton Street, Manchester, M13 9WU
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-11-14
+  helper: ['Andy Brass, Mike Cornell']
+  humandate: Nov 10-14, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aleksandra Pawlik, Aleksandra Nenadic]
+  latlng: 53.463651,-2.227592
+  layout: workshop
+  lessons: [Python, Git, Bash, VM]
+  registration: restricted
+  root: .
+  slug: 2014-11-10-manchester
+  startdate: 2014-11-10
+  url: http://anenadic.github.io/2014-11-10-manchester/
+  user: anenadic
+  venue: The Nowgen Centre, University of Manchester
+- address: EMBL Heidelberg
+  contact: admin@software-carpentry.org
+  country: Germany
+  enddate: 2014-11-14
+  helper: []
+  humandate: Nov 12-14, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Luis Pedro Coelho]
+  latlng: 49.38485,8.71074
+  layout: redirect
+  lessons: [Python, Git, Bash]
+  redirect: http://www.embl.de/training/events/2014/SWC14-01/index.html
+  registration: open
+  root: .
+  slug: 2014-11-12-embl
+  startdate: 2014-11-12
+  url: http://swcarpentry.github.io/2014-11-12-embl/
+  user: swcarpentry
+  venue: European Molecular Biology Laboratory
+- address: Charles Thackrah Building, University of Leeds, Leeds, LS2 9JT
+  contact: a.walker@leeds.ac.uk
+  country: United-Kingdom
+  enddate: 2014-11-26
+  helper: [Aaron O'Leary, Peter Willetts, Marlene Mengoni, Jo Leng]
+  humandate: Nov 24-26, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Martin Callaghan, Devasena Inupakutika, Andrew Walker]
+  latlng: 53.8070,-1.5607
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-11-24-leeds
+  startdate: 2014-11-24
+  url: http://andreww.github.io/2014-11-24-leeds/
+  user: andreww
+  venue: NERC / University of Leeds
+- address: Atlas 1-2 Room, Kilburn Building, Oxford Road, M13 9PL Manchester
+  contact: data-carpentry@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2014-11-28
+  eventbrite: 13760815971
+  helper: ['Ian Dunlop, Aleksandra Nenadic, Christian Brenninkmeijer']
+  humandate: Nov 27-28, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aleksandra Pawlik, Shoaib Sufi, Alejandra Gonzalez-Beltran]
+  latlng: 53.467293, -2.233876
+  layout: bootcamp2
+  registration: open
+  root: .
+  slug: 2014-11-27-elixiruk-manchester
+  startdate: 2014-11-27
+  url: http://apawlik.github.io/2014-11-27-elixiruk-manchester/
+  user: apawlik
+  venue: University of Manchester
+- address: TS 3B and TS 3C, Snape Building, Upper Campus
+  contact: admin@software-carpentry.org
+  country: South-Africa
+  enddate: 2014-11-28
+  helper: [Dane Kennedy (CSIR), Hein de Jager (UCT), Ashley Rustin (UCT), David Matten
+      (SU), Armin Deffur (UCT), Anelda van der Walt (UCT), Warren Jacobus (UWC), Chris
+      Mitsengu (UCT), Gustavo Salazar (UCT), Jon Ambler (UCT), Benjamin Hugo (UCT),
+    Jon Zwart (UCT), Adrianna Pinska (UCT), Timothy Povall (UCT)]
+  humandate: Nov 27-28, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: ['Jonah Duckles (University of Oklahoma, USA)', 'James Hetherington
+      (University College London, UK)', '', 'David Merand (University of the Witwatersrand,
+      South Africa)']
+  latlng: -33.9574965,18.4622421
+  layout: bootcamp
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2014-11-27-uct
+  startdate: 2014-11-27
+  url: http://jduckles.github.io/2014-11-27-uct/
+  user: jduckles
+  venue: University of Cape Town
+- address: Room 3217, James Clerk Maxwell Building, Peter Guthrie Tait Road, Edinburgh,
+    EH9 3FD
+  contact: support@archer.ac.uk
+  country: United-Kingdom
+  enddate: 2014-12-04
+  helper: [Emmanouil Farsarakis, Leighton Pritchard, Peter Cock]
+  humandate: Dec 3-4, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Mike Jackson, Arno Proeme, Mario Antonioletti, Alistair Grant]
+  latlng: 55.921628,-3.174155
+  layout: workshop
+  lessons: [Git, Python, VM]
+  registration: open
+  root: .
+  slug: 2014-12-03-edinburgh
+  startdate: 2014-12-03
+  url: http://hpcarcher.github.io/2014-12-03-edinburgh/
+  user: hpcarcher
+  venue: The University of Edinburgh
+- address: ul. Kawiory 21, 30-055 Kraków
+  contact: admin-uk@software-carpentry.org
+  country: Poland
+  enddate: 2014-12-07
+  eventbrite: 14426226231
+  helper: ['Barbara Szczygieł, Iwona Grelowska, Patrycja Radaczyńska, Anna Ślimak']
+  humandate: 6-7 Dec 2014
+  humantime: 9:30  - 17:30
+  instructor: [Paulina Lach, Aleksandra Pawlik]
+  latlng: 50.0677112,19.9124284
+  layout: workshop
+  lessons: [Python, SQL, Git, Bash]
+  registration: open
+  root: .
+  slug: 2014-12-06-wise-krakow
+  startdate: 2014-12-06
+  url: http://apawlik.github.io/2014-12-06-wise-krakow/
+  user: apawlik
+  venue: Women in Science and Engineering
+- address: Theatre 2, Alan Gilbert
+  contact: scottcr@unimelb.edu.au
+  country: Australia
+  enddate: 2014-12-09
+  etherpad: https://etherpad.mozilla.org/2014-12-08-combine-r
+  helper: [Andrew Lonsdale, Harriet Dashnow, Timothy Rice, Noel Faux, Simon Gladman,
+    Pip Griffin, Alistair Walsh]
+  humandate: Dec 8-9, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Scott Ritchie, Damien Irving]
+  latlng: -37.800138,144.959285
+  layout: workshop
+  root: .
+  slug: 2014-12-08-combine-r
+  startdate: 2014-12-08
+  url: http://resbaz.github.io/2014-12-08-combine-r/
+  user: resbaz
+  venue: University of Melbourne
+- address: Room 240, Searle Chemistry Lab, 5735 S. Ellis Ave, Chicago, IL 60637
+  contact: balamurugan@uchicago.edu
+  country: United-States
+  enddate: 2014-12-17
+  helper: [Anna Olson]
+  humandate: Dec 15-17, 2014
+  humantime: 8:30 am - 4:30 pm (Day 1), 8.30 am - 4.30 pm (Day 2), 8.30 am - 11.00
+    am (Day 3)
+  instructor: ['Bala Desinghu, Suchandra Thapa, David Champion, Lincoln Bryant, Rob
+      Gardner']
+  latlng: 41.790743, -87.601077
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2014-12-15-UChicago
+  startdate: 2014-12-15
+  url: http://SWC-OSG-Workshop.github.io/2014-12-15-UChicago/
+  user: SWC-OSG-Workshop
+  venue: University of Chicago
+- Registration: restricted
+  address: SPL Rm. 48, Sloane Physics Laboratory, 217 Prospect St, New Haven, CT
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2014-12-19
+  helper: [Camille Avestruz, Tomomi Sunayama, Nick Sawyer, Jieming Chen, Luis Vargas]
+  humandate: Dec. 18-19, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Dhavide Aruliah, Robert Till]
+  latlng: 41.317623, -72.923169
+  layout: workshop
+  lessons: [Matlab, SQL, Bash]
+  root: .
+  slug: 2014-12-18-yale
+  startdate: 2014-12-18
+  url: http://dhavide.github.io/2014-12-18-yale/
+  user: dhavide
+  venue: Yale University
+- address: 3rd floor Training Room, 7 Sir Winston Churchill Square
+  contact: vvarga@epl.ca
+  country: Canada
+  enddate: 2014-12-16
+  helper: [Cody Moorhouse, Katie Thompson]
+  humandate: Dec 15 & 16 2014
+  humantime: 9:00 am - 4:00 pm
+  instructor: [Cam MacDonell, Vicky Varga]
+  latlng: 53.5430628,-113.4897479
+  layout: workshop
+  lessons: [Python, SQL, Bash]
+  registration: restricted
+  root: .
+  slug: 12-14-epl
+  startdate: 2014-12-15
+  url: http://vixvarga.github.io/12-14-epl/
+  user: vixvarga
+  venue: Edmonton Public Library
+- address: Auditório do BEG, CCB. Entrada para o campus fica na esquina entre a Rua
+    Professor Lauro Caldeira de Andrara e a Rua João Pio Duarte Silva - entrada do
+    bairro Córrego Grande). Nos prédios do CCB (MIP), procure o segundo bloco, andar
+    térreo, corredor da direita, última sala do corredor
+  contact: diego.barneche@mq.edu.au
+  country: Brazil
+  enddate: 2014-12-12
+  etherpad: https://etherpad.mozilla.org/SWC-UFSC
+  helper: ['']
+  humandate: Dez 11-12, 2014
+  humantime: 8:00 am - 5:30 pm
+  instructor: [Diego Barneche, Raniere Silva]
+  latlng: -27.59803,-48.51514
+  layout: workshop
+  root: .
+  slug: 2014-12-11-ufsc
+  startdate: 2014-12-11
+  url: http://dbarneche.github.io/2014-12-11-ufsc/
+  user: dbarneche
+  venue: Universidade Federal de Santa Catarina
+- address: Lab 323, Kelvin Building, G12 8SU
+  contact: alistair.grant@ed.ac.uk
+  country: United-Kingdom
+  enddate: 2014-12-12
+  helper: [Paul Mullen, Sean Leavey, Gavin Kirby]
+  humandate: Dec 11-12, 2014
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Alistair Grant, Norman Gray]
+  latlng: 55.871709,-4.291651
+  layout: workshop
+  root: .
+  slug: 2014-12-11-ugsupa
+  startdate: 2014-12-11
+  url: http://supa-uk.github.io/2014-12-11-ugsupa/
+  user: supa-uk
+  venue: University of Glasgow
+- address: 1 Cyclotron Road, Berkeley, CA
+  contact: nlucido@lbl.gov
+  country: United-States
+  enddate: 2014-12-17
+  helper: [Sam Penrose]
+  humandate: Dec 16-17, 2014
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jens von der Linden, Andrea Zonca, Chris Holdgraf]
+  latlng: 37.8706976,-122.30098
+  layout: workshop
+  root: .
+  slug: 2014-12-16-lbl
+  startdate: 2014-12-16
+  url: http://zonca.github.io/2014-12-16-lbl/
+  user: zonca
+  venue: Lawrence Berkeley National Lab
+- address: Room 609, Seattle Convention Center, Seattle WA
+  contact: kabostroem@ucdavis.edu
+  country: United-States
+  enddate: 2015-01-04
+  helper: [Pauline Barmby, Sophie Clayton, Jens von der Linden]
+  humandate: Jan 3-4, 2015
+  humantime: 9:00 am - 5:30 pm
+  instructor: [Azalee Bostroem, Erik Bray, Matt Davis, Phil Rosenfield]
+  latlng: 47.6117,-122.3325
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: open
+  root: .
+  slug: 2015-01-03-aas
+  startdate: 2015-01-03
+  url: http://abostroem.github.io/2015-01-03-aas/
+  user: abostroem
+  venue: American Astronomical Society 225th Meeting
+- address: Mathematics Building, Room 135, UC Boulder
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2015-01-06
+  eventbrite: 14752447969
+  humandate: Jan 5-6, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Christina Koch, Mariela Perignon, Rachel Slaybaugh, Leah Wasser]
+  latlng: 40.00796,-105.264317
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-05-wise-cuboulder
+  startdate: 2015-01-05
+  url: http://christinalk.github.io/2015-01-05-wise-cuboulder/
+  user: christinalk
+  venue: Women in Science and Engineering, University of Colorado
+- address: North Campus Research Complex, Building 10 Room G064 and the South Atrium,
+    2800 Plymouth Road, Ann Arbor, MI
+  contact: admin@software-carpentry.org
+  country: United-States
+  enddate: 2015-01-06
+  helper: [Alyxandria Schubert, Iris Holmes, Marian Schmidt, Michelle Berry]
+  humandate: Jan 5-6, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Sarah Supp, Kara Woo, Christie Bahlai, Dana Bauer]
+  latlng: 42.29932560385452,-83.70677590370178
+  layout: workshop
+  lessons: [R, SQL, Git, Bash, VM]
+  registration: restricted
+  root: .
+  slug: 2015-01-05-wise-umich
+  startdate: 2015-01-05
+  url: http://danabauer.github.io/2015-01-05-wise-umich/
+  user: danabauer
+  venue: Women in Science and Engineering, University of Michigan
+- address: 3100 Marine Street, Boulder, CO 80309
+  contact: aron@ahmadia.net
+  country: United-States
+  enddate: 2015-01-09
+  humandate: Jan 7-9, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Aron Ahmadia, Chris Kees]
+  latlng: 40.013294, -105.251890
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2015-01-07-instaar
+  startdate: 2015-01-07
+  url: http://geocarpentry.github.io/2015-01-07-instaar/
+  user: geocarpentry
+  venue: Institute of Arctic and Alpine Research (INSTAAR), Room 620
+- address: Avery Hall, room 119
+  contact: sheldon.mckay@gmail.com
+  country: United-States
+  enddate: 2015-01-09
+  etherpad: https://etherpad.mozilla.org/2015-01-08-unl
+  helper: [Derek Weitzel, Emelie Harstad, Jingchao Zhang, Adam Caprez, Natasha Pavlovijk,
+    O. William McClung]
+  humandate: Jan 8-9, 2015
+  humantime: 8:30 am - 4:30 pm
+  instructor: [Sheldon McKay, Daniel Smith]
+  latlng: 40.819348, -96.704387
+  layout: workshop
+  root: .
+  slug: 2014-01-08-unl
+  startdate: 2015-01-08
+  url: http://mckays630.github.io/2014-01-08-unl/
+  user: mckays630
+  venue: University of Nebraska-Lincoln
+- address: null
+  contact: imunoz@sesync.org
+  country: United-States
+  enddate: 2015-01-09
+  helper: [Sean Davis]
+  humandate: Jan 8-9, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Ian Munoz, Daniel Chen]
+  latlng: 39.00281, -77.10444
+  layout: workshop
+  lessons: [R, Python, SQL, Git, Bash, VM]
+  registration: restricted
+  root: .
+  slug: 2015-01-08-NIH
+  startdate: 2015-01-08
+  url: http://ianamunoz.github.io/2015-01-08-NIH/
+  user: ianamunoz
+  venue: National Institutes of Health Library
+- address: 1050 Massachusetts Ave., Cambridge,  2nd floor Conference Room
+  contact: tjc.swc@gmail.com
+  country: United-States
+  enddate: 2015-01-09
+  helper: [Matthew Lamberti]
+  humandate: Jan 8-9, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Tim Cerino, Ivan Gonzalez]
+  latlng: 42.369970, -71.113038
+  layout: workshop
+  lessons: [Python, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-08-nber
+  startdate: 2015-01-08
+  url: http://Koltrane.github.io/2015-01-08-nber/
+  user: Koltrane
+  venue: National Bureau of Economic Research
+- address: ERC 1058, UOIT, 2000 Simcoe St N, Oshawa, ON
+  contact: admin@software-carpentry.org
+  country: Canada
+  enddate: 2015-01-09
+  helper: ['Jessica Cervi, Kevin Green']
+  humandate: Jan 8-9, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Catalina Anghel, Dhavide Aruliah, Thomas Wright]
+  latlng: 43.945879, -78.896292
+  layout: workshop
+  lessons: [Python, SQL, Git, Bash]
+  registration: open
+  root: .
+  slug: 2015-01-08-uoit
+  startdate: 2015-01-08
+  url: http://dhavide.github.io/2015-01-08-uoit/
+  user: dhavide
+  venue: University of Ontario Institute of Technology
+- address: Sonntag Pavilion, St. Joseph's Hospital. 350 West Thomas Rd, Phoenix, AZ
+    85013
+  contact: sammankin@gmail.com
+  country: United-States
+  enddate: 2015-01-11
+  helper: [To be determined]
+  humandate: Jan 10-11, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Jonathan Strootman]
+  latlng: 33.480726,-112.079483
+  layout: workshop
+  lessons: [R, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-10-st_josephs
+  startdate: 2015-01-10
+  url: http://naupaka.github.io/2015-01-10-st_josephs/
+  user: naupaka
+  venue: St. Joseph’s Hospital and Medical Center
+- address: Stanley Hall Room 044, 801 National Road West, Richmond, IN 47374
+  contact: jeremiahlant@gmail.com
+  country: United-States
+  enddate: 2015-01-12
+  helper: [Michael Lerner, Charlie Peck, Demian Riccardi]
+  humandate: Jan 11-12, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Jeremiah Lant, Jonah Duckles]
+  latlng: 39.823910, -84.913179
+  layout: workshop
+  lessons: [Python, Bash, Git, SQL]
+  registration: restricted
+  root: .
+  slug: 2015-01-11-earlham
+  startdate: 2015-01-11
+  url: http://jlant.github.io/2015-01-11-earlham/
+  user: jlant
+  venue: Earlham College
+- address: Wellcome Trust for Human Genetics, Roosevelt Drive, Oxford, OX3 7BN
+  contact: jane.charlesworth@ndm.ox.ac.uk
+  country: United-Kingdom
+  enddate: 2015-01-14
+  eventbrite: 14958184332
+  helper: [Tom Smith, Mike Morgan, Jane Charlesworth]
+  humandate: Jan 13-14, 2015
+  humantime: 9:30 am - 4:30 pm
+  instructor: [Philip Fowler]
+  latlng: 51.752110,-1.215238
+  layout: workshop
+  lessons: [Python, Git, Shell, SQL]
+  registration: restricted
+  root: .
+  slug: 2015-01-13-oxford
+  startdate: 2015-01-13
+  url: http://philipwfowler.github.io/2015-01-13-oxford/
+  user: philipwfowler
+  venue: Oxford University
+- address: School of Earth and Environment, University of Leeds, Leeds, LS2 9JT
+  contact: a.walker@leeds.ac.uk
+  country: United-Kingdom
+  enddate: 2015-01-16
+  helper: [Jo Leng, Grace Cox]
+  humandate: Jan 14-16, 2015
+  humantime: 9:00 am - 5:30 pm
+  instructor: [Martin Callaghan, Aleksandra Pawlik, Andrew Walker, Aaron O'Leary,
+    Peter Willetts]
+  latlng: 53.8052724,-1.5554359
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2015-01-14-leeds
+  startdate: 2015-01-14
+  url: http://andreww.github.io/2015-01-14-leeds/
+  user: andreww
+  venue: NERC / University of Leeds
+- address: Atmospheric Oceanic and Planetary Physics Department, Dobson Room, Atmospheric
+    Physics Building, Sherrington Road, Oxford
+  contact: jamesallen0108@gmail.com
+  country: United-Kingdom
+  enddate: 2015-01-15
+  helper: [Edward Doddridge, Russell Jones]
+  humandate: Jan 14-15, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [James Allen, TBD]
+  latlng: 51.759155,-1.25596
+  layout: workshop
+  root: .
+  slug: 2015-01-14-oxford
+  startdate: 2015-01-14
+  url: http://jpallen.github.io/2015-01-14-oxford/
+  user: jpallen
+  venue: University of Oxford
+- address: 2119 Hornbake South, College Park, MD
+  contact: msmorul@sesync.org
+  country: United-States
+  enddate: 2015-01-16
+  eventbrite: https://www.eventbrite.com/e/umd-data-carpentry-tickets-14847664765
+  helper: [Donal Heidenblad, Andrea Wiggins, Susan Winters]
+  humandate: Jan 15-16, 2015
+  humantime: 9:00 am - 5 pm
+  instructor: [Ian Munoz, Mike Smorul]
+  latlng: 38.988202,-76.941699
+  layout: bootcamp
+  raw: raw.github.com/sesync-ci/2015-01-15-umd/gh-pages
+  registration: open
+  root: .
+  slug: 2015-01-15-umd
+  sponsors: SESYNC and Maryland's iSchool
+  startdate: 2015-01-15
+  url: http://sesync-ci.github.io/2015-01-15-umd/
+  user: sesync-ci
+  venue: University of Maryland
+- address: Seattle, WA
+  contact: bmarwick@uw.edu
+  country: United-States
+  enddate: 2015-01-16
+  eventbrite: 14655221161
+  helper: [Tania Melo, Tiffany Timbers, Earle Wilson]
+  humandate: Jan 15-16, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Russell Alleen-Willems, Becca Blakewood, Tyler Fox, Tracy Fuentes,
+    Emilia Gan, Esther Le Grezause, Chungho Kim, Jens von der Linden, Maria Mckinley,
+    Ben Marwick, Jaclyn Saunders, Peter Schmiedeskamp, Rachael Tatman, Sam White]
+  latlng: 47.655481,-122.305098
+  layout: workshop
+  lessons: [R, Python, SQL, Git, Bash]
+  registration: open
+  root: .
+  slug: 2015-01-15-uw
+  startdate: 2015-01-15
+  url: http://sophieclayton.github.io/2015-01-15-uw/
+  user: sophieclayton
+  venue: University of Washington
+- address: New Orleans, Louisiana
+  contact: cogrady@tulane.edu
+  country: United-States
+  enddate: 2015-01-27
+  eventbrite: 14944695988
+  helper: [To Be Determined]
+  humandate: Jan 26 - 27, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Nichole Bennett]
+  latlng: 29.936756,-90.122193
+  layout: workshop
+  lessons: [R, SQL, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-01-26-tulane
+  startdate: 2015-01-26
+  url: http://naupaka.github.io/2015-01-26-tulane/
+  user: naupaka
+  venue: Tulane Univeristy
+- address: Multi-media Room, Peter Gilgan Centre for Research and Learning, 686 Bay
+    Street, Toronto, Ontario, M5G 0A4
+  contact: thomas.wright@sickkids.ca
+  country: Canada
+  enddate: 2015-01-30
+  etherpad: https://etherpad.mozilla.org/2015-01-29-sickkids
+  eventbrite: '14777984349'
+  helper: [Xu Fei, Luke Johnston, Daiva Nielsen, Sahar Rahmani]
+  humandate: Jan 29-30, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Tom Wright, Greg Wilson, Elizabeth Patitsas]
+  latlng: 43.65,-79.38
+  layout: workshop
+  root: .
+  slug: 2015-01-29-sickkids
+  startdate: 2015-01-29
+  url: http://tomwright01.github.io/2015-01-29-sickkids/
+  user: tomwright01
+  venue: The Hospital For Sick Children
+- address: NCSA 1030, 1205 W Clark St, Urbana, IL
+  contact: training@cse.illinois.edu
+  country: United-States
+  enddate: 2015-01-30
+  etherpad: https://etherpad.mozilla.org/OR1ObWDaah
+  eventbrite: 10121948019
+  helper: [David LeBauer]
+  humandate: Jan 29-30, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Neal Davis, Ivan Gonzalez, Matthew Turk]
+  latlng: 40.093692, -88.237606
+  layout: workshop
+  root: .
+  slug: 2015-01-29-uiuc
+  startdate: 2015-01-29
+  url: http://uiuc-cse.github.io/2015-01-29-uiuc/
+  user: uiuc-cse
+  venue: University of Illinois
+- address: Room C24 in the Sackville St Building, Sackville Street, Manchester
+  contact: admin-uk@software-carpentry.org
+  country: United-Kingdom
+  enddate: 2015-02-04
+  helper: [Shoaib Sufi]
+  humandate: Feb 03-04, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Aleksandra Pawlik]
+  latlng: 53.4773,-2.2374
+  layout: bootcamp
+  registration: restricted
+  root: .
+  slug: 2015-02-03-CDT-reg-medicine
+  startdate: 2015-02-03
+  url: http://apawlik.github.io/2015-02-03-CDT-reg-medicine/
+  user: apawlik
+  venue: EPSRC & MRC Centre for Doctoral Training in Regenerative Medicine, University
+    of Manchester
+- address: Sidney Myer Asia Centre
+  contact: isa.kiral@gmail.com
+  country: Australia
+  enddate: 2015-02-17
+  etherpad: https://etherpad.mozilla.org/2015-02-16-resbaz-matlab
+  helper: [Bryan Paton, Kerry Halupka, Andrew Boyd, Gregory Bass]
+  humandate: Feb 16-17, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Isabell Kiral-Kornek, Scott Kolbe, Bill Mills]
+  latlng: -37.799243, 144.964422
+  layout: workshop
+  root: .
+  slug: 2015-02-16-resbaz-matlab
+  startdate: 2015-02-16
+  url: http://resbaz.github.io/2015-02-16-resbaz-matlab/
+  user: resbaz
+  venue: University of Melbourne
+- address: Sidney Myer Asia Centre
+  contact: irving.damien@gmail.com
+  country: Australia
+  enddate: 2015-02-17
+  etherpad: https://etherpad.mozilla.org/2015-02-16-resbaz-python
+  helper: [Thomas Coudrat, Sam Hames, Michael Imelfort, Robert Johnson, Tom Remenyi,
+    John Rugis, Alistair Walsh, Constantine Zakkaroff, Errol Lloyd, Sung Bae]
+  humandate: Feb 16-17, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving]
+  latlng: -37.799243, 144.964422
+  layout: workshop
+  root: .
+  slug: 2015-02-16-resbaz-python
+  startdate: 2015-02-16
+  url: http://resbaz.github.io/2015-02-16-resbaz-python/
+  user: resbaz
+  venue: University of Melbourne
+- address: Sidney Myer Asia Centre
+  contact: scottcr@unimelb.edu.au
+  country: Australia
+  enddate: 2015-02-17
+  etherpad: https://etherpad.mozilla.org/2015-02-16-resbaz-r
+  helper: [Areej Alsheikh-Hussain, Noel Faux, Pip Griffin, Andrew Lonsdale, Jack Simpson,
+    Mike Sumner]
+  humandate: Feb 16-17, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Scott Ritchie]
+  latlng: -37.799243, 144.964422
+  layout: workshop
+  root: .
+  slug: 2015-02-16-resbaz-r
+  startdate: 2015-02-16
+  url: http://resbaz.github.io/2015-02-16-resbaz-r/
+  user: resbaz
+  venue: University of Melbourne
+- address: BIO5 Institute, Keating Bioresearch Bldg, Room 103, 1657 East Helen Street,
+    Tucson, AZ 85721
+  contact: naupaka@gmail.com
+  country: United-States
+  enddate: 2015-02-22
+  eventbrite: 15013479722
+  helper: [Blake Joyce, John McMullin, Andre Mercer, Uwe Hilgert]
+  humandate: Feb 21-22, 2015
+  humantime: 9:00 am - 4:30 pm
+  instructor: [Naupaka Zimmerman, Jonathan Strootman]
+  latlng: 32.2375235,-110.9470173
+  layout: workshop
+  lessons: [R, Git, Bash]
+  registration: restricted
+  root: .
+  slug: 2015-02-21-iplant
+  startdate: 2015-02-21
+  url: http://naupaka.github.io/2015-02-21-iplant/
+  user: naupaka
+  venue: iPlant Collaborative, University of Arizona
+- address: Planning Studio, Rooms 314 & 315, Level 3, Steele Building
+  contact: irving.damien@gmail.com
+  country: Australia
+  enddate: 2015-07-14
+  etherpad: https://etherpad.mozilla.org/2015-07-13-amos
+  helper: [Scott Wales, Hol Wolff]
+  humandate: Jul 13-14, 2015
+  humantime: 9:00 am - 5:00 pm
+  instructor: [Damien Irving, Rob Johnson, Nic Hannah]
+  latlng: -27.497257,153.014473
+  layout: workshop
+  root: .
+  slug: 2015-07-13-amos
+  startdate: 2015-07-13
+  url: http://damienirving.github.io/2015-07-13-amos/
+  user: damienirving
+  venue: University of Queensland


### PR DESCRIPTION
Requiring people to have the full build stack (including a Github API token stashed in a file) in order to check a blog post is ridiculous, so this pull request simplifies the build process:

1.  Files that are generated by commands are now saved in Git.
    -   `_config.yml`
    -   `_dashboard_cache.yml`
    -   `_includes/recent_blog_posts.html`
    -   `_workshop_cache.yml`
    These files will be generated and committed by site admins when/as needed.

2.  The Makefile now includes a bit more documentation to separate core commands (`make clean`, `make site`) from supplementary commands.

3.  `README.md` is updated to reflect all these changes (it had fallen well out of date).

Hopefully, all these changes will make it much easier for people to contribute blog posts.