### PR TITLE
Drop to collapsed menu earlier to prevent the menu disappearing behind the logo.

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -733,7 +733,7 @@ div.chapter h2 {
 }
 
 /* Collapse navbar */
-@media (max-width: 993px) {
+@media (max-width: 1200px) {
     .navbar-header {
         float: none;
 	min-height: 80px;


### PR DESCRIPTION
This is a rather brute-force approach to the following problem:

![screen shot 2015-10-29 at 15 03 33](https://cloud.githubusercontent.com/assets/1391051/10822272/5d0fed60-7e4e-11e5-8529-fb52dcf0d07d.png)

I can not think of another way around it however.