### PR TITLE
update storage location of lessons

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -377,8 +377,8 @@ title: Frequently Asked Questions
   <dt id="where-is-stuff">Where are Software Carpentry materials stored?</dt>
   <dd>
     <p>
-      All of our slides, notes, and example programs are in Git repository at
-      <a href="{{site.github_url}}/bc">{{site.github_url}}/bc</a>,
+      All of our slides, notes, and example programs are in Git repositories at
+      <a href="{{site.github_url}}">{{site.github_url}}</a>,
       and the source for our website (including our blog) at
       <a href="{{site.github_url}}/site">{{site.github_url}}/site</a>.
     </p>


### PR DESCRIPTION
to the SWC github org, rather than /bc since each lesson is now its own repo. There might be a better way to do this that takes the user to only the lesson repos, but I can't think of it...