### PR TITLE
Removing direct 'request a DC workshop' link

### DIFF
--- a/workshops/request.html
+++ b/workshops/request.html
@@ -5,25 +5,23 @@ title: "Request a Workshop"
 nocomments: 1
 ---
 <p>
-  If would like to host a workshop at your institution, please fill in
-  one of the forms below to let us know a bit more about your needs
-  and someone will contact you as soon as possible. For more
-  information on how our workshops are run, please read
-  our <a href="operations.html">operations guide</a>.
+  If would like to host a Software Carpentry workshop at your
+  institution, please fill in the form below to let us know a bit more
+  about your needs and someone will contact you as soon as
+  possible. For more information on how our workshops are run, please
+  read our <a href="operations.html">operations guide</a>.
 </p>
 
-<div class="row">
-  <div class="col-sm-6" align="center">
-    <h4>
-      <a href="https://amy.software-carpentry.org/workshops/swc/request/">Request a Software Carpentry workshop</a>
-    </h4>
-  </div>
-  <div class="col-sm-6" align="center">
-    <h4>
-      <a href="https://amy.software-carpentry.org/workshops/dc/request/">Request a Data Carpentry workshop</a>
-    </h4>
-  </div>
+<div align="center">
+  <h4>
+    <a href="https://amy.software-carpentry.org/workshops/swc/request/">Request a Software Carpentry workshop</a>
+  </h4>
 </div>
+
+<p>
+  If you would like a Data Carpentry workshop,
+  please <a href="http://www.datacarpentry.org/workshops-host/">visit their web site</a>.
+</p>
 
 <p>
   Our instructors are volunteers, and so are not paid for their


### PR DESCRIPTION
1. Remove the direct link to the DC workshop request form.
2. Add a link to the DC website's "request a workshop" explanation.
3. Changing wording to reflect this.