### PR TITLE
python 3.x now recommended, not 2.x

### DIFF
--- a/workshops/setup.html
+++ b/workshops/setup.html
@@ -176,9 +176,8 @@ title: Workshop Setup
 
     <p>
       Regardless of how you choose to install it,
-      <strong>please make sure you install Python version 2.x and not version 3.x</strong>
-      (e.g., 2.7 is fine but not 3.4).
-      Python 3 introduced changes that will break some of the code we teach during the workshop.
+      <strong>please make sure you install Python version 3.x and not version 2.x</strong>
+      (e.g., 3.5 is fine but not 2.7).
     </p>
 
   <div class="row">
@@ -190,7 +189,7 @@ title: Workshop Setup
           install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
 	</li>
 	<li>
-          Download the default Python 2 installer (do not follow the link to version 3).
+          Download the default Python 3 installer (do not follow the link to version 2).
 	  Use all of the defaults for installation
           <em>except</em> make sure to check
 	  <strong>Make Anaconda the default Python</strong>.
@@ -205,7 +204,7 @@ title: Workshop Setup
           install <a href="https://store.continuum.io/cshop/anaconda/">Anaconda</a>.
 	</li>
 	<li>
-          Download the default Python 2 installer (do not follow the link to version 3).
+          Download the default Python 3 installer (do not follow the link to version 2).
 	  Use all of the defaults for installation
           <em>except</em>
           make sure to check <strong>Make Anaconda the default Python</strong>.
@@ -226,7 +225,7 @@ title: Workshop Setup
 	<li>
           Download the installer that matches your operating
           system and save it in your home folder.
-	  Download the default Python 2 installer (do not follow the link to version 3). 
+	  Download the default Python 3 installer (do not follow the link to version 2). 
 	</li>
 	<li>
           Open a terminal window.


### PR DESCRIPTION
Switched wording so Python 3 is recommended to be installed, not Python 2.
cc @rgaiacs 