### PR TITLE
Add links to assessments

### DIFF
--- a/workshops/checklists/lead_instructor.html
+++ b/workshops/checklists/lead_instructor.html
@@ -60,7 +60,7 @@ title: Workshop Checklist &mdash; Lead Instructor
       Be sure to allow enough
       time to set up
       on the first day,
-      and for learners to fill in the post-workshop assessment on the last day.
+      and for learners to fill in the <a href="{{page.root}}/workshops/assess/index.html">post-workshop assessment</a> on the last day.
     </li>
     <li>
       Create the home page for the workshop in that repository,
@@ -105,7 +105,7 @@ title: Workshop Checklist &mdash; Lead Instructor
       A <a href="#email">template email message</a> is included in this checklist.
     </li>
     <li>
-      Make sure the pre-workshop assessment questionnaire has been created
+      Make sure the <a href="{{page.root}}/workshops/assess/index.html">pre-workshop assessment questionnaire</a> has been created
       and sent to your learners,
       and share the responses with your fellow instructors.
     </li>
@@ -178,7 +178,7 @@ title: Workshop Checklist &mdash; Lead Instructor
       or in a plain text file.
     </li>
     <li>
-      Distribute the post-workshop assessment.
+      Distribute the <a href="{{page.root}}/workshops/assess/index.html">post-workshop assessment</a>.
       It's best if learners complete it before they leave.
     </li>
     <li>

--- a/workshops/operations.html
+++ b/workshops/operations.html
@@ -592,7 +592,7 @@ title: "Operations Guide: How to Run a Workshop"
     <p>
       A few days before the workshop begins,
       learners will be asked to complete a
-      pre-workshop skills assessment, usually as a Google form.
+      <a href="{{page.root}}/workshops/assess/index.html">pre-workshop skills assessment</a>, usually as a Google form.
       The responses to the assessment will help the instructors
       tailor the workshop material to the group's needs.
     </p>
@@ -893,7 +893,7 @@ title: "Operations Guide: How to Run a Workshop"
     <h3>Post-workshop assessment</h3>
     <p>
       Before the workshop ends, the host or an instructor will direct
-      the learners to a post-workshop assessment. This is very much like
+      the learners to a <a href="{{page.root}}/workshops/assess/index.html">post-workshop assessment</a>. This is very much like
       the pre-workshop assessment, and helps us establish
       how well our workshops
       actually work.


### PR DESCRIPTION
I added links to the page about assessments at a couple of places where they were mentioned, but not linked (and where I wanted to get to them!). Hope that helps others using the already very comprehensive guide to running a workshop.