### PR TITLE
Protocol agnostic disqus URL.

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -7,7 +7,7 @@
     var disqus_title = "{{ page.title }}";
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
   </script>

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -7,7 +7,7 @@
     var disqus_title = "{{ page.title }}";
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js?https';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
   </script>


### PR DESCRIPTION
This should enable disqus under both HTTP and HTTPS protocols

Fixes #896.