### PR TITLE
Upgrading to Python 3.4 in order to get SSL to work properly.

### DIFF
--- a/bin/util.py
+++ b/bin/util.py
@@ -3,11 +3,12 @@
 Utilities for site regeneration.
 '''
 
+import sys
 import os
 import re
 import urllib.request
+import ssl
 import yaml
-import sys
 from PyRSS2Gen import RSS2, RSSItem
 
 # Standard name for metadata files.
@@ -72,8 +73,12 @@ def load_info(folder, filename=CONFIG_YML):
 
 def fetch_info(base_url, url):
     """Download a file and save it."""
+
+    # Loads operating system's trusted CA certificates
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+
     address = base_url + url
-    with urllib.request.urlopen(address) as f:
+    with urllib.request.urlopen(address, context=ssl_context) as f:
         content = f.read()
     return yaml.load(content.decode('utf-8'))
 


### PR DESCRIPTION
Use `conda install python=3.4` to get the right version of Python, then `pip install pyyaml` to get the YAML library.