### PR TITLE
Instructor / Helper Retreat announcement

### DIFF
--- a/blog/2015/09/instructor-helper-retreat.html
+++ b/blog/2015/09/instructor-helper-retreat.html
@@ -1,0 +1,41 @@
+---
+layout: blog
+root: ../../..
+author: Bill Mills
+title: "Announcing the 2015 Instructor & Helper Retreat"
+date: 2015-09-15
+time: "10:00:00"
+category: [""]
+---
+
+The Mentorship Committee is very excited to announce the first ever <strong>Software Carpentry Instructors & Helpers Retreat</strong>, happening worldwide on <strong>November 14</strong>. We're inviting Software Carpentry instructors and helpers to get together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related.
+
+To get an idea of just a few of the things that will be going on, here's a short preview of some of the events the community has requested:
+
+<ul>
+  <li><strong>Contributions Workshop:</strong> have you ever wanted to contribute something back to the lesson material, but weren't really sure how to do it? We will be running at least two sessions, broadcast on Google Hangouts on Air, walking you through the process of contributing back to Software Carpentry.</li>
+  <li><strong>Teaching Practice:</strong> Pythonistas, have you been waiting for a chance to jump into R? Have you never taught git before? Or do you have a brand new way to teach one of the lessons you want to try out? There will be plenty of time to give short sessions in front of your peers, to practice teaching new material and get some helpful feedback.</li>
+  <li><strong>Broadcast Sessions:</strong> We'll be asking site hosts & individuals to each arrange a lesson (like the contribution workshop) or discussions in one-hour blocks to be broadcast worldwide on Google Hangouts, so you can interact with your colleagues around the world on topics of interest.</li>
+</ul>
+ 
+As the date approaches, keep checking back on the <a href='http://swcarpentry.github.io/instructor-retreat-2015/'>event website</a> to see a map of sites worldwide, and a schedule of broadcast sessions.
+ 
+<h2>Hosting a Site</h2>
+
+In order to make the Retreat a success, we want as many sites around the world to participate as we can get, to make it easy for instructors and helpers to get together in their home towns wherever possible. There are three simple steps to hosting a site:
+
+<ul>
+  <li><strong>Book a room:</strong> your site will need space from 9 AM - 5 PM, your local time, on the day. The room should be able to accommodate however many instructors and helpers you estimate live nearby, and have plugs for everyone!</li>
+  <li><strong>Arrange a Hangout session:</strong> we'd like every local site to lead a one-hour session on the worldwide Google Hangout that we'll be connecting all the sites through. This session could be a tutorial, a discussion, or anything else you imagine. The site host doesn't have to be the one to lead the session - as long as you find someone to do so.</li>
+  <li><strong>Handle local communications:</strong> Before the Retreat, site hosts should reach out to their local communities, to make sure all the instructors and helpers around town hear about the event. On the day, you'll need to provide a connection to the global Google Hangout.</li>
+</ul>
+ 
+If you're interested in hosting a site, <strong>get in touch with the mentorship committee</strong> at <a href='mailto:mentoring@lists.software-carpentry.org'>mentoring@lists.software-carpentry.org</strong>, and we'll help you get set up.
+
+<h2>Participating Remotely</h2>
+
+If you're not able to attend one of the meetups we're arranging, we invite you to participate remotely via Google Hangouts on Air. All worldwide sessions will be broadcast live on YouTube, and remote participants are welcome to lead a session themselves. Send your session idea to the mentorship committee at mentoring@lists.software-carpentry.org, and we'll get you on the schedule! If you'd like to get some teaching practice in, contact us and we'll help connect you with the closest group, to whom you can teach over a remote connection. Also, we're encouraging everyone to **join in the Gitter chat room** we'll be setting up to have conversations throughout the day with your colleagues worldwide.
+
+<h2>Come on out!</h2>
+
+If you're an instructor who would like to practice teaching a lesson you've never taught before, a helper who would like to continue building their teaching and workshop skills right away, or anyone in the community who has ideas for making the instructor and helper experience at Software Carpentry even better, this event is for you - we look forward to seeing you all there! Keep an eye on the <a href='http://swcarpentry.github.io/instructor-retreat-2015/'>event website</a> for updates.

