### PR TITLE
htaccess fix for bootcamps/ redirect to workshops/

### DIFF
--- a/_htaccess
+++ b/_htaccess
@@ -5,7 +5,7 @@ AddDefaultCharset UTF-8
 
 # Route /bootcamps to /workshops
 RewriteCond %{REQUEST_URI} ^/bootcamps
-RewriteRule ^bootcamps/(.*)$ /workshops/$1 [R,L]
+RewriteRule ^bootcamps(.*)$ /workshops$1 [R,L]
 
 # Route /3_0 and /4_0 pages to /v3, /v4
 RewriteCond %{REQUEST_URI} ^/3_0


### PR DESCRIPTION
This supersedes PR #1041 and solves #1040. 

Turns out we had a rule in .htaccess to rewrite /bootcamps URLs, it just didn't handle the case where the trailing slash was left out. 