### PR TITLE
Minor updates to bibliography

### DIFF
--- a/bib/bib.html
+++ b/bib/bib.html
@@ -169,7 +169,7 @@ title: Recommended Reading
     </p>
   </dd>
 
-  <dt>Greg Wilson, D. A. Aruliah, C. Titus Brown, Neil P. Chue Hong, Matt Davis, Richard T. Guy, Steven H. D. Haddock, Katy Huff, Ian M. Mitchell, Mark Plumbley, Ben Waugh, Ethan P. White, and Paul Wilson: "Best Practices for Scientific Computing."  <a href="http://arxiv.org/abs/1210.0530">arXiv pre-print</a>, submitted November 29, 2012.</dt>
+  <dt>Greg Wilson, D. A. Aruliah, C. Titus Brown, Neil P. Chue Hong, Matt Davis, Richard T. Guy, Steven H. D. Haddock, Kathryn D. Huff, Ian M. Mitchell, Mark D. Plumbley, Ben Waugh, Ethan P. White, and Paul Wilson: "<a href="http://journals.plos.org/plosbiology/article?id=10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>." <cite>PLoS Biology</cite>, 12(1), e1001745, 2014. http://dx.doi.org/10.1371/journal.pbio.1001745</dt>
   <dd>
     <p>
     Describes a set of best practices for scientific software development that have solid foundations in research and experience,

--- a/bib/software-carpentry.bib
+++ b/bib/software-carpentry.bib
@@ -1209,15 +1209,15 @@
 	volume={2},
 	number={1},
 	pages={e18},
-	year={2014}
+	year={2014},
 	doi={10.5334/jors.bc}
 }
 
-@inproceedings{trainer2014b
+@inproceedings{trainer2014b,
 	title={Beyond Code: Prioritizing Issues, Sharing Knowledge, and Establishing Identity at Hackathons for Science},
 	author={Trainer, Erik H and Herbsleb, James D},
 	booktitle={CSCW Workshop on Sharing, Re-use, and Circulation of Resources in Scientific Cooperative Work},
-	year={2014}
+	year={2014},
 	url={http://files.figshare.com/1423965/etrainer_cscw14_sharingWkshp_revised_final.pdf}
 }
 


### PR DESCRIPTION
Some minor changes to the bibliography to:
* Update the citation for "best practices" in bib.html 
* Fix syntax errors in software-carpentry.bib
 
Note that while making these I noticed that the process to go from `software-carpentry.bib` to `bib.html` (i.e. `make biblio`) stamps over the stuff at the top of `bib.html`. Fixing this will be a separate issue (#1074).