### PR TITLE
Fix Disqus

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -4,7 +4,7 @@
     var disqus_shortname = 'software-carpentry';
     var disqus_developer = 1;
     var disqus_identifier = "{{page.filename}}";
-    var disqus_title = '{{ page.title }}';
+    var disqus_title = "{{ page.title }}";
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
       dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
Some titles have single quote and because of that we need to use
double quote.