### PR TITLE
fix video link in call for instructor

### DIFF
--- a/blog/2015/10/call-for-instructor-training.html
+++ b/blog/2015/10/call-for-instructor-training.html
@@ -22,7 +22,7 @@ People who are interested in participating in this round can now apply to take p
 <li><p>Watch one of the two videos below and submit a paragraph of feedback on the video they chose to watch as part of their application.</p>
 <ul>
 <li><a href="https://vimeo.com/139316669">https://vimeo.com/139316669</a></li>
-<li><a href="https://vimeo.com/139181120http">https://vimeo.com/139181120</a></li>
+<li><a href="https://vimeo.com/139181120">https://vimeo.com/139181120</a></li>
 </ul></li>
 <li><p>People who wish to teach Software Carpentry must submit a small pull request to a specified GitHub repository.  <strong>People who wish to teach Data Carpentry do not need to do so.</strong>
 <p>Your pull request should contain one file (and one file only) called &quot;your_name.txt&quot; (e.g., marie_curie.txt or alan_turing.txt). This file should contain a sentence or two that describes the type of work you do. You will submit the name of this file as part of your application.</p>


### PR DESCRIPTION
I believe there was a typo in the 2nd video link in the blog post "call for trainers".

best,
Pierre