### PR TITLE
instrutions for workshop-specific contacts

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -67,6 +67,10 @@ nocomments: 1
 
 <div id="future">
   <h2>Future Workshops</h2>
+  <p><em>
+    For questions about a specific workshop, please contact the person listed on that workshop's page below. For general inquiries, send an email to <a href="mailto:admin@software-carpentry.org">admin@software-carpentry.org</a>.
+  </em></p>
+
   <table class="table table-striped workshops">
     {% for w in site.workshops_upcoming %}
     <tr>


### PR DESCRIPTION
Ask people to look for workshop-specific contact people on each workshop's webpage.  

For general inquiries, next step is to figure out best way to have geo-referenced admin contacts listed.  Right now I'm fine with them all coming to me & I'll forward as needed.