### PR TITLE
Fixing pricing information

### DIFF
--- a/blog/2015/07/changes-to-admin-fee.html
+++ b/blog/2015/07/changes-to-admin-fee.html
@@ -13,40 +13,11 @@ category: ["Workshops"]
   have agreed to make some changes to the administration fee we charge
   for workshops that we help organize in order to reflect the real
   cost of our staff's time and our overheads, and to reflect the value
-  of the training:
+  of the training.  Please see
+  <a href="{{page.root}}/workshops/request.html">the workshop request page</a>
+  for the updated pricing information.
 </p>
 <!-- end excerpt -->
-<ol>
-  <li>
-    <p>
-      If a host site arranges instructors and handles registration,
-      they do not owe us an administration fee.
-    </p>
-  </li>
-  <li>
-    <p>
-      If we are involved in getting instructors or managing
-      registration, the host owes us $2500 per workshop if the host is
-      not a partner or affiliate, and $1250 per workshop if they are.
-    </p>
-  </li>
-  <li>
-    <p>
-      If a partner or affiliate recruits instructors and handles
-      registration for another host, without using either SCF staff
-      time or any staff time they might owe SCF, then they may charge
-      what they like for the service (including nothing). If they do
-      charge a fee, we strongly encourage them to make it similar to
-      ours.
-    </p>
-  </li>
-  <li>
-    <p>
-      We will continue to be generous with waivers for organizations
-      that would otherwise not be able to afford to host workshops.
-    </p>
-  </li>
-</ol>
 <p>
   These rules keep us in step with Data Carpentry,
   which <a href="http://datacarpentry.github.io/blog/2015/07/20/workshop-fees/">recently
@@ -58,11 +29,10 @@ category: ["Workshops"]
 <p>
   The new administrative fees will apply to workshops requested after
   September 1, 2015.  (Note that the transition is based on when the
-  <a href="{{page.root}}/workshops/request.html">workshop request</a>
-  is received, not when the workshop takes place.)  As per our current
-  policy, if a not-for-profit organization such as a university or
-  government institution has already paid $1250 for a workshop this
-  year, we will only charge $750 per workshop for their subsequent
-  workshops until December 31st.  If you have any questions, please
-  <a href="mailto:{{site.contact}}">get in touch</a>.
+  workshop request is received, not when the workshop takes place.)
+  As per our current policy, if a not-for-profit organization such as
+  a university or government institution has already paid $1250 for a
+  workshop this year, we will only charge $750 per workshop for their
+  subsequent workshops until December 31st.  If you have any
+  questions, please <a href="mailto:{{site.contact}}">get in touch</a>.
 </p>

--- a/scf/workshops.html
+++ b/scf/workshops.html
@@ -7,22 +7,13 @@ subtitle: Workshop Fees and Operations
 <h2 id="preamble">1) Preamble</h2>
 <p>The Software Carpentry Foundation charges an administration fee for workshops it helps organize to cover some of its central costs, such as instructor training, curriculum development, and staff salaries. This document describes and explains this fee, which is intended to satisfy the following constraints:</p>
 <ol style="list-style-type: decimal">
-<li><p>There is no fee for workshops organized <em>without</em> the SCF's involvement. For example, if a group of graduate students at Euphoric State University wish to organize and run a workshop entirely on their own, they do not owe the SCF any money.</p></li>
+<li><p>There is no fee for workshops organized <em>without</em> the SCF's involvement. For example, if a group of graduate students at Euphoric State University wish to organize and run a workshop on their own, they do not owe the SCF any money.  However, we do ask for a small donation in this case to cover the cost of setting up Eventbrite, collecting survey data, etc.</p></li>
 <li><p>The administration fee must be low enough to encourage potential hosts to give workshops a try, but high enough to make institutional membership attractive.</p></li>
 <li><p>Instructors' travel and accommodation are paid directly by the host organization: the SCF is not involved in making travel arrangements or in fulfilling payment of expenses.</p></li>
 <li><p>The people who actually do the organizing are often staff of member organizations, rather than SCF staff.</p></li>
 <li><p>The fee is greater for workshops at companies and other for-profit organizations. This extra income is used to underwrite fees for special events (such as workshops for women in science and engineering) and fees for non-profit institutions that might otherwise not be able to host a workshop (such as schools in less affluent or more remote areas).</p></li>
 <li><p>Much of the effort in organizing a workshop goes into getting to know the hosts and their institution, so subsequent workshops at any particular site are less expensive.</p></li>
 </ol>
-<div align="center">
-  <p>
-    <strong>
-      A new fee schedule is being introduced for workshop requests received on or after September 1, 2015.
-      Please see <a href="{{page.root}}/blog/2015/07/changes-to-admin-fee.html">this blog post</a> for details,
-      or <a href="mailto:{{site.contact}}">contact us</a> if you would like more information.
-    </strong>
-  </p>
-</div>
 <h2 id="terminology">2) Terminology</h2>
 <ul>
 <li><p>The term <em>member organization</em> refers to <a href="http://software-carpentry.org/scf/membership.html#partner">Partners</a>, <a href="http://software-carpentry.org/scf/membership.html#affiliate">Affiliates</a>, and <a href="http://software-carpentry.org/scf/membership.html#sponsor">Sponsors</a> as defined in <a href="http://software-carpentry.org/scf/membership.html">the description of organizational membership</a>.</p></li>
