### PR TITLE
Add instructions to select Windows' console when installing Git for Windows

### DIFF
--- a/workshops/setup.html
+++ b/workshops/setup.html
@@ -71,9 +71,14 @@ title: Workshop Setup
     <div class="span4">
       <h4>Windows</h4>
       <p>
-	Install Git for Windows by download and running
-	<a href="http://msysgit.github.io/">the installer</a>.
-	This will provide you with both Git and Bash in the Git Bash program.
+        Download the Git for Windows
+        <a href="https://git-for-windows.github.io/">installer</a>. Run the
+        installer. **Important: on the 6th page of the installation wizard (the
+        page titled `Configuring the terminal emulator...`) select `Use Windows'
+        default console window`. If you forgot to do this programs that you need
+        for the workshop will not work properly. If this happens rerun the
+        installer and select the appropriate option.** This will provide you
+        with both Git and Bash in the Git Bash program.
       </p>
       <p><strong>Software Carpentry Installer</strong></p>
       <p><em>This installer requires an active internet connection.</em></p>


### PR DESCRIPTION
Git for Windows now (at least for 2.5+) defaults to using MinTTY as the terminal
emulator. This causes nano and other programs to fail to work properly and we
have been unable to come up with consistent ways to fix this. This changes the
setup instructions to have students change the default to use the Windows' default
console, which works fine with our stack.

This mirrors https://github.com/swcarpentry/workshop-template/pull/235