### PR TITLE
Update jekyll required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ The commands used to rebuild the website are stored in `Makefile`.
     and other pages in `_site`
     to see what your changes will look like.
 
+
+**Note: You must have Jekyll 2.5 or later.** If you had an older version
+installed, you can update it with:
+
+~~~
+gem update
+~~~
+
 Note: Disqus comments will *not* load properly,
 since you'll be on your machine rather than our server.
 
@@ -139,8 +147,6 @@ For More Advanced Users
     and combines it with static configuration information.
 
 2.  Run Jekyll to build the web site.
-
-    **Note: You must have Jekyll 2.5 or later.**
 
 3.  Run `bin/make_rss_feed.py` to generate the RSS feed file `feed.xml`.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The commands used to rebuild the website are stored in `Makefile`.
     to see what your changes will look like.
 
 
-**Note: You must have Jekyll 2.5 or later.** If you had an older version
+**Note: You must have Jekyll 2.5 or later.** If you have an older version
 installed, you can update it with:
 
 ~~~


### PR DESCRIPTION
I had some problems building the site and using an old version of Jekyll (see #807). Apparently, jekyll 2.5 is required to `make site`, but the note on that was found only in the "More advanced user" section. This moves this note up the "Building section".

Also, the "Gemfile.lock" may need an update. (I understand that requires jekyll 1.4.3). I didn't change it in this PR, because I'm not sure how :). 