### PR TITLE
Update CSS to also work with lessons

### DIFF
--- a/_includes/banner.html
+++ b/_includes/banner.html
@@ -1,5 +1,0 @@
-<div class="banner">
-  <a href="{{page.root}}/index.html" title="Software Carpentry Home">
-    <img src="{{page.root}}/img/software-carpentry-banner.png" alt="Software Carpentry banner" />
-  </a>
-</div>

--- a/css/lesson.css
+++ b/css/lesson.css
@@ -1,47 +1,126 @@
-/* Comments in code. */
-.comment {
-    color: purple;
+code {
+    color: #333333;
 }
 
-/* Highlighted changes in code. */
-.highlight {
-    background-color: mistyrose;
+/* Code sample */
+pre.sourceCode,
+pre.input {
+    color: ForestGreen;
+}
+pre.output {
+    color: MediumBlue;
+}
+pre.error {
+    color: Red;
 }
 
-/* Manual input. */
-.in {
-    color: darkgreen;
+.objectives, .keypoints, .callout, .challenge {
+    margin: 1em 0;
+    padding: 0em 1em;
 }
 
-/* Program output. */
-.out {
-    color: darkblue;
-    font-style: italic;
+.objectives h2:first-child,
+.keypoints h2:first-child,
+.callout h2:first-child,
+.challenge h2:first-child {
+    margin-top: 10px;
 }
 
-/* Error output. */
-.err {
-    color: darkred;
-    font-style: italic;
-    font-weight: bold;
+.objectives, .keypoints {
+    background-color: azure;
+    border: 5px solid azure;
 }
 
-/* Explanatory call-out boxes. */
-div.box {
-    background-color: lightgray;
+.callout {
+    background-color: #EEE;
+    border: 5px solid #EEE;
 }
 
-/* Challenge questions. */
-div.challenges {}
+.challenge {
+    background-color: #CCFFCC;
+    border: 5px solid #CCFFCC;
+}
 
-/* Key points in summary. */
-div.keypoints {}
+/* Tables used for displaying choices in challenges. */
+table.choices tr td {
+    vertical-align : top;
+}
 
-/* Main lesson. */
-div.lesson {}
-
-/* Learning objectives. */
-div.objectives {}
-
-/* Continuation paragraph. */
-p.continue {}
+/* Database tables do _not_ have double borders */
+table.outlined {
+    border-collapse: collapse;
+}
+    
+/* Printing */
+@media print {
+    h1 {
+        font-size: 16pt;
+        line-height: 18pt;
+    }
+    
+    h2,h3,h4,h5,h6 {
+        font-size: 12pt;
+        line-height: 13pt;
+    }
+    
+    /* Objectives, Callout Box and Challenges */
+    .objectives, .keypoints {
+        background-color: unset;
+        border: 5px solid;
+    }
+    
+    .callout {
+        background-color: unset;
+        border: 5px solid;
+    }
+    
+    .challenge {
+        background-color: unset;
+        border: 5px solid;
+    }
+    
+    p,ul,ol,li,pre,code {
+        font-size: 8pt;
+        line-height: 9pt;
+    }
+    
+    code {
+        padding: 0px;
+        border: 0px;
+        background: unset;
+    }
+    
+    pre.sourceCode::before,
+    pre.input::before. {
+        content: "Input:";
+    }
+    
+    pre.output::before {
+        content: "Output:";
+    }
+    
+    pre.error::before {
+        content: "Error:";
+    }
+    
+    pre.sourceCode code,
+    pre.input code,
+    pre.output code,
+    pre.error code {
+        display: block;
+        margin-top: 1em;
+        margin-left: 2em;
+    }
+    
+    #github-ribbon {
+        display: none;
+    }
+    
+    .banner {
+        display: none;
+    }
+    
+    .footer {
+        display: none;
+    }
+}

--- a/css/swc-workshop-and-lesson.css
+++ b/css/swc-workshop-and-lesson.css
@@ -1,0 +1,32 @@
+body.workshop {
+	background-color: #BEC3C6;
+	margin: 20px 0;
+}
+
+.card {
+	background-color: white;
+}
+
+/* Top banner of every page. */
+div.banner {
+	background-color: #FFFFFF;
+	width: 100%;
+	height: 90px;
+	margin: 0px;
+	padding: 0;
+	border-bottom: 1px solid #A6A6A6;
+}
+
+/* Padding around image in top banner. */
+div.banner a img {
+	padding: 20px 25px;
+}
+
+/* Footer of every page. */
+div.footer {
+	clear: both;
+	background: url("/img/main_shadow.png") repeat-x scroll center top #FFFFFF;
+	padding: 4px 10px 7px 10px;
+	border-top: 1px solid #A6A6A6;
+	text-align: right;
+}

--- a/css/swc-workshop-and-lesson.css
+++ b/css/swc-workshop-and-lesson.css
@@ -1,6 +1,10 @@
-body.workshop {
+body.workshop, body.lesson {
 	background-color: #BEC3C6;
 	margin: 20px 0;
+}
+
+.container-full-width {
+	max-width: none;
 }
 
 .card {

--- a/css/swc.css
+++ b/css/swc.css
@@ -85,21 +85,6 @@ body.stylesheet {
     margin: 20 auto;
 }
 
-/* Top banner of every page. */
-div.banner {
-    background-color: #FFFFFF;
-    width: 100%;
-    height: 90px;
-    margin: 0px;
-    padding: 0;
-    border-bottom: 1px solid #A6A6A6;
-}
-
-/* Padding around image in top banner. */
-div.banner a img {
-    padding: 20px 25px;
-}
-
 /* Explanatory call-out boxes. */
 div.box {
     width: 54em;
@@ -128,15 +113,6 @@ div.content div h3 {
 /* PDF and slide files referenced from lectures. */
 div.files {
     padding: 10px;
-}
-
-/* Footer of every page. */
-div.footer {
-    clear: both;
-    background: url("/img/main_shadow.png") repeat-x scroll center top #FFFFFF;
-    padding: 4px 10px 7px 10px;
-    border-top: 1px solid #A6A6A6;
-    text-align: right;
 }
 
 .swc-blue-bg {

--- a/css/swc.css
+++ b/css/swc.css
@@ -14,38 +14,11 @@ h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
     color: inherit;
 }
 
-/* Comments in code. */
-.comment {
-    color: purple;
-}
-
-/* Error messages. */
-.err {
-    color: darkred;
-    font-style: italic;
-}
-
 /* Things to fix. */
 .fixme {
     text-decoration: underline;
     color: darkred;
     background-color: lightgray;
-}
-
-/* Highlighted changes in code. */
-.highlight {
-    background-color: mistyrose;
-}
-
-/* Manual input. */
-.in {
-    color: darkgreen;
-}
-
-/* Program output. */
-.out {
-    color: darkblue;
-    font-style: italic;
 }
 
 /* Putting shadows around things. */
@@ -158,13 +131,6 @@ div.toc {
 
 .transcript .media img {
     border: 1px solid grey;
-}
-
-
-/* Title styling */
-h1.title {
-    margin: 40px 0px;
-    border-bottom: 1px solid #515151;
 }
 
 /* YouTube video embed. */


### PR DESCRIPTION
With the addition of a few HTML classes at the top level, the lessons template
should now work with this CSS, so long as it includes swc.css,
swc-workshop-and-lesson.css and lesson.css. The important thing is that there
aren't any conflicts between classes in site and lessons anymore, so how the
CSS files are grouped and delivered is easy to change. Perhaps everything
should be shrunk into just swc.css for use everywhere?

This has a small effect on site: h1.title in site is used to add an underline,
but only actually used in the badges pages. The CSS seems broken on these pages
anyway, so I've removed this class in the CSS since it conflicts with h1.title
in lessons.

Another point to note is that I've changed the global selectors for
h1:first-child and h2:first-child to only affect .objective, .callout and
.challenge blocks, since the global selector used for lessons conflicted with
site. However, the selector now only picks up h2:first-child, not h1 since this
seemed to be all that was used for headers in these blocks.  It's easy to also
include h1 if needed though.

Finally, there is a .keypoints selector in the current lesson CSS, but I see no
mention of that in the blockquote2div.py filter in the lesson template. There
is a .prereq class however in blockquote2div.py which currently has no CSS.
Perhaps .keypoints -> .prereq? Or at least we can remove .keypoints?

I've only checked this thoroughly with shell-novice so far, so there may be
issues with the other lessons that I haven't audited.