### PR TITLE
Closing instructor training registration

### DIFF
--- a/blog/2015/11/applications-for-december.html
+++ b/blog/2015/11/applications-for-december.html
@@ -13,6 +13,7 @@ category: ["Instructor Training"]
   <a href="{{page.root}}/blog/2015/10/call-for-instructor-training.html">December's two-day instructor training class</a>
   are now closed.
   We received more than three dozen applications from four continents,
+  including over 400 people,
   and will let people know early next week whether they have been selected.
   Groups that we can't include in this round will be given priority to take part in the new year.
 </p>
@@ -23,6 +24,8 @@ category: ["Instructor Training"]
   The next step is to match trainees with experienced instructors
   who will guide them through the core Data Carpentry and Software Carpentry material
   and oversee their final mini-lesson.
-  If all goes well,
-  we will be ready to do more and better instructor training in 2016.
+  This will start early in the new year
+  so that we include people from both the multi-week and two-day pilots.
+  Assuming it goes well,
+  we will finally have a pipeline that can meet our community's desire for instructor training.
 </p>

--- a/blog/2015/11/applications-for-december.html
+++ b/blog/2015/11/applications-for-december.html
@@ -1,0 +1,28 @@
+---
+layout: blog
+root: ../../..
+author: Greg Wilson
+title: "Applications for December Instructor Training Are Now Closed"
+date: 2015-11-20
+time: "01:00:00"
+category: ["Instructor Training"]
+---
+<!-- start excerpt -->
+<p>
+  Applications to take part in
+  <a href="{{page.root}}/blog/2015/10/call-for-instructor-training.html">December's two-day instructor training class</a>
+  are now closed.
+  We received more than three dozen applications from four continents,
+  and will let people know early next week whether they have been selected.
+  Groups that we can't include in this round will be given priority to take part in the new year.
+</p>
+<!-- end excerpt -->
+<p>
+  Meanwhile,
+  yesterday saw the final meeting of the six-week cohort of instructor trainees.
+  The next step is to match trainees with experienced instructors
+  who will guide them through the core Data Carpentry and Software Carpentry material
+  and oversee their final mini-lesson.
+  If all goes well,
+  we will be ready to do more and better instructor training in 2016.
+</p>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ nocomments: 1
             <p>
 	      You can <a href="{{page.root}}/workshops/request.html">request a workshop</a>,
 	      <a href="{{page.root}}/workshops/operations.html">host one</a>,
-	      <a href="{{page.root}}/pages/register.html">become an instructor</a>,
+	      <a href="{{page.root}}/pages/join.html#instructors">become an instructor</a>,
 	      <a href="{{page.root}}/scf/membership.html">support us</a>,
 	      help <a href="{{page.root}}/pages/dashboard.html">improve our lessons</a>,
 	      or

--- a/pages/join.html
+++ b/pages/join.html
@@ -11,8 +11,17 @@ nocomments: 1
   hours/week for 12 weeks, while the live version runs over two full
   days.  Both cover the basics of educational psychology,
   instructional design, and how to apply both to teaching programming
-  to adults.  To apply to take part,
-  please <a href="{{page.root}}/pages/register.html">fill in this form</a>.
+  to adults.
+</p>
+<p align="center">
+  <em>
+    Registration for instructor training is currently on hold
+    while we try to clear our backlog.
+    If you have already applied to take part,
+    we will keep your application in queue.
+    Registration will reopen in 2016&mdash;please
+    keep an eye on our blog for announcements.
+  </em>
 </p>
 <p>
   If you are already an instructor and would like to let us know that you have moved,


### PR DESCRIPTION
1.  Blog post saying that applications for December 7-8 are closed.
2.  Add note to `pages/join.html` saying that registration in general is temporarily suspended.
3.  Adding anchor to link on home page.

@karinlag @jduckles @rgaiacs please review.