### PR TITLE
The PEcAN logo is too wide

### DIFF
--- a/_includes/projects/pecan.html
+++ b/_includes/projects/pecan.html
@@ -1,5 +1,5 @@
 <div class="media">
-  <img class="media-object pull-left" src="{{page.root}}/img/projects/pecan.jpg" alt="PEcAn Project" />
+  <img class="media-object pull-left" style="width: 120px;" src="{{page.root}}/img/projects/pecan.jpg" alt="PEcAn Project" />
   <div id="macroeco" class="media-body">
     The <a href="http://http://pecanproject.github.io/" class="project">Predictive Ecosystem Analyzer (PEcAn)</a> 
     is an integrated ecological bioinformatics toolbox that provides tools to synthesize 


### PR DESCRIPTION
quick fix to reduce the width of the PEcAN logo