@@ -34,58 +25,24 @@ subtitle: Workshop Fees and Operations
 <h2 id="operations">3) Operations</h2>
 <h3 id="travel-and-accommodation">3.1) Travel and Accommodation</h3>
 <p>Hosts always pay instructors' travel and accommodation costs. They do this directly, i.e., the SCF does not act as an intermediary.</p>
-<h3 id="self-organized-workshops">3.2) Self-Organized Workshops</h3>
-<p>Anyone who wants to organize and run a workshop using the Software Carpentry name and logo without the support of the SCF is free to do so provided they adhere to <a href="http://software-carpentry.org/faq.html#trademark">our rules</a> about content and certified instructors. There is no charge for self-organized workshops, and we will advertise them on our website so long as they:</p>
-<ol style="list-style-type: decimal">
-<li><p>provide the metadata we require (such as the workshop's date and location) in a format we can easily consume, and</p></li>
-<li><p>allow us to administer our pre- and post-workshop surveys, or collect equivalent information themselves and share it with us.</p></li>
-</ol>
-<h3 id="coordination">3.3) Coordination</h3>
+<h3 id="coordination">3.2) Coordination</h3>
 <ol style="list-style-type: decimal">
 <li><p>All requests for workshops, no matter who receives them or how, are pooled in a central location that all coordinators can access.</p></li>
 <li><p>Once a workshop has been allocated to a coordinator, she can communicate with the host using either an organizational email address or a software-carpentry.org email address, whichever the organization prefers.</p></li>
 <li><p>All conversations must be archived in a shared central location approved by the Steering Committee.</p></li>
 </ol>
-<h3 id="administration-fees-for-internal-workshops-run-by-member-organizations">3.4) Administration Fees for Internal Workshops Run by Member Organizations</h3>
-<p>There is no administration fee for internal workshops run by member organizations. (This is one of the benefits of becoming a member organization.)</p>
-<h3 id="administration-fees-for-arranged-workshops-for-not-for-profit-organizations">3.5) Administration Fees for Arranged Workshops for Not-For-Profit Organizations</h3>
-<p>Arranged workshops for not-for-profit organizations such as universities and government institutions are charged:</p>
-<ol style="list-style-type: lower-alpha">
-<li><p>US$1250 for the first workshop in any year;</p></li>
-<li><p>an additional US$750/workshop for the second and subsequent workshops in a year.</p></li>
-</ol>
-<h3 id="administration-fees-for-arranged-workshops-for-for-profit-organizations">3.6) Administration Fees for Arranged Workshops for For-Profit organizations</h3>
-<p>We are presently (April 2015) running a short pilot program offering workshops to companies and other for-profit organizations. These are charged:</p>
-<ol style="list-style-type: lower-alpha">
-<li><p>US$5000 for the first workshop in any year;</p></li>
-<li><p>an additional US$3000/workshop for the second and subsequent workshops in a year.</p></li>
-</ol>
-<p>The SCF may use one quarter of administration fee revenue from for-profit organizations for its own purposes. It must use the remaining three quarters of this money to underwrite the costs of workshops for not-for-profit organizations, such as their administration fees and/or instructors' travel and accommodation.</p>
-<h3 id="attendance-fees-for-workshops">3.7) Attendance Fees for Workshops</h3>
-<p>Host may charge learners a small fee for participating in a workshop. (In fact we encourage them to do so, since it significantly reduces the no-show rate.) If they do this, they may use that money to pay part or all of any administration fee owed to the SCF.</p>
-<h3 id="fee-waivers">3.8) Fee Waivers</h3>
-<p>The Steering Committee may reduce or waive workshop fees at its discretion. In particular, Software Carpentry strives to be a global project and support a diverse set of organizations; any potential host that wishes to offer a workshop that would aid these goals is urged to contact the SCF to discuss waivers and other arrangements.</p>
-<h2 id="examples">4) Examples</h2>
-<p>These examples of arranged workshops for institutions that are <em>not</em> member organizations are for illustrative purposes only. If there is any disagreement between an example and the wording above, the wording above shall be considered definitive.</p>
+<h3 id="self-organized-workshops">3.3) Self-Organized Workshops</h3>
+<p>Anyone who wants to organize and run a workshop using the Software Carpentry name and logo without the support of the SCF is free to do so provided they adhere to <a href="http://software-carpentry.org/faq.html#trademark">our rules</a> about content and certified instructors. There is no charge for self-organized workshops, and we will advertise them on our website so long as they:</p>
 <ol style="list-style-type: decimal">