--- a/blog/2015/09/instructor-helper-retreat.html
+++ b/blog/2015/09/instructor-helper-retreat.html
@@ -2,13 +2,13 @@
 layout: blog
 root: ../../..
 author: Bill Mills
-title: "Announcing the 2015 Instructor & Helper Retreat"
+title: "Announcing the 2015 Instructor and Helper Retreat"
 date: 2015-09-15
 time: "10:00:00"
 category: [""]
 ---
 <!-- start excerpt -->
-The Mentorship Committee is very excited to announce the first ever <strong>Software Carpentry Instructors & Helpers Retreat</strong>, happening worldwide on <strong>November 14</strong>. We're inviting Software Carpentry instructors and helpers to get together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related.
+The Mentorship Committee is very excited to announce the first ever <strong>Software Carpentry Instructors &amp; Helpers Retreat</strong>, happening worldwide on <strong>November 14</strong>. We're inviting Software Carpentry instructors and helpers to get together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related.
 <!-- end excerpt -->
 <p>
 To get an idea of just a few of the things that will be going on, here's a short preview of some of the events the community has requested:
@@ -16,7 +16,7 @@ To get an idea of just a few of the things that will be going on, here's a short
 <ul>
   <li><strong>Contributions Workshop:</strong> have you ever wanted to contribute something back to the lesson material, but weren't really sure how to do it? We will be running at least two sessions, broadcast on Google Hangouts on Air, walking you through the process of contributing back to Software Carpentry.</li>
   <li><strong>Teaching Practice:</strong> Python/R users, have you been waiting for a chance to jump into R/Python? Have you never taught one of Software Carpentry lessons before? Or do you have a brand new way to teach one of the lessons you want to try out? There will be plenty of time to give short sessions in front of your peers, to practice teaching new material and get some helpful feedback.</li>
-  <li><strong>Broadcast Sessions:</strong> We'll be asking site hosts & individuals to each arrange a lesson (like the contribution workshop) or discussions in one-hour blocks to be broadcast worldwide on Google Hangouts, so you can interact with your colleagues around the world on topics of interest.</li>
+  <li><strong>Broadcast Sessions:</strong> We'll be asking site hosts &amp; individuals to each arrange a lesson (like the contribution workshop) or discussions in one-hour blocks to be broadcast worldwide on Google Hangouts, so you can interact with your colleagues around the world on topics of interest.</li>
 </ul>
 <p>
 As the date approaches, keep checking back on the <a href='http://swcarpentry.github.io/instructor-retreat-2015/'>event website</a> to see a map of sites worldwide, and a schedule of broadcast sessions.

--- a/blog/2015/09/instructor-helper-retreat.html
+++ b/blog/2015/09/instructor-helper-retreat.html
@@ -8,7 +8,9 @@ time: "10:00:00"
 category: [""]
 ---
 
+<!-- start excerpt -->
 The Mentorship Committee is very excited to announce the first ever <strong>Software Carpentry Instructors & Helpers Retreat</strong>, happening worldwide on <strong>November 14</strong>. We're inviting Software Carpentry instructors and helpers to get together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related.
+<!-- end excerpt -->
 
 To get an idea of just a few of the things that will be going on, here's a short preview of some of the events the community has requested:
 


### PR DESCRIPTION
Here's the blog post requested in https://github.com/swcarpentry/site/issues/1087. Since they're going to point at each other, let's hold off on merging here until we're all happy with [the website](http://swcarpentry.github.io/instructor-retreat-2015/); I'm going to set up a milestone for that over there momentarily. Meanwhile, comments & suggestions on this post very welcome!