### PR TITLE
Make New Zealand visible

### DIFF
--- a/js/maps.js
+++ b/js/maps.js
@@ -50,8 +50,8 @@ SWC.maps = (function() {
 
   maps.upcoming = function() {
     var mapOptions = {
-      zoom: 2,
-      center: new google.maps.LatLng(25,8),
+      zoom: 1,
+      center: new google.maps.LatLng(0,0),
       mapTypeId: google.maps.MapTypeId.ROADMAP
     },
     info_window   = new google.maps.InfoWindow({}),
@@ -78,8 +78,8 @@ SWC.maps = (function() {
 
   maps.previous = function() {
     var mapOptions = {
-      zoom: 2,
-      center: new google.maps.LatLng(25,8),
+      zoom: 1,
+      center: new google.maps.LatLng(0,0),
       mapTypeId: google.maps.MapTypeId.ROADMAP
     },
     info_window   = new google.maps.InfoWindow({}),
@@ -125,8 +125,8 @@ SWC.maps = (function() {
 
   maps.instructors = function() {
     var mapOptions = {
-      zoom: 2,
-      center: new google.maps.LatLng(25,8),
+      zoom: 1,
+      center: new google.maps.LatLng(0,0),
       mapTypeId: google.maps.MapTypeId.ROADMAP
     },
     info_window   = new google.maps.InfoWindow({}),


### PR DESCRIPTION
With the google maps at zoom level 2 and the chosen origin New Zealand is not visible on the google map without zooming or scrolling. This is the easy solution: changing the zoom level to 1. 

We need to move the origin to the equator so that we don't start with a grey bar at the top of the map. This isn't a fantastic solution, as we now have lots of the map dedicated to high latitudes (where workshops are unlikely) and the map wraps around several times, but should help avoid us showing up on http://worldmapswithout.nz/

Another approach we may want to try is to change the aspect ratio of the height and width of the div element where the maps are drawn. But, from memory, this just scales the map and shows the same area. I also tried playing around with: `map.fitBounds(new google.maps.LatLngBounds(new google.maps.LatLng(-60, -179), new google.maps.LatLng(60, 180)));` inserted into line 59. This works (it forces the map to show New Zealand, whatever zoom is provided) but we get the same result.

The current SWC website shows this:

![old_map](https://cloud.githubusercontent.com/assets/19102/6168284/cdb4a268-b2bb-11e4-9092-e4da5a4314af.jpg)

this change means the map looks like this:

![new_map](https://cloud.githubusercontent.com/assets/19102/6168288/dabd6cb0-b2bb-11e4-9252-ef3677810c59.jpg)

as rendered on Chrome on a Mac (with different data for the upcoming workshops). I've made the same change to all three of our maps.

This is a possible fix to #802.