### PR TITLE
Fix several typos on Call for training blog

### DIFF
--- a/blog/2015/10/call-for-instructor-training.html
+++ b/blog/2015/10/call-for-instructor-training.html
@@ -48,9 +48,9 @@ People who are interested in participating in this round can now apply to take p
 <li><p><strong>Academic qualification.</strong> Faculty and students will be considered equally, as will groups from different academic disciplines.</p></li>
 </ul>
 <h3>What is the minimum/maximum number of people to a group?</h3>
-<p><strong>We prefer groups with 3-8 people.</strong> Groups that have more than one member and less than hundreds of members will be considere.</p>
+<p><strong>We prefer groups with 3-8 people.</strong> Groups that have more than one member and less than hundreds of members will be considered.</p>
 <h3>What level of knowledge is needed throughout the group?</h3>
-<p>We expected that each member of the group are confortable with (or master) the content of at least one of our lessons. For example, if the answer of one is <strong>yes</strong> for at least one of the following questions s/he can be part of your group:</p>
+<p>We expected that each member of the group are comfortable with (or master) the content of at least one of our lessons. For example, if the answer of one is <strong>yes</strong> for at least one of the following questions s/he can be part of your group:</p>
 <ul>
     <li>Can you search for one word in all text files of one project using <code>grep</code>?</li>
     <li>Can you get the changes that your collaborator sent to GitHub yesterday, solve the conflicts and push your changes?</li>
@@ -58,7 +58,7 @@ People who are interested in participating in this round can now apply to take p
     <li>Can you read the gap minder dataset R and plot any information from it?</li>
 </ul>
 <h3>Is is absolutely necessary that our group members have attended a Software Carpentry workshop before?</h3>
-<p><strong>No.</strong> If you live in one city that had a couple of Software Carpentry workshop in the past year we hope that you had attend at least one of our workshops. If you live somewhere that never had one of our workshops we expected that you are confortable with the content of at least one of our lessons <strong>and</strong> participate in any local project that help people learn programming.</p>
+<p><strong>No.</strong> If you live in one city that had a couple of Software Carpentry workshop in the past year we hope that you had attend at least one of our workshops. If you live somewhere that never had one of our workshops we expected that you are comfortable with the content of at least one of our lessons <strong>and</strong> participate in any local project that help people learn programming.</p>
 <h3>There is any cost for me or the institution that I'm affiliated?</h3>
 <p><strong>No.</strong> This round of instruction training is free. The workshop that your group will need to organize will be considered self-organized so you or the instruction that you are affiliated do not own anything to Software Carpentry Foundation. If the institution that you are affiliated can make a donation related with the instructor training and/or the workshop we will be grateful.</p>
 <h3 id="timeline">What is the timeline</h3>


### PR DESCRIPTION
This fixes several typos on one blog post page.