-<li><p>A university hosts one arranged workshop in a year.</p>
-<ul>
-<li>The administration fee is $1250.</li>
-</ul></li>
-<li><p>A university hosts three arranged workshops in a year.</p>
-<ul>
-<li>The university pays ($1250 + 2 x $750) = $2750.</li>
-</ul></li>
-<li><p>A company hosts one arranged workshop in a year.</p>
-<ul>
-<li>The SCF receives $5000.</li>
-<li>$1250 of this goes into the SCF's general funds.</li>
-<li>The remaining $3750 is used to pay the administration fees for three workshops at not-for-profit institutions.</li>
-</ul></li>
-<li><p>A company hosts three arranged workshops in a year.</p>
-<ul>
-<li>The company pays ($5000 + 2 x $3000) = $11,000.</li>
-<li>Of this, $2750 goes into the SCF's general funds.</li>
-<li>The remaining $8250 is used to pay travel and accommodation costs for six instructors for a WiSE workshop.</li>
-</ul></li>
+<li><p>provide the metadata we require (such as the workshop's date and location) in a format we can easily consume, and</p></li>
+<li><p>allow us to administer our pre- and post-workshop surveys, or collect equivalent information themselves and share it with us.</p></li>
 </ol>
+<p>In this case, we ask for (but do not require) a donation, and recommend $500 as a suitable amount.</p>
+<h3 id="administration-fees-for-not-for-profit-organizations">3.4) Administration Fees for Not-for-Profit Organizations</h3>
+<p>The administration fee for not-for-profit organizations, such as universities or government labs, is US$2,500 if the organization is not a Software Carpentry member organization, and US$1,250 if it is, but still requires our help.</p>
+<h3 id="administration-fees-for-for-profit-organizations">3.5) Administration Fees for For-Profit Organizations</h3>
+<p>The administration fee for for-profit organizations, such as companies, is US$10,000, of which three quarters is used to underwrite workshops at institutions that could otherwise not afford them.</p>
+<h3 id="attendance-fees-for-workshops">3.6) Attendance Fees for Workshops</h3>
+<p>Host may charge learners a small fee for participating in a workshop. (In fact we encourage them to do so, since it significantly reduces the no-show rate.) If they do this, they may use that money to pay part or all of any administration fee owed to the SCF.</p>
+<h3 id="fee-waivers">3.7) Fee Waivers</h3>
+<p>The Steering Committee may reduce or waive workshop fees at its discretion. In particular, Software Carpentry strives to be a global project and support a diverse set of organizations; any potential host that wishes to offer a workshop that would aid these goals is urged to contact the SCF to discuss waivers and other arrangements.</p>

--- a/workshops/request.html
+++ b/workshops/request.html
@@ -4,7 +4,13 @@ root: ..
 title: "Request a Workshop"
 nocomments: 1
 ---
-<p>If would like to host a workshop at your institution, please fill in one of the forms below to let us know a bit more about your needs and someone will contact you as soon as possible. For more information on how our workshops are run, please read our <a href="operations.html">operations guide</a>.</p>
+<p>
+  If would like to host a workshop at your institution, please fill in
+  one of the forms below to let us know a bit more about your needs
+  and someone will contact you as soon as possible. For more
+  information on how our workshops are run, please read
+  our <a href="operations.html">operations guide</a>.
+</p>
 
 <div class="row">
   <div class="col-sm-6" align="center">
@@ -19,7 +25,14 @@ nocomments: 1
   </div>
 </div>
 
-<p>Our instructors are volunteers, and so are not paid for their teaching, but host sites are required to cover their travel and accommodation costs. In addition, the Software Carpentry Foundation charges an administration fee for workshops that it helps organize at institutions which are not partners or affiliates.  For workshop requests received after September 1, 2015, these fees are:</p>
+<p>
+  Our instructors are volunteers, and so are not paid for their
+  teaching, but host sites are required to cover their travel and
+  accommodation costs. In addition, the Software Carpentry Foundation
+  charges an administration fee for workshops that it helps organize
+  at institutions which are not partners or affiliates.  For workshop
+  requests received after September 1, 2015, these fees are:
+</p>
 <ul>
   <li>
     <p>
@@ -49,12 +62,12 @@ nocomments: 1
   </li>
 </ul>
 <p>
-  If you hosted a workshop in 2015 before September 1,
-  the old fee schedule applies for subsequent workshops hosted before the end of the year:
-  please see <a href="{{page.root}}/blog/2015/07/changes-to-admin-fee.html">this blog post</a> for details.
-</p>
-<p>
   We strive to be a global project and support diversity in science.
   If you wish to offer a workshop that would further these goals,
   please <a href="mailto:{{site.contact}}">contact us</a> regarding a waiver for the administration fee.
+</p>
+<p>
+  Note: if you hosted a workshop in 2015 before September 1,
+  the old fee schedule applies for subsequent workshops hosted before the end of the year:
+  please <a href="mailto:{{site.contact}}">contact us</a> for details.
 </p>


### PR DESCRIPTION
Fixes #1104 by updating information about pricing on SCF workshops description page and on request form, and removing information from July 2015 blog post (points people at definitive description instead). @jduckles @maneesha please check.