### PR TITLE
Updates the checklist for the lead instructor to use the workshop template

### DIFF
--- a/workshops/checklists/lead_instructor.html
+++ b/workshops/checklists/lead_instructor.html
@@ -31,7 +31,7 @@ title: Workshop Checklist &mdash; Lead Instructor
       Create the
       <a href="{{site.github_url}}/workshop-template">GitHub repository</a>
       that will host the workshop's web pages, following <a
-          href="{{site.github_url}}/workshop-template/blob/gh-pages/README.md#creating-a-repository">these
+          href="{{site.github_url}}/workshop-template/#creating-a-repository">these
           instructions in the README.md file.</a>.
     </li>
     <li>

--- a/workshops/checklists/lead_instructor.html
+++ b/workshops/checklists/lead_instructor.html
@@ -29,9 +29,10 @@ title: Workshop Checklist &mdash; Lead Instructor
   <ul>
     <li>
       Create the
-      <a href="{{site.github_url}}/bc">GitHub repository</a>
-      that will host the workshop's web pages.
-      <a href="https://vimeo.com/87241285">This video</a> shows how to do it as of early 2014.
+      <a href="{{site.github_url}}/workshop-template">GitHub repository</a>
+      that will host the workshop's web pages, following <a
+          href="{{site.github_url}}/workshop-template/blob/gh-pages/README.md#creating-a-repository">these
+          instructions in the README.md file.</a>.
     </li>
     <li>
       <strong>Send the workshop's URL to the administrators</strong>


### PR DESCRIPTION
The checklist for the lead instructor uses the old way of cloning bc to create the repo for a new workshop. 

This updates the checklist to create the workshop's repo according to the instructions in the README file of workshop template.